### PR TITLE
feat(signals): extract core package

### DIFF
--- a/packages/signals/LICENSE
+++ b/packages/signals/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026-present Andrea Zanenghi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/signals/README.md
+++ b/packages/signals/README.md
@@ -1,0 +1,109 @@
+# Ecopages Signals
+
+`@ecopages/signals` is a renderer-agnostic signals package that can be used standalone or underneath Radiant.
+
+Its core model is based on the [TC39 Signals proposal](https://github.com/tc39/proposal-signals/tree/main), with a smaller surface area and a few convenience helpers for application code today.
+
+The public entrypoint remains `index.ts`, while the implementation now lives in focused modules under `src/` so the core runtime, effects, watcher support, and store logic can evolve independently.
+
+## Current Scope
+
+This package currently provides:
+
+- `State<T>` for writable values
+- `Computed<T>` for lazily derived values
+- `currentComputed()` for advanced derived helpers that need the active computed context
+- `effect(...)` for reactive side effects with scheduled re-execution
+- `watch(...)` for observing derived values with previous-value access
+- `untrack(...)` and `peek(...)` for non-tracking reads
+- `subtle.Watcher` plus `watched` and `unwatched` hooks for low-level invalidation workflows
+- `createStore(...)` for deep reactive object and array state
+- `isStore(...)` for detecting signal-backed store proxies
+- `snapshot(...)` for materializing plain nested data
+- automatic dependency discovery during `Computed` evaluation
+- subscription support for renderer or framework adapters
+
+## Source Layout
+
+The package is organized around a stable public barrel and smaller implementation files:
+
+- `index.ts` re-exports the public API and exposes `subtle`
+- `src/types.ts` defines the public contracts, options, and low-level symbols
+- `src/state.ts` implements writable `State` signals
+- `src/computed.ts` implements lazy derived `Computed` signals and active-computation helpers
+- `src/effect.ts` and `src/watch.ts` implement effect scheduling and derived-value observation
+- `src/watcher.ts` implements proposal-shaped low-level watchers
+- `src/tracking.ts` contains non-tracking read helpers
+- `src/store.ts` contains deep store proxying and snapshot materialization
+
+## Design Position
+
+This package is renderer-agnostic.
+
+- It does not know about JSX.
+- It does not know about Radiant components.
+- It is meant to work both as a standalone package and underneath adapters in those packages.
+
+## TC39 Relationship
+
+This package is based on the current TC39 Signals proposal and tracks the same broad model around:
+
+- `State` and `Computed` signal classes
+- lazy pull-based recomputation with cached values
+- automatic dependency discovery during computed evaluation
+- custom equality functions for writable and computed signals
+- untracked reads as an escape hatch
+
+It is not a drop-in implementation of the current proposal draft.
+
+It is best understood as proposal-aligned in its core semantics, but not yet fully API-compatible with the draft surface.
+
+- It exposes convenience helpers such as `effect(...)`, `watch(...)`, `createStore(...)`, and `snapshot(...)` directly.
+- It currently exposes manual `subscribe(...)` hooks for adapter and library integration.
+- It exposes a proposal-shaped `subtle.Watcher` API, while still keeping the existing convenience helpers.
+- Its `subtle.Watcher` follows the proposal-style re-arm behavior, where calling `watch(...)` resets the pending set and notification latch for the next invalidation cycle.
+- It does not yet expose the full TC39 subtle introspection surface.
+
+## API Notes
+
+- `subscribe(...)` is intended for adapter-style push integration. Application-level derived work is usually better expressed with `Computed`, `effect(...)`, or `watch(...)`.
+- `watch(...)` is built on top of a computed signal plus an effect, so it inherits computed equality behavior and effect scheduling.
+- `subtle.Watcher` reports staleness rather than recalculated values. Calling `watch(...)` is both registration and reset.
+- `createStore(...)` wraps nested plain objects and arrays, while `snapshot(...)` detaches the current plain value graph for logging, serialization, or comparison.
+
+## Example
+
+```ts
+import { Computed, State, createStore, effect, watch } from '@ecopages/signals';
+
+const count = new State(0);
+const parity = new Computed(() => ((count.get() & 1) === 0 ? 'even' : 'odd'));
+const store = createStore({ profile: { name: 'Ada' } });
+
+const dispose = effect(() => {
+	console.log(parity.get(), store.profile.name);
+});
+
+const stopWatching = watch(
+	() => store.profile.name,
+	(nextName, previousName) => {
+		console.log(previousName, '->', nextName);
+	},
+);
+
+count.set(1);
+store.profile.name = 'Grace';
+dispose();
+stopWatching();
+```
+
+## Limits
+
+This implementation is still smaller than the current TC39 proposal draft.
+
+- no full TC39 `Watcher` and subtle semantics surface yet
+- no full proposal-style subtle introspection helpers yet
+- no batching or transaction model
+- no framework-owned disposal tree or component ownership integration yet
+
+Those omissions are deliberate. The goal is to keep a small, useful standalone package while leaving room to align further as the proposal evolves.

--- a/packages/signals/build.ts
+++ b/packages/signals/build.ts
@@ -1,0 +1,18 @@
+const watchMode = process.argv.includes('--watch');
+
+const build = await Bun.build({
+	entrypoints: ['index.ts'],
+	format: 'esm',
+	minify: !watchMode,
+	outdir: 'dist',
+	sourcemap: 'external',
+	target: 'browser',
+});
+
+if (!build.success) {
+	for (const log of build.logs) {
+		console.log('[@ecopages/signals]', log);
+	}
+
+	process.exitCode = 1;
+}

--- a/packages/signals/check-size.ts
+++ b/packages/signals/check-size.ts
@@ -1,0 +1,93 @@
+import path from 'node:path';
+import { styleText } from 'node:util';
+import { gzipSync } from 'node:zlib';
+import { $ } from 'bun';
+
+type BundleBudget = {
+	entrypoint: string;
+	label: string;
+	maxBytes: number;
+	maxGzipBytes: number;
+};
+
+type SizeBudgetFile = {
+	bundles: BundleBudget[];
+};
+
+type SizeResult = {
+	bytes: number;
+	entrypoint: string;
+	gzipBytes: number;
+	label: string;
+	maxBytes: number;
+	maxGzipBytes: number;
+	passed: boolean;
+};
+
+const reportOnly = process.argv.includes('--report-only');
+const budgetPath = path.resolve(import.meta.dir, 'size-budget.json');
+const budgetFile = (await Bun.file(budgetPath).json()) as SizeBudgetFile;
+const outputRoot = path.resolve(import.meta.dir, '.tmp-size-audit');
+
+await $`rm -rf ${outputRoot}`;
+
+const results: SizeResult[] = [];
+
+for (const bundle of budgetFile.bundles) {
+	const bundleDir = path.join(outputRoot, bundle.label);
+	const build = await Bun.build({
+		entrypoints: [path.resolve(import.meta.dir, bundle.entrypoint)],
+		format: 'esm',
+		minify: true,
+		outdir: bundleDir,
+		target: 'browser',
+	});
+
+	if (!build.success) {
+		for (const log of build.logs) {
+			console.error('[size-audit]', log);
+		}
+
+		process.exit(1);
+	}
+
+	const outputFile = build.outputs.find((output) => output.path.endsWith('.js'));
+
+	if (!outputFile) {
+		console.error(`[size-audit] No JavaScript output generated for ${bundle.label}.`);
+		process.exit(1);
+	}
+
+	const bytes = Buffer.from(await Bun.file(outputFile.path).arrayBuffer());
+	const gzipBytes = gzipSync(bytes).length;
+
+	results.push({
+		bytes: bytes.length,
+		entrypoint: bundle.entrypoint,
+		gzipBytes,
+		label: bundle.label,
+		maxBytes: bundle.maxBytes,
+		maxGzipBytes: bundle.maxGzipBytes,
+		passed: bytes.length <= bundle.maxBytes && gzipBytes <= bundle.maxGzipBytes,
+	});
+}
+
+await $`rm -rf ${outputRoot}`;
+
+console.log('Bundle size audit (minified browser bundles)');
+
+for (const result of results) {
+	const rawKb = (result.bytes / 1024).toFixed(2);
+	const gzipKb = (result.gzipBytes / 1024).toFixed(2);
+	const rawBudgetKb = (result.maxBytes / 1024).toFixed(2);
+	const gzipBudgetKb = (result.maxGzipBytes / 1024).toFixed(2);
+	const status = result.passed ? styleText('green', 'PASS') : styleText('red', 'FAIL');
+
+	console.log(
+		`${status} ${result.label} (${result.entrypoint}) raw ${rawKb} KB / ${rawBudgetKb} KB, gzip ${styleText('blue', `${gzipKb} KB`)} / ${gzipBudgetKb} KB`,
+	);
+}
+
+if (!reportOnly && results.some((result) => !result.passed)) {
+	process.exit(1);
+}

--- a/packages/signals/index.ts
+++ b/packages/signals/index.ts
@@ -1,0 +1,52 @@
+export {
+	asyncState,
+	type AsyncStateConfig,
+	type AsyncStateFetcherOptions,
+	type AsyncStateResult,
+	type AsyncStateSourcedConfig,
+	type AsyncStatus,
+} from './src/async-state';
+export { Computed, computed, currentComputed } from './src/computed';
+export { trackDependency } from './src/dependency';
+export { effect } from './src/effect';
+export { State, state } from './src/state';
+export { createStore, isStore, snapshot } from './src/store';
+export { peek, untrack } from './src/tracking';
+export {
+	type DependencyNode,
+	type EffectCallback,
+	type EffectCleanup,
+	type EffectOptions,
+	type EffectScheduler,
+	type Signal,
+	type SignalOptions,
+	type SignalStore,
+	type SignalSubscriber,
+	type WatchOptions,
+	type WritableSignal,
+	watched,
+	unwatched,
+} from './src/types';
+export { Watcher } from './src/watcher';
+export { watch } from './src/watch';
+
+import { currentComputed } from './src/computed';
+import { trackDependency } from './src/dependency';
+import { untrack } from './src/tracking';
+import { watched, unwatched } from './src/types';
+import { Watcher } from './src/watcher';
+
+/**
+ * Proposal-shaped low-level APIs for framework and adapter authors.
+ *
+ * This groups the lower-level pieces that mirror the TC39 proposal naming
+ * without forcing application code onto the subtle surface by default.
+ */
+export const subtle = Object.freeze({
+	Watcher,
+	currentComputed,
+	trackDependency,
+	untrack,
+	watched,
+	unwatched,
+});

--- a/packages/signals/package.json
+++ b/packages/signals/package.json
@@ -1,0 +1,60 @@
+{
+	"name": "@ecopages/signals",
+	"version": "0.3.0-alpha.4",
+	"description": "Renderer-agnostic signal primitives based on the TC39 Signals proposal",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/ecopages/radiant.git",
+		"directory": "packages/signals"
+	},
+	"homepage": "https://github.com/ecopages/radiant/tree/main/packages/signals#readme",
+	"bugs": {
+		"url": "https://github.com/ecopages/radiant/issues"
+	},
+	"author": "Andrea Zanenghi",
+	"license": "MIT",
+	"main": "dist/index.js",
+	"module": "dist/index.js",
+	"types": "dist/index.d.ts",
+	"type": "module",
+	"publishConfig": {
+		"access": "public"
+	},
+	"sideEffects": false,
+	"files": [
+		"dist/*",
+		"README.md",
+		"size-budget.json",
+		"package.json"
+	],
+	"keywords": [
+		"signals",
+		"reactivity",
+		"tc39",
+		"state-management",
+		"radiant"
+	],
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js"
+		},
+		"./package.json": "./package.json"
+	},
+	"scripts": {
+		"build:lib": "bun run clean && bun run build:files && bun run build:types",
+		"build:files": "bun run ./build.ts",
+		"build:types": "tsc -p tsconfig.build.json",
+		"clean": "rm -rf ./dist",
+		"size:check": "bun run ./check-size.ts",
+		"size:report": "bun run ./check-size.ts --report-only",
+		"test:lib": "vitest run"
+	},
+	"devDependencies": {
+		"@vitest/coverage-v8": "3.2.4",
+		"vitest": "^3.2.4"
+	},
+	"peerDependencies": {
+		"typescript": "^5"
+	}
+}

--- a/packages/signals/size-budget.json
+++ b/packages/signals/size-budget.json
@@ -1,0 +1,10 @@
+{
+	"bundles": [
+		{
+			"label": "index",
+			"entrypoint": "./index.ts",
+			"maxBytes": 12288,
+			"maxGzipBytes": 3891
+		}
+	]
+}

--- a/packages/signals/src/async-state/README.md
+++ b/packages/signals/src/async-state/README.md
@@ -1,0 +1,215 @@
+# asyncState
+
+Reactive primitive for tracking async operations. Exposes `data`, `status`, and
+`error` as dependency-tracked signals so any computed, effect, or
+`RadiantComponent.render()` that reads them re-evaluates automatically when the
+fetch lifecycle advances.
+
+## API
+
+```typescript
+function asyncState<T>(config: AsyncStateConfig<T>): AsyncStateResult<T>;
+
+function asyncState<S, T>(config: AsyncStateSourcedConfig<S, T>): AsyncStateResult<T>;
+```
+
+### Config
+
+| Property       | Type                                                    | Default | Description                                                           |
+| -------------- | ------------------------------------------------------- | ------- | --------------------------------------------------------------------- |
+| `fetcher`      | `(opts) => Promise<T>` / `(source, opts) => Promise<T>` | —       | **Required.** The async function to execute.                          |
+| `source`       | `() => S \| false \| null \| undefined`                 | —       | Reactive source. Triggers refetch on change. Falsy = disabled.        |
+| `initialValue` | `T`                                                     | —       | Seed value for `data` before the first successful resolution.         |
+| `staleTime`    | `number`                                                | `0`     | Milliseconds a response stays fresh. Cache hits skip the network.     |
+| `pendingDelay` | `number`                                                | `0`     | Milliseconds to wait before `status` moves to `'pending'`.            |
+| `onSuccess`    | `(data: T) => void`                                     | —       | Called after each successful resolution, including cache hits.        |
+| `onError`      | `(error: unknown) => void`                              | —       | Called after each failed resolution. Not called for aborted requests. |
+| `onSettled`    | `(data: T \| undefined, error: unknown) => void`        | —       | Called after each resolution, whether successful or failed.           |
+
+### `AsyncStateResult<T>`
+
+| Member      | Type                     | Description                                                   |
+| ----------- | ------------------------ | ------------------------------------------------------------- |
+| `data`      | `Signal<T \| undefined>` | Latest resolved value. Retains last success while refetching. |
+| `status`    | `Signal<AsyncStatus>`    | `'idle'` · `'pending'` · `'success'` · `'error'`              |
+| `error`     | `Signal<unknown>`        | Latest rejection. Cleared when a new fetch starts.            |
+| `refetch()` | `() => void`             | Re-execute, aborting any in-flight request.                   |
+| `abort()`   | `() => void`             | Cancel the current request without changing status.           |
+| `dispose()` | `() => void`             | Abort + tear down source watcher.                             |
+
+## Usage
+
+### Unsourced (manual)
+
+Fetches immediately on creation. Call `.refetch()` to re-execute.
+
+```typescript
+const todos = asyncState({
+	fetcher: ({ signal }) => fetch('/api/todos', { signal }).then((r) => r.json()),
+});
+
+todos.status.get(); // 'pending' → 'success'
+todos.data.get(); // Todo[] | undefined
+```
+
+### Sourced (reactive)
+
+Watches a reactive `source`. When it emits a new truthy value the fetcher runs
+with that value. Falsy values (`false`, `null`, `undefined`) disable fetching
+and preserve the current state — useful for deferred / conditional fetches.
+
+```typescript
+const cityId = state('venice');
+
+const weather = asyncState({
+	source: () => cityId.get(),
+	fetcher: (id, { signal }) => fetchWeather(id, signal),
+});
+
+// Changing the source auto-triggers a new fetch:
+cityId.set('madrid');
+// → previous request aborted, weather.status → 'pending'
+```
+
+## Lifecycle
+
+```
+[idle] ──▶ refetch() / source change ──▶ [pending]
+                                            │
+                                ┌───────────┴───────────┐
+                                ▼                       ▼
+                            [success]               [error]
+                                │                       │
+                                └───────┬───────────────┘
+                                        ▼
+                              refetch() / source change ──▶ [pending]
+```
+
+### Auto-abort
+
+When a new fetch starts:
+
+1. The previous `AbortController` is aborted.
+2. A new controller is created.
+3. A version counter increments — only the latest version can commit.
+4. `AbortError` exceptions are silently swallowed.
+
+This means rapid source changes (e.g. fast city switching) only resolve the
+latest request. Stale responses are discarded automatically.
+
+## Stale-while-revalidate
+
+`data` retains the last successful value while a refetch is in-flight. This
+allows UIs to keep showing content with a loading indicator instead of
+blanking out.
+
+## Caching with `staleTime`
+
+When `staleTime` is set, successful responses are cached by their serialized
+source value. If the source changes back to a previously-fetched key whose
+cache entry is still within the stale window, the cached value is served
+synchronously — no network request, no pending state.
+
+```typescript
+const weather = asyncState({
+	source: () => cityId.get(),
+	fetcher: (id, { signal }) => fetchWeather(id, signal),
+	staleTime: 60_000, // 1 minute
+});
+```
+
+Set `staleTime: Infinity` to cache forever (useful for data that never
+changes within a session). Only sourced queries benefit from caching — the
+source value is serialized with `JSON.stringify` to produce the cache key.
+
+## Pending delay with `pendingDelay`
+
+Fast responses should not flash a loading spinner. `pendingDelay` defers
+the `'pending'` status transition by N milliseconds. If the response
+arrives within that window, `status` jumps straight from its previous value
+to `'success'` or `'error'`.
+
+```typescript
+const todos = asyncState({
+	fetcher: ({ signal }) => fetch('/api/todos', { signal }).then((r) => r.json()),
+	pendingDelay: 300,
+});
+
+// Fast response (< 300ms):
+// status: 'idle' → 'success'  (never shows 'pending')
+
+// Slow response (> 300ms):
+// status: 'idle' → 'pending' → 'success'
+```
+
+This eliminates the common UX problem of flickery spinners without
+introducing artificial slowness. The response is committed as soon as it
+arrives — only the loading indicator is delayed.
+
+## Lifecycle callbacks
+
+`onSuccess`, `onError`, and `onSettled` run after each resolution — useful
+for side effects like syncing context providers, logging, or toast messages.
+
+```typescript
+const weather = asyncState({
+	source: () => cityId.get(),
+	fetcher: (id, { signal }) => fetchWeather(id, signal),
+	onSuccess: (report) => {
+		provider.setContext({ activeCityId: report.cityId });
+	},
+	onError: (err) => {
+		console.error('Weather fetch failed', err);
+	},
+});
+```
+
+## Usage in RadiantComponent
+
+Signal reads during `render()` participate in automatic rerender tracking.
+No decorator or special integration is needed — just read the signals:
+
+```typescript
+@customElement('my-user-card')
+class MyUserCard extends RadiantComponent {
+  @prop({ type: String }) userId = '';
+
+  private userQuery = asyncState({
+    source: () => this.userId || false,
+    fetcher: (id, { signal }) => fetchUser(id, signal),
+  });
+
+  override disconnectedCallback() {
+    this.userQuery.dispose();
+    super.disconnectedCallback();
+  }
+
+  override render() {
+    const status = this.userQuery.status.get();
+    const user = this.userQuery.data.get();
+    const error = this.userQuery.error.get();
+
+    if (status === 'pending') return <p>Loading...</p>;
+    if (status === 'error') return <p>Error: {String(error)}</p>;
+    if (!user) return <p>No user selected</p>;
+
+    return <p>{user.name}</p>;
+  }
+}
+```
+
+## Deferred fetch
+
+Pass a falsy initial source to keep the query idle until ready:
+
+```typescript
+const trigger = state<string | false>(false);
+
+const report = asyncState({
+	source: () => trigger.get(),
+	fetcher: (cityId, { signal }) => fetchReport(cityId, signal),
+});
+
+// Stays idle until:
+trigger.set('venice');
+```

--- a/packages/signals/src/async-state/index.ts
+++ b/packages/signals/src/async-state/index.ts
@@ -1,0 +1,257 @@
+import { state } from '../state';
+import { watch } from '../watch';
+import type { Signal } from '../types';
+
+/** Lifecycle status of an async operation. */
+export type AsyncStatus = 'idle' | 'pending' | 'success' | 'error';
+
+/** Options passed to the fetcher function. */
+export interface AsyncStateFetcherOptions {
+	signal: AbortSignal;
+}
+
+type UnsourcedFetcher<T> = (options: AsyncStateFetcherOptions) => Promise<T>;
+type SourcedFetcher<S, T> = (sourceValue: S, options: AsyncStateFetcherOptions) => Promise<T>;
+
+interface AsyncStateBaseConfig<T> {
+	/** Seed value for `data` before the first successful resolution. */
+	initialValue?: T;
+
+	/**
+	 * Milliseconds a successful response is considered fresh. While fresh,
+	 * source changes that resolve to an already-cached key skip the network
+	 * entirely and serve the cached value synchronously.
+	 *
+	 * Defaults to `0` (always refetch). Set to `Infinity` to cache forever.
+	 *
+	 * Only meaningful for sourced queries — the source value is serialized
+	 * with `JSON.stringify` to produce the cache key.
+	 */
+	staleTime?: number;
+
+	/**
+	 * Milliseconds to wait before transitioning `status` to `'pending'`.
+	 *
+	 * If the response arrives within this window the status jumps straight
+	 * from its previous value to `'success'` or `'error'`, avoiding a
+	 * flash-of-loading-state for fast responses.
+	 *
+	 * Defaults to `0` (transition immediately).
+	 */
+	pendingDelay?: number;
+
+	/** Called after each successful resolution, including cache hits. */
+	onSuccess?: (data: T) => void;
+
+	/** Called after each failed resolution. Not called for aborted requests. */
+	onError?: (error: unknown) => void;
+
+	/**
+	 * Called after each resolution, whether successful or failed.
+	 *
+	 * Exactly one of `data` / `error` is defined per call.
+	 */
+	onSettled?: (data: T | undefined, error: unknown) => void;
+}
+
+/** Configuration for an unsourced `asyncState` that fetches immediately. */
+export interface AsyncStateConfig<T> extends AsyncStateBaseConfig<T> {
+	fetcher: UnsourcedFetcher<T>;
+	source?: undefined;
+}
+
+/** Configuration for a sourced `asyncState` driven by a reactive source. */
+export interface AsyncStateSourcedConfig<S, T> extends AsyncStateBaseConfig<T> {
+	/**
+	 * Reactive source function. The fetcher is invoked whenever `source`
+	 * emits a new truthy value. Falsy values (`false`, `null`, `undefined`)
+	 * disable fetching and preserve the current state.
+	 */
+	source: () => S | false | null | undefined;
+
+	fetcher: SourcedFetcher<S, T>;
+}
+
+/** Reactive handle returned by `asyncState`. */
+export interface AsyncStateResult<T> {
+	/** Latest resolved value. Retains last success while refetching. */
+	readonly data: Signal<T | undefined>;
+
+	/** Current lifecycle status. */
+	readonly status: Signal<AsyncStatus>;
+
+	/** Latest error. Cleared when a new fetch starts. */
+	readonly error: Signal<unknown>;
+
+	/** Trigger a new fetch, aborting any in-flight request. */
+	refetch(): void;
+
+	/** Abort the current in-flight request without changing status. */
+	abort(): void;
+
+	/** Dispose all subscriptions and abort any pending request. */
+	dispose(): void;
+}
+
+/**
+ * Creates a reactive async state that fetches immediately on creation.
+ *
+ * Call `.refetch()` to re-execute. The previous in-flight request is aborted
+ * automatically and `AbortError` exceptions are silently discarded.
+ */
+export function asyncState<T>(config: AsyncStateConfig<T>): AsyncStateResult<T>;
+
+/**
+ * Creates a reactive async state driven by a reactive `source`.
+ *
+ * The fetcher is invoked whenever `source` emits a new truthy value. Falsy
+ * values (`false`, `null`, `undefined`) disable fetching and preserve the
+ * current state.
+ */
+export function asyncState<S, T>(config: AsyncStateSourcedConfig<S, T>): AsyncStateResult<T>;
+
+export function asyncState<S, T>(config: AsyncStateConfig<T> | AsyncStateSourcedConfig<S, T>): AsyncStateResult<T> {
+	const hasSource = config.source !== undefined;
+	const source = hasSource ? (config as AsyncStateSourcedConfig<S, T>).source : undefined;
+	const fetcher = config.fetcher as UnsourcedFetcher<T> | SourcedFetcher<S, T>;
+
+	const staleTime = config.staleTime ?? 0;
+	const pendingDelay = config.pendingDelay ?? 0;
+
+	const dataState = state<T | undefined>(config.initialValue);
+	const statusState = state<AsyncStatus>('idle');
+	const errorState = state<unknown>(undefined);
+
+	const cache = new Map<string, { value: T; timestamp: number }>();
+
+	let activeController: AbortController | null = null;
+	let requestVersion = 0;
+	let pendingTimer: ReturnType<typeof setTimeout> | undefined;
+	const disposers: (() => void)[] = [];
+
+	const clearPendingTimer = () => {
+		if (pendingTimer !== undefined) {
+			clearTimeout(pendingTimer);
+			pendingTimer = undefined;
+		}
+	};
+
+	const commitPending = () => {
+		pendingTimer = undefined;
+		statusState.set('pending');
+	};
+
+	const schedulePending = () => {
+		clearPendingTimer();
+		errorState.set(undefined);
+
+		if (pendingDelay <= 0) {
+			statusState.set('pending');
+			return;
+		}
+
+		pendingTimer = setTimeout(commitPending, pendingDelay);
+	};
+
+	const execute = (sourceValue?: S) => {
+		const canUseCache = hasSource && staleTime > 0;
+		const cacheKey = hasSource ? JSON.stringify(sourceValue) : '';
+
+		if (canUseCache) {
+			const cached = cache.get(cacheKey);
+			if (cached && Date.now() - cached.timestamp < staleTime) {
+				requestVersion += 1;
+				activeController?.abort();
+				activeController = null;
+				clearPendingTimer();
+				dataState.set(cached.value);
+				statusState.set('success');
+				errorState.set(undefined);
+				config.onSuccess?.(cached.value);
+				config.onSettled?.(cached.value, undefined);
+				return;
+			}
+		}
+
+		const version = ++requestVersion;
+
+		activeController?.abort();
+		activeController = new AbortController();
+
+		schedulePending();
+
+		const controller = activeController;
+		const fetcherOptions: AsyncStateFetcherOptions = { signal: controller.signal };
+
+		const promise = hasSource
+			? (fetcher as SourcedFetcher<S, T>)(sourceValue as S, fetcherOptions)
+			: (fetcher as UnsourcedFetcher<T>)(fetcherOptions);
+
+		promise.then(
+			(value) => {
+				if (version !== requestVersion || controller.signal.aborted) return;
+				clearPendingTimer();
+
+				if (canUseCache) {
+					cache.set(cacheKey, { value, timestamp: Date.now() });
+				}
+
+				dataState.set(value);
+				statusState.set('success');
+				activeController = null;
+				config.onSuccess?.(value);
+				config.onSettled?.(value, undefined);
+			},
+			(err) => {
+				if (version !== requestVersion || controller.signal.aborted) return;
+				if (err instanceof DOMException && err.name === 'AbortError') return;
+				clearPendingTimer();
+				errorState.set(err);
+				statusState.set('error');
+				activeController = null;
+				config.onError?.(err);
+				config.onSettled?.(undefined, err);
+			},
+		);
+	};
+
+	if (source) {
+		const stopWatch = watch(
+			source,
+			(value) => {
+				if (value === false || value === null || value === undefined) return;
+				execute(value as S);
+			},
+			{ immediate: true },
+		);
+		disposers.push(stopWatch);
+	} else {
+		execute();
+	}
+
+	return {
+		data: dataState,
+		status: statusState,
+		error: errorState,
+		refetch() {
+			if (source) {
+				const value = source();
+				if (value === false || value === null || value === undefined) return;
+				execute(value as S);
+			} else {
+				execute();
+			}
+		},
+		abort() {
+			activeController?.abort();
+			activeController = null;
+		},
+		dispose() {
+			clearPendingTimer();
+			activeController?.abort();
+			activeController = null;
+			for (const fn of disposers) fn();
+			disposers.length = 0;
+		},
+	};
+}

--- a/packages/signals/src/computed.ts
+++ b/packages/signals/src/computed.ts
@@ -1,0 +1,292 @@
+import {
+	assertSignalAccessAllowed,
+	currentComputedSignal,
+	defaultEquals,
+	getActiveComputedSignal,
+	getActiveDependencyRecorder,
+	setActiveComputedSignal,
+	setActiveDependencyRecorder,
+} from './runtime';
+import { SignalNode } from './signal-node';
+import type { ComputedCallback, DependencyNode, SignalEquals, SignalOptions, SignalSubscriber } from './types';
+
+const COMPUTED_NO_ERROR = Symbol.for('@ecopages/signals.computed-no-error');
+
+/**
+ * Lazily derived signal backed by other signals read during evaluation.
+ *
+ * Dependencies are discovered automatically every time the computation runs,
+ * and the last successful value or thrown error is cached until one of those
+ * dependencies changes.
+ */
+export class Computed<Value> extends SignalNode<Value> {
+	private readonly compute: ComputedCallback<Value>;
+	private readonly dependencyUnsubscribers = new Map<DependencyNode, () => void>();
+	private readonly dependencyWatcherUnsubscribers = new Map<DependencyNode, () => void>();
+	private readonly equals: SignalEquals<Value>;
+	private dependencies = new Map<DependencyNode, number>();
+	private computing = false;
+	private error: unknown = undefined;
+	private hasError = false;
+	private initialized = false;
+	private pendingDependencies = new Map<DependencyNode, number>();
+	private stale = true;
+	private value!: Value;
+
+	/**
+	 * Creates a lazily evaluated derived signal.
+	 *
+	 * The compute function only reruns when the cached dependency versions become
+	 * stale, and the optional equality callback controls whether a recomputation
+	 * publishes a new exposed value.
+	 */
+	constructor(compute: ComputedCallback<Value>, options: SignalOptions<Value> = {}) {
+		super(options);
+		this.compute = compute;
+		this.equals = (options.equals ?? defaultEquals) as SignalEquals<Value>;
+	}
+
+	/**
+	 * Returns the cached value, recomputing lazily when tracked dependencies have
+	 * changed.
+	 *
+	 * If the latest evaluation threw, the cached error is rethrown until a
+	 * dependency invalidates the computed signal.
+	 */
+	public get(): Value {
+		assertSignalAccessAllowed();
+		this.refreshIfNeeded();
+		this.connectToActiveComputed();
+
+		if (this.hasError) {
+			throw this.error;
+		}
+
+		return this.value;
+	}
+
+	/**
+	 * Subscribes to changes in the computed signal's exposed value.
+	 *
+	 * The first subscriber eagerly initializes dependency subscriptions so future
+	 * source writes can invalidate and republish this computed signal.
+	 */
+	public subscribe(notify: SignalSubscriber<Value>): () => void {
+		const wasEmpty = this.subscribers.size === 0;
+		this.subscribers.add(notify);
+
+		if (wasEmpty) {
+			try {
+				this.refreshIfNeeded();
+				this.syncDependencySubscriptions();
+			} catch (error) {
+				this.subscribers.delete(notify);
+				throw error;
+			}
+		}
+
+		return () => {
+			this.subscribers.delete(notify);
+
+			if (this.subscribers.size === 0) {
+				this.clearDependencySubscriptions();
+			}
+		};
+	}
+
+	private clearDependencySubscriptions(): void {
+		for (const unsubscribe of this.dependencyUnsubscribers.values()) {
+			unsubscribe();
+		}
+
+		this.dependencyUnsubscribers.clear();
+	}
+
+	private clearDependencyWatcherSubscriptions(): void {
+		for (const unsubscribe of this.dependencyWatcherUnsubscribers.values()) {
+			unsubscribe();
+		}
+
+		this.dependencyWatcherUnsubscribers.clear();
+	}
+
+	private handleDependencyChange = () => {
+		this.stale = true;
+
+		if (this.subscribers.size === 0) {
+			return;
+		}
+
+		const previousVersion = this.version;
+		this.refreshIfNeeded();
+
+		if (this.version !== previousVersion && !this.hasError) {
+			this.publish(this.value);
+		}
+	};
+
+	private handleDependencyWatcherChange = () => {
+		this.stale = true;
+		this.notifyWatchers();
+	};
+
+	private haveDependenciesChanged(): boolean {
+		for (const [dependency, version] of this.dependencies) {
+			dependency.get();
+
+			if (dependency.getVersion() !== version) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private recompute(): void {
+		if (this.computing) {
+			throw new Error('Cannot read a computed signal recursively.');
+		}
+
+		const previousActiveDependencyRecorder = getActiveDependencyRecorder();
+		const previousActiveComputedSignal = getActiveComputedSignal();
+		const previousValue = this.value;
+		const previousError = this.error;
+		const wasInitialized = this.initialized;
+		let nextValue!: Value;
+		let nextDependencies = new Map<DependencyNode, number>();
+		let nextError: typeof COMPUTED_NO_ERROR | unknown = COMPUTED_NO_ERROR;
+
+		this.computing = true;
+		this.pendingDependencies = new Map();
+
+		try {
+			setActiveComputedSignal(this);
+			setActiveDependencyRecorder((dependency) => {
+				this.trackDependency(dependency);
+			});
+			nextValue = this.compute.call(this);
+		} catch (error) {
+			nextError = error;
+		} finally {
+			nextDependencies = this.pendingDependencies;
+			setActiveComputedSignal(previousActiveComputedSignal);
+			setActiveDependencyRecorder(previousActiveDependencyRecorder);
+			this.pendingDependencies = new Map();
+			this.computing = false;
+		}
+
+		this.dependencies = nextDependencies;
+		this.stale = false;
+		const hasChanged =
+			!wasInitialized ||
+			(nextError === COMPUTED_NO_ERROR
+				? this.hasError || !this.equals.call(this, previousValue, nextValue)
+				: !this.hasError || previousError !== nextError);
+
+		if (nextError === COMPUTED_NO_ERROR) {
+			this.value = nextValue;
+			this.error = undefined;
+			this.hasError = false;
+		} else {
+			this.error = nextError;
+			this.hasError = true;
+		}
+
+		this.initialized = true;
+
+		if (hasChanged) {
+			this.version += 1;
+		}
+
+		if (this.subscribers.size > 0) {
+			this.syncDependencySubscriptions();
+		}
+
+		if (this.getWatcherCount() > 0) {
+			this.syncDependencyWatcherSubscriptions();
+		}
+	}
+
+	private refreshIfNeeded(): void {
+		if (!this.initialized || this.stale || this.haveDependenciesChanged()) {
+			this.recompute();
+		}
+	}
+
+	private syncDependencySubscriptions(): void {
+		for (const [dependency, unsubscribe] of this.dependencyUnsubscribers) {
+			if (this.dependencies.has(dependency)) {
+				continue;
+			}
+
+			unsubscribe();
+			this.dependencyUnsubscribers.delete(dependency);
+		}
+
+		for (const dependency of this.dependencies.keys()) {
+			if (this.dependencyUnsubscribers.has(dependency)) {
+				continue;
+			}
+
+			this.dependencyUnsubscribers.set(dependency, dependency.subscribe(this.handleDependencyChange));
+		}
+	}
+
+	private syncDependencyWatcherSubscriptions(): void {
+		for (const [dependency, unsubscribe] of this.dependencyWatcherUnsubscribers) {
+			if (this.dependencies.has(dependency)) {
+				continue;
+			}
+
+			unsubscribe();
+			this.dependencyWatcherUnsubscribers.delete(dependency);
+		}
+
+		for (const dependency of this.dependencies.keys()) {
+			if (this.dependencyWatcherUnsubscribers.has(dependency)) {
+				continue;
+			}
+
+			this.dependencyWatcherUnsubscribers.set(
+				dependency,
+				dependency.addWatcher(this.handleDependencyWatcherChange),
+			);
+		}
+	}
+
+	private trackDependency(dependency: DependencyNode): void {
+		this.pendingDependencies.set(dependency, dependency.getVersion());
+	}
+
+	protected override handleFirstWatcherAdded(): void {
+		this.refreshIfNeeded();
+		this.syncDependencyWatcherSubscriptions();
+	}
+
+	protected override handleLastWatcherRemoved(): void {
+		this.clearDependencyWatcherSubscriptions();
+	}
+}
+
+/**
+ * Creates a computed signal.
+ *
+ * This is equivalent to `new Computed(...)` and can be convenient in codebases
+ * that prefer functional construction over classes.
+ */
+export function computed<Value>(
+	computeValue: ComputedCallback<Value>,
+	options?: SignalOptions<Value>,
+): Computed<Value> {
+	return new Computed(computeValue, options);
+}
+
+/**
+ * Returns the computed signal currently being evaluated, if any.
+ *
+ * This is mainly useful inside advanced derived helpers that need access to
+ * the active computed during dependency discovery.
+ */
+export function currentComputed(): Computed<unknown> | null {
+	return currentComputedSignal();
+}

--- a/packages/signals/src/dependency.ts
+++ b/packages/signals/src/dependency.ts
@@ -1,0 +1,14 @@
+import { assertSignalAccessAllowed, trackActiveDependency } from './runtime';
+import type { DependencyNode } from './types';
+
+/**
+ * Registers a custom dependency node with the currently active computation.
+ *
+ * This is intended for framework and renderer adapters that need plain reactive
+ * sources to participate in `Computed`, `effect(...)`, or watcher dependency
+ * discovery without first wrapping those sources in a full signal instance.
+ */
+export function trackDependency(dependency: DependencyNode): void {
+	assertSignalAccessAllowed();
+	trackActiveDependency(dependency);
+}

--- a/packages/signals/src/effect.ts
+++ b/packages/signals/src/effect.ts
@@ -1,0 +1,104 @@
+import { getActiveDependencyRecorder, scheduleMicrotask, setActiveDependencyRecorder } from './runtime';
+import type { DependencyNode, EffectCallback, EffectOptions, EffectScheduler } from './types';
+
+class EffectRunner {
+	private cleanup: (() => void) | undefined;
+	private readonly dependencies = new Map<DependencyNode, () => void>();
+	private disposed = false;
+	private queued = false;
+	private readonly scheduler: EffectScheduler;
+
+	constructor(
+		private readonly callback: EffectCallback,
+		options: EffectOptions,
+	) {
+		this.scheduler = options.scheduler ?? scheduleMicrotask;
+	}
+
+	public dispose(): void {
+		if (this.disposed) {
+			return;
+		}
+
+		this.disposed = true;
+		this.cleanup?.();
+		this.cleanup = undefined;
+
+		for (const unsubscribe of this.dependencies.values()) {
+			unsubscribe();
+		}
+
+		this.dependencies.clear();
+	}
+
+	public run = (): void => {
+		if (this.disposed) {
+			return;
+		}
+
+		this.queued = false;
+		this.cleanup?.();
+		this.cleanup = undefined;
+
+		const nextDependencies = new Set<DependencyNode>();
+		const previousActiveDependencyRecorder = getActiveDependencyRecorder();
+
+		try {
+			setActiveDependencyRecorder((dependency) => {
+				nextDependencies.add(dependency);
+			});
+			const result = this.callback();
+
+			if (typeof result === 'function') {
+				this.cleanup = result;
+			}
+		} finally {
+			setActiveDependencyRecorder(previousActiveDependencyRecorder);
+		}
+
+		this.syncDependencies(nextDependencies);
+	};
+
+	private handleDependencyChange = () => {
+		if (this.disposed || this.queued) {
+			return;
+		}
+
+		this.queued = true;
+		this.scheduler(this.run);
+	};
+
+	private syncDependencies(nextDependencies: Set<DependencyNode>): void {
+		for (const [dependency, unsubscribe] of this.dependencies) {
+			if (nextDependencies.has(dependency)) {
+				continue;
+			}
+
+			unsubscribe();
+			this.dependencies.delete(dependency);
+		}
+
+		for (const dependency of nextDependencies) {
+			if (this.dependencies.has(dependency)) {
+				continue;
+			}
+
+			this.dependencies.set(dependency, dependency.subscribe(this.handleDependencyChange));
+		}
+	}
+}
+
+/**
+ * Runs a reactive side effect and reschedules it when one of the signals read
+ * during execution changes.
+ *
+ * The callback may return a cleanup function, which runs before the next
+ * execution and again when the returned disposer is called.
+ */
+export function effect(callback: EffectCallback, options: EffectOptions = {}): () => void {
+	const runner = new EffectRunner(callback, options);
+	runner.run();
+	return () => {
+		runner.dispose();
+	};
+}

--- a/packages/signals/src/runtime.ts
+++ b/packages/signals/src/runtime.ts
@@ -1,0 +1,54 @@
+import type { Computed } from './computed';
+import type { DependencyNode, EffectScheduler, SignalEquals } from './types';
+
+let activeDependencyRecorder: ((dependency: DependencyNode) => void) | undefined;
+let activeComputedSignal: Computed<any> | undefined;
+let frozenWatcherDepth = 0;
+
+export const defaultEquals: SignalEquals<unknown> = function (previousValue, nextValue) {
+	return Object.is(previousValue, nextValue);
+};
+
+export const scheduleMicrotask: EffectScheduler = (run) => {
+	queueMicrotask(run);
+};
+
+export function assertSignalAccessAllowed(): void {
+	if (frozenWatcherDepth > 0) {
+		throw new Error('Cannot read or write signals during a Watcher notification.');
+	}
+}
+
+export function currentComputedSignal(): Computed<unknown> | null {
+	return activeComputedSignal ?? null;
+}
+
+export function getActiveComputedSignal(): Computed<any> | undefined {
+	return activeComputedSignal;
+}
+
+export function setActiveComputedSignal(nextSignal: Computed<any> | undefined): void {
+	activeComputedSignal = nextSignal;
+}
+
+export function getActiveDependencyRecorder(): ((dependency: DependencyNode) => void) | undefined {
+	return activeDependencyRecorder;
+}
+
+export function setActiveDependencyRecorder(nextRecorder: ((dependency: DependencyNode) => void) | undefined): void {
+	activeDependencyRecorder = nextRecorder;
+}
+
+export function trackActiveDependency(dependency: DependencyNode): void {
+	activeDependencyRecorder?.(dependency);
+}
+
+export function runWatcherNotify(callback: () => void): void {
+	frozenWatcherDepth += 1;
+
+	try {
+		callback();
+	} finally {
+		frozenWatcherDepth -= 1;
+	}
+}

--- a/packages/signals/src/signal-node.ts
+++ b/packages/signals/src/signal-node.ts
@@ -1,0 +1,107 @@
+import { trackActiveDependency } from './runtime';
+import {
+	watched,
+	unwatched,
+	type DependencyNode,
+	type Signal,
+	type SignalOptions,
+	type SignalSubscriber,
+} from './types';
+
+/**
+ * Shared signal implementation used by writable and computed signals.
+ *
+ * It centralizes subscriber delivery, monotonic versioning, and the low-level
+ * watcher hooks consumed by `subtle.Watcher`.
+ */
+export abstract class SignalNode<Value> implements Signal<Value>, DependencyNode {
+	protected readonly subscribers = new Set<SignalSubscriber<Value>>();
+	protected version = 0;
+	private readonly watcherListeners = new Set<() => void>();
+	private readonly onWatched: ((this: Signal<Value>) => void) | undefined;
+	private readonly onUnwatched: ((this: Signal<Value>) => void) | undefined;
+
+	protected constructor(options: SignalOptions<Value> = {}) {
+		this.onWatched = options[watched];
+		this.onUnwatched = options[unwatched];
+	}
+
+	abstract get(): Value;
+	abstract subscribe(notify: SignalSubscriber<Value>): () => void;
+
+	public addWatcher(notify: () => void): () => void {
+		const wasEmpty = this.watcherListeners.size === 0;
+		this.watcherListeners.add(notify);
+
+		if (wasEmpty) {
+			try {
+				this.handleFirstWatcherAdded();
+				this.onWatched?.call(this);
+			} catch (error) {
+				this.watcherListeners.delete(notify);
+				throw error;
+			}
+		}
+
+		return () => {
+			if (!this.watcherListeners.delete(notify)) {
+				return;
+			}
+
+			if (this.watcherListeners.size === 0) {
+				this.handleLastWatcherRemoved();
+				this.onUnwatched?.call(this);
+			}
+		};
+	}
+
+	public getVersion(): number {
+		return this.version;
+	}
+
+	public getWatcherCount(): number {
+		return this.watcherListeners.size;
+	}
+
+	protected connectToActiveComputed(): void {
+		trackActiveDependency(this);
+	}
+
+	protected handleFirstWatcherAdded(): void {}
+
+	protected handleLastWatcherRemoved(): void {}
+
+	protected publish(nextValue: Value): void {
+		for (const subscriber of this.subscribers) {
+			subscriber(nextValue);
+		}
+	}
+
+	protected notifyWatchers(): void {
+		const errors: unknown[] = [];
+
+		for (const listener of this.watcherListeners) {
+			try {
+				listener();
+			} catch (error) {
+				errors.push(error);
+			}
+		}
+
+		if (errors.length === 1) {
+			throw errors[0];
+		}
+
+		if (errors.length > 1) {
+			throw new AggregateError(errors, 'Multiple watcher notifications failed.');
+		}
+	}
+}
+
+export function resolveSignalNode(signal: Signal<unknown>): SignalNode<unknown> {
+	if (!(signal instanceof SignalNode)) {
+		throw new TypeError('Expected a signal created by @ecopages/signals.');
+	}
+
+	return signal;
+}

--- a/packages/signals/src/state.ts
+++ b/packages/signals/src/state.ts
@@ -1,0 +1,98 @@
+import { assertSignalAccessAllowed, defaultEquals } from './runtime';
+import { SignalNode } from './signal-node';
+import type { SignalEquals, SignalOptions, SignalSubscriber, WritableSignal } from './types';
+
+/**
+ * Writable state signal.
+ *
+ * State signals are the smallest unit of mutable reactive data in this package.
+ */
+export class State<Value> extends SignalNode<Value> implements WritableSignal<Value> {
+	private readonly equals: SignalEquals<Value>;
+	private value: Value;
+
+	/**
+	 * Creates a writable signal with an initial value.
+	 *
+	 * The optional `equals` callback can suppress redundant writes, and the
+	 * watcher hooks integrate with `subtle.Watcher` lifecycle events.
+	 */
+	constructor(initialValue: Value, options: SignalOptions<Value> = {}) {
+		super(options);
+		this.value = initialValue;
+		this.equals = (options.equals ?? defaultEquals) as SignalEquals<Value>;
+	}
+
+	/**
+	 * Returns the current value and records this state as a dependency when a
+	 * computation is actively collecting dependencies.
+	 */
+	public get(): Value {
+		assertSignalAccessAllowed();
+		this.connectToActiveComputed();
+		return this.value;
+	}
+
+	/**
+	 * Replaces the current value.
+	 *
+	 * Watchers are notified before imperative subscribers so low-level invalidation
+	 * can observe the stale transition before push listeners run.
+	 */
+	public set(nextValue: Value): void {
+		assertSignalAccessAllowed();
+
+		if (this.equals.call(this, this.value, nextValue)) {
+			return;
+		}
+
+		this.value = nextValue;
+		this.version += 1;
+
+		let watcherError: unknown;
+
+		try {
+			this.notifyWatchers();
+		} catch (error) {
+			watcherError = error;
+		}
+
+		this.publish(nextValue);
+
+		if (watcherError) {
+			throw watcherError;
+		}
+	}
+
+	/**
+	 * Updates the current value using the previous one and then forwards to
+	 * `set(...)` so equality checks and notifications stay consistent.
+	 */
+	public update(updater: (value: Value) => Value): void {
+		this.set(updater(this.value));
+	}
+
+	/**
+	 * Registers an imperative subscriber.
+	 *
+	 * Subscriptions do not trigger an immediate call and are independent from the
+	 * automatic dependency tracking used by computed values and effects.
+	 */
+	public subscribe(notify: SignalSubscriber<Value>): () => void {
+		this.subscribers.add(notify);
+
+		return () => {
+			this.subscribers.delete(notify);
+		};
+	}
+}
+
+/**
+ * Creates a writable state signal.
+ *
+ * This is equivalent to `new State(...)` and can be useful in codebases that
+ * prefer factory-style construction.
+ */
+export function state<Value>(initialValue: Value, options?: SignalOptions<Value>): State<Value> {
+	return new State(initialValue, options);
+}

--- a/packages/signals/src/store.ts
+++ b/packages/signals/src/store.ts
@@ -1,0 +1,325 @@
+import { State } from './state';
+import { peek } from './tracking';
+import type { SignalStore } from './types';
+
+const STORE_BRANCH_SYMBOL = Symbol.for('@ecopages/signals.store-branch');
+const STORE_ABSENT = Symbol.for('@ecopages/signals.store-absent');
+
+type StoreBranch = {
+	readonly [STORE_BRANCH_SYMBOL]: true;
+	readonly node: StoreNode<any>;
+};
+
+type StoreEntryValue = StoreBranch | typeof STORE_ABSENT | unknown;
+
+type StoreNode<Value extends object> = {
+	entries: Map<PropertyKey, State<StoreEntryValue>>;
+	proxy: Value;
+	shape: State<number>;
+	target: Value;
+	valueType: 'array' | 'object';
+};
+
+const storeNodeLookup = new WeakMap<object, StoreNode<object>>();
+const hasOwnProperty = Object.prototype.hasOwnProperty;
+
+/**
+ * Returns `true` when `value` is a deep reactive store created by this package.
+ *
+ * This is useful for adapters that need to accept either plain objects or
+ * signal-backed store proxies.
+ */
+export function isStore(value: unknown): value is SignalStore<object> {
+	return typeof value === 'object' && value !== null && storeNodeLookup.has(value);
+}
+
+/**
+ * Creates a deep reactive store backed by nested state signals.
+ *
+ * Plain object and array branches are wrapped recursively so property reads,
+ * keyed access, and structural changes can participate in dependency tracking.
+ */
+export function createStore<Value extends object>(initialValue: Value): SignalStore<Value> {
+	return createStoreNode(initialValue).proxy;
+}
+
+/**
+ * Materializes the current plain snapshot of a signal store or nested store
+ * value.
+ *
+ * The returned value is detached from the reactive proxy graph, making it safe
+ * to serialize or compare outside the live store.
+ */
+export function snapshot<Value>(value: Value): Value {
+	if (isStore(value)) {
+		return snapshotStoreNode(getStoreNode(value)) as Value;
+	}
+
+	return snapshotNestedValue(value);
+}
+
+function createStoreBranch(value: object): StoreBranch {
+	return {
+		[STORE_BRANCH_SYMBOL]: true,
+		node: createStoreNode(value),
+	};
+}
+
+function createStoreEntryValue(value: unknown): StoreEntryValue {
+	const normalizedValue = isStore(value) ? snapshot(value) : value;
+
+	if (isStoreBranchValue(normalizedValue)) {
+		return createStoreBranch(normalizedValue);
+	}
+
+	return normalizedValue;
+}
+
+function createStoreNode<Value extends object>(initialValue: Value): StoreNode<Value> {
+	const valueType = Array.isArray(initialValue) ? 'array' : 'object';
+	const target = (valueType === 'array' ? [] : {}) as Value;
+	const node: StoreNode<Value> = {
+		entries: new Map(),
+		proxy: undefined as unknown as Value,
+		shape: new State(0),
+		target,
+		valueType,
+	};
+
+	for (const key of Reflect.ownKeys(initialValue)) {
+		const entry = new State<StoreEntryValue>(
+			createStoreEntryValue((initialValue as Record<PropertyKey, unknown>)[key]),
+		);
+		node.entries.set(key, entry);
+		Reflect.set(target as object, key, unwrapStoreEntryValue(peek(entry)));
+	}
+
+	if (Array.isArray(initialValue)) {
+		(target as unknown as any[]).length = initialValue.length;
+	}
+
+	node.proxy = new Proxy(target, createStoreProxyHandler(node));
+	storeNodeLookup.set(node.proxy as object, node as StoreNode<object>);
+	return node;
+}
+
+function createStoreProxyHandler<Value extends object>(node: StoreNode<Value>): ProxyHandler<Value> {
+	return {
+		defineProperty(target, key, descriptor) {
+			if ('value' in descriptor) {
+				return applyStoreSet(node, key, descriptor.value);
+			}
+
+			const result = Reflect.defineProperty(target, key, descriptor);
+
+			if (result) {
+				node.shape.update((value) => value + 1);
+			}
+
+			return result;
+		},
+
+		deleteProperty(_target, key) {
+			return deleteStoreProperty(node, key);
+		},
+
+		get(target, key, receiver) {
+			if (node.valueType === 'array' && key === 'length') {
+				node.shape.get();
+				return Reflect.get(target, key, receiver);
+			}
+
+			if (hasOwnProperty.call(target, key)) {
+				const entry = ensureStoreEntry(node, key);
+				const value = entry.get();
+
+				if (value === STORE_ABSENT) {
+					return undefined;
+				}
+
+				return unwrapStoreEntryValue(value);
+			}
+
+			return Reflect.get(target, key, receiver);
+		},
+
+		getOwnPropertyDescriptor(target, key) {
+			node.shape.get();
+			return Reflect.getOwnPropertyDescriptor(target, key);
+		},
+
+		has(target, key) {
+			node.shape.get();
+			return Reflect.has(target, key);
+		},
+
+		ownKeys(target) {
+			node.shape.get();
+			return Reflect.ownKeys(target);
+		},
+
+		set(_target, key, value) {
+			return applyStoreSet(node, key, value);
+		},
+	};
+}
+
+function getStoreNode(value: object): StoreNode<object> {
+	const node = storeNodeLookup.get(value);
+
+	if (!node) {
+		throw new Error('Value is not a signal store.');
+	}
+
+	return node;
+}
+
+function applyStoreSet<Value extends object>(node: StoreNode<Value>, key: PropertyKey, value: unknown): boolean {
+	if (node.valueType === 'array' && key === 'length') {
+		return setStoreArrayLength(node as StoreNode<any[]>, value);
+	}
+
+	const entry = ensureStoreEntry(node, key);
+	const hadOwn = hasOwnProperty.call(node.target, key);
+	const previousLength = node.valueType === 'array' ? (node.target as unknown as any[]).length : undefined;
+	const nextEntryValue = createStoreEntryValue(value);
+	entry.set(nextEntryValue);
+	Reflect.set(node.target as object, key, unwrapStoreEntryValue(nextEntryValue));
+
+	if (!hadOwn) {
+		node.shape.update((current) => current + 1);
+	}
+
+	if (node.valueType === 'array') {
+		const nextLength = (node.target as unknown as any[]).length;
+
+		if (previousLength !== nextLength) {
+			node.shape.update((current) => current + 1);
+		}
+	}
+
+	return true;
+}
+
+function deleteStoreProperty<Value extends object>(node: StoreNode<Value>, key: PropertyKey): boolean {
+	if (!hasOwnProperty.call(node.target, key)) {
+		return true;
+	}
+
+	const entry = ensureStoreEntry(node, key);
+	entry.set(STORE_ABSENT);
+	Reflect.deleteProperty(node.target as object, key);
+	if (node.valueType === 'array' && key === 'length') {
+		(node.target as unknown as any[]).length = 0;
+	}
+	node.shape.update((current) => current + 1);
+	return true;
+}
+
+function ensureStoreEntry<Value extends object>(node: StoreNode<Value>, key: PropertyKey): State<StoreEntryValue> {
+	let entry = node.entries.get(key);
+
+	if (!entry) {
+		entry = new State<StoreEntryValue>(STORE_ABSENT);
+		node.entries.set(key, entry);
+	}
+
+	return entry;
+}
+
+function isStoreBranch(value: unknown): value is StoreBranch {
+	return typeof value === 'object' && value !== null && STORE_BRANCH_SYMBOL in value;
+}
+
+function isStoreBranchValue(value: unknown): value is object {
+	if (value === null || typeof value !== 'object') {
+		return false;
+	}
+
+	if (Array.isArray(value)) {
+		return true;
+	}
+
+	const prototype = Object.getPrototypeOf(value);
+	return prototype === Object.prototype || prototype === null;
+}
+
+function setStoreArrayLength(node: StoreNode<any[]>, value: unknown): boolean {
+	const nextLength = Number(value);
+
+	if (!Number.isInteger(nextLength) || nextLength < 0) {
+		throw new RangeError('Invalid array length.');
+	}
+
+	const target = node.target as unknown as any[];
+	const previousLength = target.length;
+
+	if (nextLength < previousLength) {
+		for (let index = previousLength - 1; index >= nextLength; index -= 1) {
+			deleteStoreProperty(node, String(index));
+		}
+	}
+
+	target.length = nextLength;
+
+	if (previousLength !== nextLength) {
+		node.shape.update((current) => current + 1);
+	}
+
+	return true;
+}
+
+function snapshotNestedValue<Value>(value: Value): Value {
+	if (Array.isArray(value)) {
+		return value.map((item) => snapshotNestedValue(item)) as Value;
+	}
+
+	if (isStore(value)) {
+		return snapshot(value);
+	}
+
+	if (isStoreBranchValue(value)) {
+		const result: Record<PropertyKey, unknown> = {};
+
+		for (const key of Reflect.ownKeys(value)) {
+			result[key] = snapshotNestedValue((value as Record<PropertyKey, unknown>)[key]);
+		}
+
+		return result as Value;
+	}
+
+	return value;
+}
+
+function snapshotStoreNode<Value extends object>(node: StoreNode<Value>): Value {
+	const result = (node.valueType === 'array' ? [] : {}) as Value;
+
+	for (const key of Reflect.ownKeys(node.target)) {
+		const entry = ensureStoreEntry(node, key);
+		const value = peek(entry);
+
+		if (value === STORE_ABSENT) {
+			continue;
+		}
+
+		Reflect.set(result as object, key, snapshotNestedValue(unwrapStoreEntryValue(value)));
+	}
+
+	if (node.valueType === 'array') {
+		(result as unknown as any[]).length = (node.target as unknown as any[]).length;
+	}
+
+	return result;
+}
+
+function unwrapStoreEntryValue(value: StoreEntryValue): unknown {
+	if (value === STORE_ABSENT) {
+		return undefined;
+	}
+
+	if (isStoreBranch(value)) {
+		return value.node.proxy;
+	}
+
+	return value;
+}

--- a/packages/signals/src/tracking.ts
+++ b/packages/signals/src/tracking.ts
@@ -1,0 +1,30 @@
+import { getActiveDependencyRecorder, setActiveDependencyRecorder } from './runtime';
+import type { Signal } from './types';
+
+/**
+ * Reads signals without registering their reads as dependencies of the current
+ * computed signal or effect.
+ *
+ * This is the escape hatch for code that needs the latest value without making
+ * future writes retrigger the active reactive computation.
+ */
+export function untrack<Value>(read: () => Value): Value {
+	const previousActiveDependencyRecorder = getActiveDependencyRecorder();
+	setActiveDependencyRecorder(undefined);
+
+	try {
+		return read();
+	} finally {
+		setActiveDependencyRecorder(previousActiveDependencyRecorder);
+	}
+}
+
+/**
+ * Reads a signal's current value without tracking it as a dependency.
+ *
+ * This is a convenience wrapper around `untrack(...)` for the common case of a
+ * single signal read.
+ */
+export function peek<Value>(signal: Signal<Value>): Value {
+	return untrack(() => signal.get());
+}

--- a/packages/signals/src/types.ts
+++ b/packages/signals/src/types.ts
@@ -1,0 +1,128 @@
+import type { Computed } from './computed';
+
+/**
+ * Imperative listener invoked after a signal publishes a new exposed value.
+ *
+ * Subscribers are separate from automatic dependency tracking and are mainly
+ * useful for adapters, bridge code, or tests that need push-based updates.
+ */
+export type SignalSubscriber<Value> = (value: Value) => void;
+
+/** Hook invoked when a signal becomes watched through `subtle.Watcher`. */
+export const watched = Symbol.for('@ecopages/signals.subtle.watched');
+
+/** Hook invoked when a signal stops being watched through `subtle.Watcher`. */
+export const unwatched = Symbol.for('@ecopages/signals.subtle.unwatched');
+
+export type SignalEquals<Value> = (this: Signal<Value>, previousValue: Value, nextValue: Value) => boolean;
+
+export type ComputedCallback<Value> = (this: Computed<Value>) => Value;
+
+/**
+ * Optional configuration shared by writable and computed signals.
+ *
+ * These hooks control equality and low-level watcher lifecycle integration.
+ */
+export interface SignalOptions<Value> {
+	/**
+	 * Equality comparison used to suppress redundant updates.
+	 *
+	 * Defaults to `Object.is`.
+	 */
+	equals?: SignalEquals<Value>;
+
+	/** Called when the signal becomes watched through `subtle.Watcher`. */
+	[watched]?: (this: Signal<Value>) => void;
+
+	/** Called when the signal is no longer watched through `subtle.Watcher`. */
+	[unwatched]?: (this: Signal<Value>) => void;
+}
+
+/**
+ * Read-only signal contract.
+ *
+ * Reading from a signal participates in dependency discovery when a computed
+ * signal or effect is currently collecting dependencies.
+ */
+export interface Signal<Value> {
+	/**
+	 * Returns the current value.
+	 *
+	 * Reads performed during a tracked computation register this signal as a
+	 * dependency of that computation.
+	 */
+	get(): Value;
+
+	/**
+	 * Subscribes to exposed value changes.
+	 *
+	 * Subscribers are only called when the signal's value changes according to
+	 * its configured equality function.
+	 */
+	subscribe(notify: SignalSubscriber<Value>): () => void;
+}
+
+/**
+ * Read-write signal contract.
+ *
+ * Writable signals expose direct writes in addition to dependency-tracked
+ * reads.
+ */
+export interface WritableSignal<Value> extends Signal<Value> {
+	/**
+	 * Replaces the current value.
+	 *
+	 * No invalidation happens when the configured equality function reports the
+	 * new value as equal to the current one.
+	 */
+	set(nextValue: Value): void;
+
+	/**
+	 * Replaces the current value by deriving the next one from the current one.
+	 */
+	update(updater: (value: Value) => Value): void;
+}
+
+/** Scheduler used to defer effect re-execution. */
+export type EffectScheduler = (run: () => void) => void;
+
+/** Cleanup function returned from an effect body. */
+export type EffectCleanup = void | (() => void);
+
+/** Callback executed by an effect. */
+export type EffectCallback = () => EffectCleanup;
+
+/**
+ * Configuration for an effect.
+ *
+ * Effects default to microtask scheduling so multiple synchronous writes can
+ * collapse into a single rerun.
+ */
+export interface EffectOptions {
+	/** Scheduler used after a dependency changes. Defaults to a microtask queue. */
+	scheduler?: EffectScheduler;
+}
+
+/**
+ * Configuration for `watch(...)`.
+ *
+ * Watches reuse computed-style equality and effect-style scheduling.
+ */
+export interface WatchOptions<Value> extends SignalOptions<Value> {
+	/**
+	 * When `true`, invokes the callback during the initial run with an undefined
+	 * previous value.
+	 */
+	immediate?: boolean;
+
+	/** Scheduler used after the watched value changes. */
+	scheduler?: EffectScheduler;
+}
+
+/** Marker interface returned from `createStore(...)`. */
+export type SignalStore<Value extends object> = Value;
+
+export interface DependencyNode extends Signal<unknown> {
+	addWatcher(notify: () => void): () => void;
+	getVersion(): number;
+}

--- a/packages/signals/src/watch.ts
+++ b/packages/signals/src/watch.ts
@@ -1,0 +1,36 @@
+import { Computed } from './computed';
+import { effect } from './effect';
+import type { WatchOptions } from './types';
+
+/**
+ * Watches a derived value and invokes `notify` when the exposed value changes
+ * under the configured equality function.
+ *
+ * This helper combines a computed signal with an effect so callers can observe
+ * derived state without manually managing previous values.
+ */
+export function watch<Value>(
+	read: () => Value,
+	notify: (nextValue: Value, previousValue: Value | undefined) => void,
+	options: WatchOptions<Value> = {},
+): () => void {
+	const watchedValue = new Computed(read, { equals: options.equals });
+	let previousValue: Value | undefined;
+	let initialized = false;
+
+	return effect(
+		() => {
+			const nextValue = watchedValue.get();
+
+			if (initialized) {
+				notify(nextValue, previousValue);
+			} else if (options.immediate) {
+				notify(nextValue, undefined);
+			}
+
+			previousValue = nextValue;
+			initialized = true;
+		},
+		{ scheduler: options.scheduler },
+	);
+}

--- a/packages/signals/src/watcher.ts
+++ b/packages/signals/src/watcher.ts
@@ -1,0 +1,117 @@
+import { assertSignalAccessAllowed, runWatcherNotify } from './runtime';
+import { resolveSignalNode } from './signal-node';
+import type { Signal } from './types';
+
+type WatchableSignal = ReturnType<typeof resolveSignalNode>;
+
+/**
+ * Low-level watcher used to schedule work when watched signals may have become
+ * stale.
+ *
+ * This follows the proposal-shaped watcher model: every call to `watch(...)`
+ * re-arms the watcher by clearing the pending set and resetting its single
+ * notification latch for the next invalidation cycle.
+ */
+export class Watcher {
+	private notified = false;
+	private readonly pendingSignals = new Map<WatchableSignal, Signal<unknown>>();
+	private readonly signals = new Map<WatchableSignal, Signal<unknown>>();
+	private readonly unsubscribers = new Map<WatchableSignal, () => void>();
+
+	/**
+	 * Creates a watcher whose callback runs once per invalidation cycle until the
+	 * watcher is re-armed with `watch(...)`.
+	 */
+	constructor(private readonly notifyCallback: (this: Watcher) => void) {}
+
+	/**
+	 * Returns the watched signals invalidated since the last `watch(...)` reset.
+	 *
+	 * The returned array preserves insertion order for the current pending set.
+	 */
+	public getPending(): Signal<unknown>[] {
+		return Array.from(this.pendingSignals.values());
+	}
+
+	/**
+	 * Stops watching the provided signals.
+	 *
+	 * Removing the last watched signal also clears the pending set and resets the
+	 * notification latch.
+	 */
+	public unwatch(...signals: Signal<unknown>[]): void {
+		assertSignalAccessAllowed();
+
+		for (const signal of signals) {
+			const node = resolveSignalNode(signal);
+			const unsubscribe = this.unsubscribers.get(node);
+
+			if (!unsubscribe) {
+				throw new Error('Signal is not watched by this watcher.');
+			}
+		}
+
+		for (const signal of signals) {
+			const node = resolveSignalNode(signal);
+			const unsubscribe = this.unsubscribers.get(node);
+
+			unsubscribe?.();
+			this.pendingSignals.delete(node);
+			this.signals.delete(node);
+			this.unsubscribers.delete(node);
+		}
+
+		if (this.signals.size === 0) {
+			this.pendingSignals.clear();
+			this.notified = false;
+		}
+	}
+
+	/**
+	 * Starts watching the provided signals.
+	 *
+	 * Re-watching is also a reset point, so `getPending()` only reports
+	 * invalidations that happen after this call.
+	 */
+	public watch(...signals: Signal<unknown>[]): void {
+		assertSignalAccessAllowed();
+
+		for (const signal of signals) {
+			const node = resolveSignalNode(signal);
+
+			if (this.signals.has(node)) {
+				continue;
+			}
+
+			this.signals.set(node, signal);
+			this.unsubscribers.set(
+				node,
+				node.addWatcher(() => {
+					this.handleSignalChange(node);
+				}),
+			);
+		}
+
+		this.pendingSignals.clear();
+		this.notified = false;
+	}
+
+	private handleSignalChange(node: WatchableSignal): void {
+		const signal = this.signals.get(node);
+
+		if (!signal) {
+			return;
+		}
+
+		this.pendingSignals.set(node, signal);
+
+		if (this.notified) {
+			return;
+		}
+
+		this.notified = true;
+		runWatcherNotify(() => {
+			this.notifyCallback.call(this);
+		});
+	}
+}

--- a/packages/signals/test/async-state.test.ts
+++ b/packages/signals/test/async-state.test.ts
@@ -1,0 +1,533 @@
+import { describe, expect, test, vi } from 'vitest';
+import { asyncState, state } from '../index';
+
+function flushMicrotasks(): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function createFetcher<T>(value: T, delay = 0) {
+	return vi.fn(({ signal }: { signal: AbortSignal }) => {
+		return new Promise<T>((resolve, reject) => {
+			const timer = setTimeout(() => resolve(value), delay);
+			signal.addEventListener('abort', () => {
+				clearTimeout(timer);
+				reject(new DOMException('Aborted', 'AbortError'));
+			});
+		});
+	});
+}
+
+function createSourcedFetcher<S, T>(map: (source: S) => T, delay = 0) {
+	return vi.fn((source: S, { signal }: { signal: AbortSignal }) => {
+		return new Promise<T>((resolve, reject) => {
+			const timer = setTimeout(() => resolve(map(source)), delay);
+			signal.addEventListener('abort', () => {
+				clearTimeout(timer);
+				reject(new DOMException('Aborted', 'AbortError'));
+			});
+		});
+	});
+}
+
+describe('asyncState', () => {
+	describe('unsourced (manual)', () => {
+		test('fetches immediately and transitions idle → pending → success', async () => {
+			const query = asyncState({ fetcher: createFetcher('hello') });
+
+			expect(query.status.get()).toBe('pending');
+			expect(query.data.get()).toBeUndefined();
+
+			await flushMicrotasks();
+
+			expect(query.status.get()).toBe('success');
+			expect(query.data.get()).toBe('hello');
+			expect(query.error.get()).toBeUndefined();
+
+			query.dispose();
+		});
+
+		test('uses initialValue before first resolution', async () => {
+			const query = asyncState({ fetcher: createFetcher('resolved'), initialValue: 'seed' });
+
+			expect(query.data.get()).toBe('seed');
+			expect(query.status.get()).toBe('pending');
+
+			await flushMicrotasks();
+
+			expect(query.data.get()).toBe('resolved');
+
+			query.dispose();
+		});
+
+		test('transitions to error on rejection', async () => {
+			const error = new Error('boom');
+			const fetcher = vi.fn(() => Promise.reject(error));
+			const query = asyncState({ fetcher });
+
+			await flushMicrotasks();
+
+			expect(query.status.get()).toBe('error');
+			expect(query.error.get()).toBe(error);
+			expect(query.data.get()).toBeUndefined();
+
+			query.dispose();
+		});
+
+		test('refetch re-executes and aborts the previous request', async () => {
+			const fetcher = createFetcher('first', 50);
+			const query = asyncState({ fetcher });
+
+			expect(fetcher).toHaveBeenCalledTimes(1);
+
+			query.refetch();
+
+			expect(fetcher).toHaveBeenCalledTimes(2);
+			expect(query.status.get()).toBe('pending');
+
+			await flushMicrotasks();
+			await new Promise((r) => setTimeout(r, 60));
+
+			expect(query.status.get()).toBe('success');
+
+			query.dispose();
+		});
+
+		test('abort cancels in-flight request', async () => {
+			const fetcher = createFetcher('value', 100);
+			const query = asyncState({ fetcher });
+
+			expect(query.status.get()).toBe('pending');
+
+			query.abort();
+
+			await flushMicrotasks();
+
+			expect(query.status.get()).toBe('pending');
+			expect(query.data.get()).toBeUndefined();
+
+			query.dispose();
+		});
+
+		test('retains last successful data while refetching', async () => {
+			let callCount = 0;
+			const fetcher = vi.fn(({ signal }: { signal: AbortSignal }) => {
+				callCount++;
+				return new Promise<string>((resolve, reject) => {
+					const timer = setTimeout(() => resolve(`result-${callCount}`), 0);
+					signal.addEventListener('abort', () => {
+						clearTimeout(timer);
+						reject(new DOMException('Aborted', 'AbortError'));
+					});
+				});
+			});
+
+			const query = asyncState({ fetcher });
+
+			await flushMicrotasks();
+			expect(query.data.get()).toBe('result-1');
+
+			query.refetch();
+			expect(query.status.get()).toBe('pending');
+			expect(query.data.get()).toBe('result-1');
+
+			await flushMicrotasks();
+			expect(query.data.get()).toBe('result-2');
+
+			query.dispose();
+		});
+
+		test('dispose aborts pending request and cleans up', async () => {
+			const fetcher = createFetcher('value', 100);
+			const query = asyncState({ fetcher });
+
+			query.dispose();
+
+			await new Promise((r) => setTimeout(r, 120));
+			expect(query.status.get()).toBe('pending');
+			expect(query.data.get()).toBeUndefined();
+		});
+	});
+
+	describe('sourced (reactive)', () => {
+		test('fetches when source emits a truthy value', async () => {
+			const cityId = state<string | false>('venice');
+			const fetcher = createSourcedFetcher((id: string) => `weather:${id}`);
+
+			const query = asyncState({ source: () => cityId.get(), fetcher });
+
+			await flushMicrotasks();
+
+			expect(query.status.get()).toBe('success');
+			expect(query.data.get()).toBe('weather:venice');
+			expect(fetcher).toHaveBeenCalledTimes(1);
+
+			query.dispose();
+		});
+
+		test('stays idle when source returns false', async () => {
+			const trigger = state<string | false>(false);
+			const fetcher = createSourcedFetcher((id: string) => id);
+
+			const query = asyncState({ source: () => trigger.get(), fetcher });
+
+			await flushMicrotasks();
+
+			expect(query.status.get()).toBe('idle');
+			expect(fetcher).not.toHaveBeenCalled();
+
+			query.dispose();
+		});
+
+		test('refetches when source changes', async () => {
+			const cityId = state('venice');
+			const fetcher = createSourcedFetcher((id: string) => `weather:${id}`);
+
+			const query = asyncState({ source: () => cityId.get(), fetcher });
+
+			await flushMicrotasks();
+			expect(query.data.get()).toBe('weather:venice');
+
+			cityId.set('madrid');
+			await flushMicrotasks();
+			await flushMicrotasks();
+
+			expect(query.data.get()).toBe('weather:madrid');
+			expect(fetcher).toHaveBeenCalledTimes(2);
+
+			query.dispose();
+		});
+
+		test('aborts previous request when source changes rapidly', async () => {
+			const cityId = state('venice');
+			const calls: string[] = [];
+			const fetcher = vi.fn((id: string, { signal }: { signal: AbortSignal }) => {
+				calls.push(id);
+				return new Promise<string>((resolve, reject) => {
+					const timer = setTimeout(() => resolve(`weather:${id}`), 50);
+					signal.addEventListener('abort', () => {
+						clearTimeout(timer);
+						reject(new DOMException('Aborted', 'AbortError'));
+					});
+				});
+			});
+
+			const query = asyncState({ source: () => cityId.get(), fetcher });
+
+			await flushMicrotasks();
+
+			cityId.set('madrid');
+			await flushMicrotasks();
+
+			cityId.set('barcelona');
+			await flushMicrotasks();
+
+			await new Promise((r) => setTimeout(r, 60));
+
+			expect(query.data.get()).toBe('weather:barcelona');
+
+			query.dispose();
+		});
+
+		test('transitions from idle when source goes from falsy to truthy', async () => {
+			const trigger = state<string | false>(false);
+			const fetcher = createSourcedFetcher((id: string) => `data:${id}`);
+
+			const query = asyncState({ source: () => trigger.get(), fetcher });
+
+			await flushMicrotasks();
+			expect(query.status.get()).toBe('idle');
+
+			trigger.set('active');
+			await flushMicrotasks();
+			await flushMicrotasks();
+
+			expect(query.status.get()).toBe('success');
+			expect(query.data.get()).toBe('data:active');
+
+			query.dispose();
+		});
+
+		test('refetch uses current source value', async () => {
+			const cityId = state('venice');
+			const fetcher = createSourcedFetcher((id: string) => `weather:${id}`);
+
+			const query = asyncState({ source: () => cityId.get(), fetcher });
+
+			await flushMicrotasks();
+			expect(query.data.get()).toBe('weather:venice');
+
+			cityId.set('tokio');
+			query.refetch();
+
+			await flushMicrotasks();
+			await flushMicrotasks();
+
+			expect(query.data.get()).toBe('weather:tokio');
+
+			query.dispose();
+		});
+
+		test('refetch is a no-op when source is falsy', async () => {
+			const trigger = state<string | false>(false);
+			const fetcher = createSourcedFetcher((id: string) => id);
+
+			const query = asyncState({ source: () => trigger.get(), fetcher });
+
+			await flushMicrotasks();
+			query.refetch();
+			await flushMicrotasks();
+
+			expect(query.status.get()).toBe('idle');
+			expect(fetcher).not.toHaveBeenCalled();
+
+			query.dispose();
+		});
+
+		test('dispose stops source observation', async () => {
+			const cityId = state('venice');
+			const fetcher = createSourcedFetcher((id: string) => `weather:${id}`);
+
+			const query = asyncState({ source: () => cityId.get(), fetcher });
+
+			await flushMicrotasks();
+			query.dispose();
+
+			cityId.set('madrid');
+			await flushMicrotasks();
+
+			expect(fetcher).toHaveBeenCalledTimes(1);
+			expect(query.data.get()).toBe('weather:venice');
+		});
+	});
+
+	describe('staleTime', () => {
+		test('serves cached value without refetching when data is still fresh', async () => {
+			const cityId = state('venice');
+			const fetcher = createSourcedFetcher((id: string) => `weather:${id}`);
+
+			const query = asyncState({ source: () => cityId.get(), fetcher, staleTime: 5_000 });
+
+			await flushMicrotasks();
+			expect(query.data.get()).toBe('weather:venice');
+			expect(fetcher).toHaveBeenCalledTimes(1);
+
+			cityId.set('madrid');
+			await flushMicrotasks();
+			await flushMicrotasks();
+			expect(query.data.get()).toBe('weather:madrid');
+			expect(fetcher).toHaveBeenCalledTimes(2);
+
+			cityId.set('venice');
+			await flushMicrotasks();
+			await flushMicrotasks();
+			expect(query.data.get()).toBe('weather:venice');
+			expect(fetcher).toHaveBeenCalledTimes(2);
+
+			query.dispose();
+		});
+
+		test('refetches after staleTime expires', async () => {
+			const cityId = state('venice');
+			const fetcher = createSourcedFetcher((id: string) => `weather:${id}`);
+
+			const query = asyncState({ source: () => cityId.get(), fetcher, staleTime: 50 });
+
+			await flushMicrotasks();
+			expect(fetcher).toHaveBeenCalledTimes(1);
+
+			await new Promise((r) => setTimeout(r, 60));
+
+			cityId.set('madrid');
+			await flushMicrotasks();
+			await flushMicrotasks();
+
+			cityId.set('venice');
+			await flushMicrotasks();
+			await flushMicrotasks();
+
+			expect(fetcher).toHaveBeenCalledTimes(3);
+
+			query.dispose();
+		});
+
+		test('cache hit sets status to success synchronously', async () => {
+			const cityId = state('venice');
+			const fetcher = createSourcedFetcher((id: string) => `weather:${id}`, 10);
+
+			const query = asyncState({ source: () => cityId.get(), fetcher, staleTime: 5_000 });
+
+			await flushMicrotasks();
+			await new Promise((r) => setTimeout(r, 15));
+			expect(query.status.get()).toBe('success');
+
+			cityId.set('madrid');
+			await flushMicrotasks();
+			await new Promise((r) => setTimeout(r, 15));
+
+			cityId.set('venice');
+			await flushMicrotasks();
+			await flushMicrotasks();
+
+			expect(query.status.get()).toBe('success');
+			expect(query.data.get()).toBe('weather:venice');
+
+			query.dispose();
+		});
+
+		test('does not cache unsourced refetches', async () => {
+			let callCount = 0;
+			const fetcher = vi.fn(({ signal }: { signal: AbortSignal }) => {
+				callCount += 1;
+
+				return new Promise<string>((resolve, reject) => {
+					const timer = setTimeout(() => resolve(`result-${callCount}`), 0);
+					signal.addEventListener('abort', () => {
+						clearTimeout(timer);
+						reject(new DOMException('Aborted', 'AbortError'));
+					});
+				});
+			});
+
+			const query = asyncState({ fetcher, staleTime: 5_000 });
+
+			await flushMicrotasks();
+			expect(query.data.get()).toBe('result-1');
+
+			query.refetch();
+			await flushMicrotasks();
+
+			expect(fetcher).toHaveBeenCalledTimes(2);
+			expect(query.data.get()).toBe('result-2');
+
+			query.dispose();
+		});
+
+		test('cache hit aborts an older in-flight request', async () => {
+			const cityId = state('venice');
+			const fetcher = vi.fn((id: string, { signal }: { signal: AbortSignal }) => {
+				const delay = id === 'madrid' ? 50 : 0;
+
+				return new Promise<string>((resolve, reject) => {
+					const timer = setTimeout(() => resolve(`weather:${id}`), delay);
+					signal.addEventListener('abort', () => {
+						clearTimeout(timer);
+						reject(new DOMException('Aborted', 'AbortError'));
+					});
+				});
+			});
+
+			const query = asyncState({ source: () => cityId.get(), fetcher, staleTime: 5_000 });
+
+			await flushMicrotasks();
+			expect(query.data.get()).toBe('weather:venice');
+
+			cityId.set('madrid');
+			await flushMicrotasks();
+
+			cityId.set('venice');
+			await flushMicrotasks();
+			await flushMicrotasks();
+
+			expect(query.status.get()).toBe('success');
+			expect(query.data.get()).toBe('weather:venice');
+			expect(fetcher).toHaveBeenCalledTimes(2);
+
+			await new Promise((resolve) => setTimeout(resolve, 60));
+
+			expect(query.status.get()).toBe('success');
+			expect(query.data.get()).toBe('weather:venice');
+
+			query.dispose();
+		});
+	});
+
+	describe('pendingDelay', () => {
+		test('skips pending state when response arrives before delay', async () => {
+			const statuses: string[] = [];
+
+			const query = asyncState({ fetcher: createFetcher('fast', 0), pendingDelay: 200 });
+
+			statuses.push(query.status.get());
+
+			await flushMicrotasks();
+
+			statuses.push(query.status.get());
+
+			expect(statuses).toEqual(['idle', 'success']);
+
+			query.dispose();
+		});
+
+		test('transitions to pending after delay when response is slow', async () => {
+			const query = asyncState({ fetcher: createFetcher('slow', 200), pendingDelay: 30 });
+
+			expect(query.status.get()).toBe('idle');
+
+			await new Promise((r) => setTimeout(r, 50));
+
+			expect(query.status.get()).toBe('pending');
+
+			await new Promise((r) => setTimeout(r, 200));
+
+			expect(query.status.get()).toBe('success');
+			expect(query.data.get()).toBe('slow');
+
+			query.dispose();
+		});
+
+		test('clears pending timer on dispose', async () => {
+			const query = asyncState({ fetcher: createFetcher('value', 200), pendingDelay: 50 });
+
+			expect(query.status.get()).toBe('idle');
+
+			query.dispose();
+
+			await new Promise((r) => setTimeout(r, 80));
+
+			expect(query.status.get()).toBe('idle');
+		});
+
+		test('clears pending timer when refetch resolves before delay', async () => {
+			let callCount = 0;
+			const fetcher = vi.fn(({ signal }: { signal: AbortSignal }) => {
+				callCount++;
+				const delay = callCount === 1 ? 0 : 0;
+				return new Promise<string>((resolve, reject) => {
+					const timer = setTimeout(() => resolve(`result-${callCount}`), delay);
+					signal.addEventListener('abort', () => {
+						clearTimeout(timer);
+						reject(new DOMException('Aborted', 'AbortError'));
+					});
+				});
+			});
+
+			const query = asyncState({ fetcher, pendingDelay: 200 });
+
+			await flushMicrotasks();
+			expect(query.status.get()).toBe('success');
+
+			query.refetch();
+			await flushMicrotasks();
+
+			expect(query.status.get()).toBe('success');
+			expect(query.data.get()).toBe('result-2');
+
+			query.dispose();
+		});
+
+		test('works with sourced queries', async () => {
+			const cityId = state('venice');
+			const fetcher = createSourcedFetcher((id: string) => `weather:${id}`, 0);
+
+			const query = asyncState({ source: () => cityId.get(), fetcher, pendingDelay: 200 });
+
+			await flushMicrotasks();
+			await flushMicrotasks();
+
+			expect(query.status.get()).toBe('success');
+			expect(query.data.get()).toBe('weather:venice');
+
+			query.dispose();
+		});
+	});
+});

--- a/packages/signals/test/computed.test.ts
+++ b/packages/signals/test/computed.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, test, vi } from 'vitest';
+import { Computed, State, computed, currentComputed, untrack } from '../index';
+
+describe('Computed', () => {
+	test('tracks dependencies lazily and caches until a source changes', () => {
+		const count = new State(2);
+		let runs = 0;
+		const double = new Computed(() => {
+			runs += 1;
+			return count.get() * 2;
+		});
+
+		expect(double.get()).toBe(4);
+		expect(double.get()).toBe(4);
+		expect(runs).toBe(1);
+
+		count.set(3);
+
+		expect(double.get()).toBe(6);
+		expect(runs).toBe(2);
+	});
+
+	test('subscribers are only notified when the derived value changes', () => {
+		const count = new State(0);
+		const parity = new Computed(() => ((count.get() & 1) === 0 ? 'even' : 'odd'));
+		const notify = vi.fn();
+
+		parity.subscribe(notify);
+
+		expect(parity.get()).toBe('even');
+		count.set(2);
+		count.set(3);
+
+		expect(notify).toHaveBeenCalledTimes(1);
+		expect(notify).toHaveBeenCalledWith('odd');
+	});
+
+	test('updates dependency subscriptions when the computed dependency set changes', () => {
+		const usePrimary = new State(true);
+		const primary = new State(1);
+		const secondary = new State(10);
+		const selected = new Computed(() => (usePrimary.get() ? primary.get() : secondary.get()));
+
+		expect(selected.get()).toBe(1);
+
+		usePrimary.set(false);
+		expect(selected.get()).toBe(10);
+
+		primary.set(2);
+		expect(selected.get()).toBe(10);
+
+		secondary.set(20);
+		expect(selected.get()).toBe(20);
+	});
+
+	test('nested computed signals refresh through chained dependencies', () => {
+		const count = new State(1);
+		const doubled = new Computed(() => count.get() * 2);
+		const label = new Computed(() => `value:${doubled.get()}`);
+
+		expect(label.get()).toBe('value:2');
+		count.update((value) => value + 2);
+		expect(label.get()).toBe('value:6');
+	});
+
+	test('untrack excludes reads from computed dependencies', () => {
+		const primary = new State(1);
+		const secondary = new State(10);
+		const total = new Computed(() => primary.get() + untrack(() => secondary.get()));
+
+		expect(total.get()).toBe(11);
+		secondary.set(20);
+		expect(total.get()).toBe(11);
+		primary.set(2);
+		expect(total.get()).toBe(22);
+	});
+
+	test('currentComputed exposes the computed currently being evaluated', () => {
+		let observedComputed: Computed<number> | null = null;
+		const count = new State(2);
+		const doubled = new Computed(function () {
+			observedComputed = currentComputed() as Computed<number> | null;
+			return count.get() * 2;
+		});
+
+		expect(doubled.get()).toBe(4);
+		expect(observedComputed).toBe(doubled);
+	});
+
+	test('caches thrown errors until dependencies change and can recover across distinct failures', () => {
+		const step = new State(0);
+		let runs = 0;
+		const failing = new Computed(() => {
+			runs += 1;
+			const currentStep = step.get();
+
+			if (currentStep < 2) {
+				throw new Error(`boom:${runs}`);
+			}
+
+			return currentStep;
+		});
+
+		expect(() => failing.get()).toThrow('boom:1');
+		expect(() => failing.get()).toThrow('boom:1');
+		expect(runs).toBe(1);
+
+		step.set(1);
+		expect(() => failing.get()).toThrow('boom:2');
+		expect(runs).toBe(2);
+
+		step.set(2);
+		expect(failing.get()).toBe(2);
+		expect(runs).toBe(3);
+	});
+
+	test('prevents recursive computed reads', () => {
+		const recursive: Computed<unknown> = new Computed((): unknown => recursive.get());
+
+		expect(() => recursive.get()).toThrow('Cannot read a computed signal recursively.');
+	});
+
+	test('factory helper creates computed signals', () => {
+		const count = new State(2);
+		const doubled = computed(() => count.get() * 2);
+
+		expect(doubled).toBeInstanceOf(Computed);
+		expect(doubled.get()).toBe(4);
+	});
+
+	test('equals callbacks receive the computed signal as this', () => {
+		const contexts: unknown[] = [];
+		const count = new State(1);
+		const doubled = new Computed(
+			function () {
+				return count.get() * 2;
+			},
+			{
+				equals(previousValue, nextValue) {
+					contexts.push(this);
+					return previousValue === nextValue;
+				},
+			},
+		);
+
+		expect(doubled.get()).toBe(2);
+		count.set(2);
+		expect(doubled.get()).toBe(4);
+
+		expect(contexts).toEqual([doubled]);
+	});
+});

--- a/packages/signals/test/effect-watch.test.ts
+++ b/packages/signals/test/effect-watch.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, test, vi } from 'vitest';
+import { State, effect, watch } from '../index';
+
+async function flushMicrotask(): Promise<void> {
+	await Promise.resolve();
+}
+
+describe('effect', () => {
+	test('reruns once through the scheduler and cleans up before the next run', async () => {
+		const count = new State(1);
+		const events: string[] = [];
+		const dispose = effect(() => {
+			const value = count.get();
+			events.push(`run:${value}`);
+
+			return () => {
+				events.push(`cleanup:${value}`);
+			};
+		});
+
+		count.set(2);
+		count.set(3);
+		await flushMicrotask();
+		dispose();
+
+		expect(events).toEqual(['run:1', 'cleanup:1', 'run:3', 'cleanup:3']);
+	});
+
+	test('custom schedulers defer reruns and collapse multiple invalidations', () => {
+		const count = new State(1);
+		const scheduledRuns: Array<() => void> = [];
+		const values: number[] = [];
+
+		effect(
+			() => {
+				values.push(count.get());
+			},
+			{
+				scheduler(run) {
+					scheduledRuns.push(run);
+				},
+			},
+		);
+
+		count.set(2);
+		count.set(3);
+
+		expect(values).toEqual([1]);
+		expect(scheduledRuns).toHaveLength(1);
+
+		scheduledRuns[0]?.();
+
+		expect(values).toEqual([1, 3]);
+	});
+
+	test('dispose stops future reruns and runs the latest cleanup once', async () => {
+		const count = new State(1);
+		const events: string[] = [];
+		const dispose = effect(() => {
+			const value = count.get();
+			events.push(`run:${value}`);
+
+			return () => {
+				events.push(`cleanup:${value}`);
+			};
+		});
+
+		dispose();
+		count.set(2);
+		await flushMicrotask();
+
+		expect(events).toEqual(['run:1', 'cleanup:1']);
+	});
+
+	test('dispose is idempotent and cancels queued reruns', () => {
+		const count = new State(1);
+		const scheduledRuns: Array<() => void> = [];
+		const events: string[] = [];
+		const dispose = effect(
+			() => {
+				events.push(`run:${count.get()}`);
+				return () => {
+					events.push('cleanup');
+				};
+			},
+			{
+				scheduler(run) {
+					scheduledRuns.push(run);
+				},
+			},
+		);
+
+		count.set(2);
+		expect(scheduledRuns).toHaveLength(1);
+
+		dispose();
+		dispose();
+		scheduledRuns[0]?.();
+
+		expect(events).toEqual(['run:1', 'cleanup']);
+	});
+
+	test('updates effect subscriptions when the dependency set changes', async () => {
+		const usePrimary = new State(true);
+		const primary = new State(1);
+		const secondary = new State(10);
+		const values: number[] = [];
+		const dispose = effect(() => {
+			values.push(usePrimary.get() ? primary.get() : secondary.get());
+		});
+
+		usePrimary.set(false);
+		await flushMicrotask();
+		primary.set(2);
+		await flushMicrotask();
+		secondary.set(20);
+		await flushMicrotask();
+		dispose();
+
+		expect(values).toEqual([1, 10, 20]);
+	});
+});
+
+describe('watch', () => {
+	test('observes derived values and receives the previous value', async () => {
+		const count = new State(1);
+		const notify = vi.fn();
+		const dispose = watch(
+			() => count.get(),
+			(nextValue, previousValue) => {
+				notify({ nextValue, previousValue });
+			},
+		);
+
+		count.set(2);
+		await flushMicrotask();
+		dispose();
+
+		expect(notify).toHaveBeenCalledTimes(1);
+		expect(notify).toHaveBeenCalledWith({ nextValue: 2, previousValue: 1 });
+	});
+
+	test('immediate mode invokes the callback during the first run', () => {
+		const count = new State(1);
+		const notify = vi.fn();
+		const dispose = watch(
+			() => count.get(),
+			(nextValue, previousValue) => {
+				notify({ nextValue, previousValue });
+			},
+			{ immediate: true },
+		);
+
+		dispose();
+
+		expect(notify).toHaveBeenCalledTimes(1);
+		expect(notify).toHaveBeenCalledWith({ nextValue: 1, previousValue: undefined });
+	});
+
+	test('custom schedulers defer notifications and preserve the latest value', () => {
+		const count = new State(0);
+		const scheduledRuns: Array<() => void> = [];
+		const notify = vi.fn();
+		const dispose = watch(() => count.get(), notify, {
+			scheduler(run) {
+				scheduledRuns.push(run);
+			},
+		});
+
+		count.set(1);
+		count.set(2);
+
+		expect(notify).not.toHaveBeenCalled();
+		expect(scheduledRuns).toHaveLength(1);
+
+		scheduledRuns[0]?.();
+		dispose();
+
+		expect(notify).toHaveBeenCalledTimes(1);
+		expect(notify).toHaveBeenCalledWith(2, 0);
+	});
+
+	test('uses watch equality to suppress redundant derived notifications', async () => {
+		const count = new State(0);
+		const notify = vi.fn();
+		const dispose = watch(() => ((count.get() & 1) === 0 ? 'even' : 'odd'), notify, {
+			equals(previousValue, nextValue) {
+				return previousValue === nextValue;
+			},
+		});
+
+		count.set(2);
+		await flushMicrotask();
+		count.set(3);
+		await flushMicrotask();
+		dispose();
+
+		expect(notify).toHaveBeenCalledTimes(1);
+		expect(notify).toHaveBeenCalledWith('odd', 'even');
+	});
+});

--- a/packages/signals/test/state.test.ts
+++ b/packages/signals/test/state.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, test, vi } from 'vitest';
+import { State, state, subtle } from '../index';
+
+describe('State', () => {
+	test('exposes current value and notifies subscribers on change', () => {
+		const count = new State(1);
+		const notify = vi.fn();
+		const unsubscribe = count.subscribe(notify);
+
+		count.set(2);
+		count.set(2);
+		unsubscribe();
+		count.set(3);
+
+		expect(count.get()).toBe(3);
+		expect(notify).toHaveBeenCalledTimes(1);
+		expect(notify).toHaveBeenCalledWith(2);
+	});
+
+	test('notifies multiple subscribers and unsubscribes them independently', () => {
+		const count = new State(0);
+		const firstNotify = vi.fn();
+		const secondNotify = vi.fn();
+		const unsubscribeFirst = count.subscribe(firstNotify);
+		count.subscribe(secondNotify);
+
+		count.set(1);
+		unsubscribeFirst();
+		count.set(2);
+
+		expect(firstNotify).toHaveBeenCalledTimes(1);
+		expect(firstNotify).toHaveBeenCalledWith(1);
+		expect(secondNotify).toHaveBeenCalledTimes(2);
+		expect(secondNotify).toHaveBeenNthCalledWith(1, 1);
+		expect(secondNotify).toHaveBeenNthCalledWith(2, 2);
+	});
+
+	test('factory helper creates a writable state signal', () => {
+		const count = state(1);
+
+		count.update((value) => value + 2);
+
+		expect(count).toBeInstanceOf(State);
+		expect(count.get()).toBe(3);
+	});
+
+	test('watch lifecycle hooks run on the first and last watcher', () => {
+		const lifecycleEvents: string[] = [];
+		const count = new State(1, {
+			[subtle.watched]() {
+				lifecycleEvents.push('watched');
+			},
+			[subtle.unwatched]() {
+				lifecycleEvents.push('unwatched');
+			},
+		});
+		const firstWatcher = new subtle.Watcher(() => undefined);
+		const secondWatcher = new subtle.Watcher(() => undefined);
+
+		firstWatcher.watch(count);
+		secondWatcher.watch(count);
+		firstWatcher.unwatch(count);
+		secondWatcher.unwatch(count);
+
+		expect(lifecycleEvents).toEqual(['watched', 'unwatched']);
+	});
+
+	test('rethrows a single watcher failure after publishing subscribers', () => {
+		const count = new State(1);
+		const notify = vi.fn();
+		const failure = new Error('watcher failed');
+		const watcher = new subtle.Watcher(() => {
+			throw failure;
+		});
+
+		count.subscribe(notify);
+		watcher.watch(count);
+
+		expect(() => count.set(2)).toThrow(failure);
+		expect(notify).toHaveBeenCalledTimes(1);
+		expect(notify).toHaveBeenCalledWith(2);
+	});
+
+	test('aggregates multiple watcher failures before rethrowing', () => {
+		const count = new State(1);
+		const notify = vi.fn();
+		const firstFailure = new Error('first watcher failed');
+		const secondFailure = new Error('second watcher failed');
+		const firstWatcher = new subtle.Watcher(() => {
+			throw firstFailure;
+		});
+		const secondWatcher = new subtle.Watcher(() => {
+			throw secondFailure;
+		});
+
+		count.subscribe(notify);
+		firstWatcher.watch(count);
+		secondWatcher.watch(count);
+
+		try {
+			count.set(2);
+			expect.unreachable('Expected multiple watcher failures to be rethrown.');
+		} catch (error) {
+			expect(error).toBeInstanceOf(AggregateError);
+			expect((error as AggregateError).errors).toEqual([firstFailure, secondFailure]);
+		}
+
+		expect(notify).toHaveBeenCalledTimes(1);
+		expect(notify).toHaveBeenCalledWith(2);
+	});
+
+	test('equals callbacks receive the state signal as this', () => {
+		const contexts: unknown[] = [];
+		const count = new State(1, {
+			equals(previousValue, nextValue) {
+				contexts.push(this);
+				return previousValue === nextValue;
+			},
+		});
+
+		count.set(2);
+		count.set(2);
+
+		expect(contexts).toEqual([count, count]);
+	});
+});

--- a/packages/signals/test/store.test.ts
+++ b/packages/signals/test/store.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, test } from 'vitest';
+import { Computed, createStore, isStore, snapshot } from '../index';
+
+describe('store', () => {
+	test('tracks nested property reads and branch replacement', () => {
+		const store = createStore({
+			profile: {
+				name: 'Ada',
+				stats: {
+					visits: 2,
+				},
+			},
+		});
+		const summary = new Computed(() => `${store.profile.name}:${store.profile.stats.visits}`);
+
+		expect(summary.get()).toBe('Ada:2');
+		store.profile.stats.visits = 3;
+		expect(summary.get()).toBe('Ada:3');
+		store.profile = {
+			name: 'Grace',
+			stats: {
+				visits: 9,
+			},
+		};
+		expect(summary.get()).toBe('Grace:9');
+	});
+
+	test('tracks array length and keyed access', () => {
+		const store = createStore({ items: ['alpha'] });
+		const summary = new Computed(() => `${store.items.length}:${store.items[0] ?? 'empty'}`);
+
+		expect(summary.get()).toBe('1:alpha');
+		store.items.push('beta');
+		expect(summary.get()).toBe('2:alpha');
+		store.items[0] = 'omega';
+		expect(summary.get()).toBe('2:omega');
+	});
+
+	test('supports direct array length assignment and truncates removed entries', () => {
+		const store = createStore({ items: ['alpha', 'beta', 'gamma'] });
+		const summary = new Computed(() => `${store.items.length}:${store.items[2] ?? 'empty'}`);
+
+		expect(summary.get()).toBe('3:gamma');
+		store.items.length = 1;
+
+		expect(summary.get()).toBe('1:empty');
+		expect(snapshot(store)).toEqual({ items: ['alpha'] });
+	});
+
+	test('rejects invalid array lengths', () => {
+		const store = createStore({ items: ['alpha'] });
+
+		expect(() => {
+			store.items.length = -1;
+		}).toThrow(RangeError);
+	});
+
+	test('materializes plain nested data from a store', () => {
+		const store = createStore({
+			filters: { published: true },
+			items: [{ id: 1, title: 'A' }],
+		});
+
+		store.items[0].title = 'Updated';
+		const plain = snapshot(store);
+
+		expect(plain).toEqual({
+			filters: { published: true },
+			items: [{ id: 1, title: 'Updated' }],
+		});
+		expect(plain).not.toBe(store);
+		expect(plain.items).not.toBe(store.items);
+	});
+
+	test('invalidates key enumeration when the shape changes', () => {
+		const store = createStore({ filters: { published: true } });
+		const keys = new Computed(() => Object.keys(store.filters).join(','));
+
+		expect(keys.get()).toBe('published');
+		(store.filters as { published: boolean; archived?: boolean }).archived = false;
+		expect(keys.get()).toBe('published,archived');
+		delete (store.filters as { published: boolean; archived?: boolean }).archived;
+		expect(keys.get()).toBe('published');
+	});
+
+	test('deleting properties removes them from reads and snapshots', () => {
+		const store = createStore({ profile: { name: 'Ada', age: 32 } });
+		const profile = store.profile as { age?: number; name: string };
+		const summary = new Computed(() => `${'age' in profile}:${profile.age ?? 'none'}`);
+
+		expect(summary.get()).toBe('true:32');
+		delete profile.age;
+
+		expect(summary.get()).toBe('false:none');
+		expect(snapshot(store)).toEqual({ profile: { name: 'Ada' } });
+	});
+
+	test('detects store proxies and nested store branches', () => {
+		const store = createStore({ profile: { name: 'Ada' } });
+
+		expect(isStore(store)).toBe(true);
+		expect(isStore(store.profile)).toBe(true);
+		expect(isStore({ profile: { name: 'Ada' } })).toBe(false);
+	});
+
+	test('normalizes assigned store branches into detached snapshots', () => {
+		const externalProfile = createStore({ name: 'Ada' });
+		const store = createStore({ profile: externalProfile });
+
+		expect(store.profile.name).toBe('Ada');
+
+		externalProfile.name = 'Grace';
+		expect(externalProfile.name).toBe('Grace');
+		expect(store.profile.name).toBe('Ada');
+
+		store.profile.name = 'Lin';
+		expect(externalProfile.name).toBe('Grace');
+		expect(snapshot(store)).toEqual({ profile: { name: 'Lin' } });
+	});
+});

--- a/packages/signals/test/watcher.test.ts
+++ b/packages/signals/test/watcher.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, test } from 'vitest';
+import { Computed, State, subtle } from '../index';
+
+describe('Watcher', () => {
+	test('notifies for watched computed signals and tracks pending signals until reset', () => {
+		const count = new State(1);
+		const doubled = new Computed(() => count.get() * 2);
+		const notifications: string[] = [];
+		const watcher = new subtle.Watcher(function () {
+			notifications.push('notify');
+		});
+
+		watcher.watch(doubled);
+		count.set(2);
+		count.set(3);
+
+		expect(notifications).toEqual(['notify']);
+		expect(watcher.getPending()).toEqual([doubled]);
+
+		watcher.watch();
+		count.set(4);
+
+		expect(notifications).toEqual(['notify', 'notify']);
+		expect(watcher.getPending()).toEqual([doubled]);
+	});
+
+	test('collects every invalidated watched signal during the current cycle', () => {
+		const first = new State(0);
+		const second = new State(0);
+		const notifications: string[] = [];
+		const watcher = new subtle.Watcher(() => {
+			notifications.push('notify');
+		});
+
+		watcher.watch(first, second);
+		first.set(1);
+		second.set(1);
+
+		expect(notifications).toEqual(['notify']);
+		expect(watcher.getPending()).toEqual([first, second]);
+	});
+
+	test('throws when unwatching a signal that is not currently watched', () => {
+		const count = new State(1);
+		const watcher = new subtle.Watcher(() => undefined);
+
+		expect(() => watcher.unwatch(count)).toThrow('Signal is not watched by this watcher.');
+	});
+
+	test('rejects signals not created by this package', () => {
+		const watcher = new subtle.Watcher(() => undefined);
+		const foreignSignal = {
+			get() {
+				return 1;
+			},
+			subscribe() {
+				return () => undefined;
+			},
+		};
+
+		expect(() => watcher.watch(foreignSignal as never)).toThrow('Expected a signal created by @ecopages/signals.');
+	});
+
+	test('notifications freeze signal reads and writes', () => {
+		const count = new State(1);
+		const watcher = new subtle.Watcher(() => {
+			expect(() => count.get()).toThrow('Cannot read or write signals during a Watcher notification.');
+			expect(() => count.set(3)).toThrow('Cannot read or write signals during a Watcher notification.');
+		});
+
+		watcher.watch(count);
+		count.set(2);
+	});
+
+	test('watch and unwatch lifecycle hooks run only for the first and last watcher', () => {
+		const events: string[] = [];
+		const count = new State(1, {
+			[subtle.watched]() {
+				events.push('watched');
+			},
+			[subtle.unwatched]() {
+				events.push('unwatched');
+			},
+		});
+		const firstWatcher = new subtle.Watcher(() => undefined);
+		const secondWatcher = new subtle.Watcher(() => undefined);
+
+		firstWatcher.watch(count);
+		secondWatcher.watch(count);
+		firstWatcher.unwatch(count);
+		secondWatcher.unwatch(count);
+
+		expect(events).toEqual(['watched', 'unwatched']);
+	});
+
+	test('re-watching the same signal resets pending state without duplicating subscriptions', () => {
+		const events: string[] = [];
+		const count = new State(1, {
+			[subtle.watched]() {
+				events.push('watched');
+			},
+		});
+		const watcher = new subtle.Watcher(() => undefined);
+
+		watcher.watch(count);
+		count.set(2);
+		expect(watcher.getPending()).toEqual([count]);
+
+		watcher.watch(count);
+		expect(watcher.getPending()).toEqual([]);
+		expect(events).toEqual(['watched']);
+	});
+
+	test('removes computed dependency watchers when the dependency set changes or the computed is unwatched', () => {
+		const lifecycleEvents: string[] = [];
+		const usePrimary = new State(true, {
+			[subtle.watched]() {
+				lifecycleEvents.push('usePrimary:watched');
+			},
+			[subtle.unwatched]() {
+				lifecycleEvents.push('usePrimary:unwatched');
+			},
+		});
+		const primary = new State(1, {
+			[subtle.watched]() {
+				lifecycleEvents.push('primary:watched');
+			},
+			[subtle.unwatched]() {
+				lifecycleEvents.push('primary:unwatched');
+			},
+		});
+		const secondary = new State(10, {
+			[subtle.watched]() {
+				lifecycleEvents.push('secondary:watched');
+			},
+			[subtle.unwatched]() {
+				lifecycleEvents.push('secondary:unwatched');
+			},
+		});
+		const selected = new Computed(() => (usePrimary.get() ? primary.get() : secondary.get()));
+		const watcher = new subtle.Watcher(() => undefined);
+
+		watcher.watch(selected);
+		expect(selected.get()).toBe(1);
+
+		usePrimary.set(false);
+		expect(selected.get()).toBe(10);
+		watcher.unwatch(selected);
+
+		expect(lifecycleEvents).toEqual([
+			'usePrimary:watched',
+			'primary:watched',
+			'primary:unwatched',
+			'secondary:watched',
+			'usePrimary:unwatched',
+			'secondary:unwatched',
+		]);
+	});
+});

--- a/packages/signals/tsconfig.build.json
+++ b/packages/signals/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"declaration": true,
+		"emitDeclarationOnly": true,
+		"noEmit": false,
+		"rootDir": ".",
+		"outDir": "./dist"
+	},
+	"include": ["index.ts"],
+	"exclude": ["dist", "node_modules", "test"]
+}

--- a/packages/signals/tsconfig.json
+++ b/packages/signals/tsconfig.json
@@ -1,0 +1,18 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"allowSyntheticDefaultImports": true,
+		"esModuleInterop": true,
+		"forceConsistentCasingInFileNames": true,
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"outDir": "./dist",
+		"rootDir": ".",
+		"strict": true,
+		"strictPropertyInitialization": false,
+		"target": "ESNext",
+		"verbatimModuleSyntax": true
+	},
+	"include": ["**/*"],
+	"exclude": ["dist", "node_modules"]
+}


### PR DESCRIPTION
# Ecopages Signals

`@ecopages/signals` is a renderer-agnostic signals package that can be used standalone or underneath Radiant.

Its core model is based on the [TC39 Signals proposal](https://github.com/tc39/proposal-signals/tree/main), with a smaller surface area and a few convenience helpers for application code today.

The public entrypoint remains `index.ts`, while the implementation now lives in focused modules under `src/` so the core runtime, effects, watcher support, and store logic can evolve independently.

## Current Scope

This package currently provides:

- `State<T>` for writable values
- `Computed<T>` for lazily derived values
- `currentComputed()` for advanced derived helpers that need the active computed context
- `effect(...)` for reactive side effects with scheduled re-execution
- `watch(...)` for observing derived values with previous-value access
- `untrack(...)` and `peek(...)` for non-tracking reads
- `subtle.Watcher` plus `watched` and `unwatched` hooks for low-level invalidation workflows
- `createStore(...)` for deep reactive object and array state
- `isStore(...)` for detecting signal-backed store proxies
- `snapshot(...)` for materializing plain nested data
- automatic dependency discovery during `Computed` evaluation
- subscription support for renderer or framework adapters

## Source Layout

The package is organized around a stable public barrel and smaller implementation files:

- `index.ts` re-exports the public API and exposes `subtle`
- `src/types.ts` defines the public contracts, options, and low-level symbols
- `src/state.ts` implements writable `State` signals
- `src/computed.ts` implements lazy derived `Computed` signals and active-computation helpers
- `src/effect.ts` and `src/watch.ts` implement effect scheduling and derived-value observation
- `src/watcher.ts` implements proposal-shaped low-level watchers
- `src/tracking.ts` contains non-tracking read helpers
- `src/store.ts` contains deep store proxying and snapshot materialization

## Design Position

This package is renderer-agnostic.

- It does not know about JSX.
- It does not know about Radiant components.
- It is meant to work both as a standalone package and underneath adapters in those packages.

## TC39 Relationship

This package is based on the current TC39 Signals proposal and tracks the same broad model around:

- `State` and `Computed` signal classes
- lazy pull-based recomputation with cached values
- automatic dependency discovery during computed evaluation
- custom equality functions for writable and computed signals
- untracked reads as an escape hatch

It is not a drop-in implementation of the current proposal draft.

It is best understood as proposal-aligned in its core semantics, but not yet fully API-compatible with the draft surface.

- It exposes convenience helpers such as `effect(...)`, `watch(...)`, `createStore(...)`, and `snapshot(...)` directly.
- It currently exposes manual `subscribe(...)` hooks for adapter and library integration.
- It exposes a proposal-shaped `subtle.Watcher` API, while still keeping the existing convenience helpers.
- Its `subtle.Watcher` follows the proposal-style re-arm behavior, where calling `watch(...)` resets the pending set and notification latch for the next invalidation cycle.
- It does not yet expose the full TC39 subtle introspection surface.

## API Notes

- `subscribe(...)` is intended for adapter-style push integration. Application-level derived work is usually better expressed with `Computed`, `effect(...)`, or `watch(...)`.
- `watch(...)` is built on top of a computed signal plus an effect, so it inherits computed equality behavior and effect scheduling.
- `subtle.Watcher` reports staleness rather than recalculated values. Calling `watch(...)` is both registration and reset.
- `createStore(...)` wraps nested plain objects and arrays, while `snapshot(...)` detaches the current plain value graph for logging, serialization, or comparison.

## Example

```ts
import { Computed, State, createStore, effect, watch } from '@ecopages/signals';

const count = new State(0);
const parity = new Computed(() => ((count.get() & 1) === 0 ? 'even' : 'odd'));
const store = createStore({ profile: { name: 'Ada' } });

const dispose = effect(() => {
	console.log(parity.get(), store.profile.name);
});

const stopWatching = watch(
	() => store.profile.name,
	(nextName, previousName) => {
		console.log(previousName, '->', nextName);
	},
);

count.set(1);
store.profile.name = 'Grace';
dispose();
stopWatching();
```

## Limits

This implementation is still smaller than the current TC39 proposal draft.

- no full TC39 `Watcher` and subtle semantics surface yet
- no full proposal-style subtle introspection helpers yet
- no batching or transaction model
- no framework-owned disposal tree or component ownership integration yet

Those omissions are deliberate. The goal is to keep a small, useful standalone package while leaving room to align further as the proposal evolves.
