### PR TITLE
refactor(radiant): phase 0 quick wins

### DIFF
--- a/packages/radiant/src/core/event-subscription-registry.ts
+++ b/packages/radiant/src/core/event-subscription-registry.ts
@@ -1,0 +1,67 @@
+export type ElementEventListenerConfig = {
+	selector: string;
+	type: string;
+	listener: EventListener;
+	options?: AddEventListenerOptions;
+};
+
+type RadiantElementEventSubscription = ElementEventListenerConfig & {
+	target: EventTarget;
+};
+
+export class EventSubscriptionRegistry {
+	private readonly subscriptions = new Map<string, RadiantElementEventSubscription>();
+
+	constructor(
+		private readonly getInteractionTarget: () => EventTarget,
+		private readonly getListenerContext: () => object,
+	) {}
+
+	public subscribe(eventConfig: ElementEventListenerConfig): () => void {
+		const interactionTarget = this.getInteractionTarget();
+		const listenerContext = this.getListenerContext();
+		const delegatedListener = (delegatedEvent: Event) => {
+			if (delegatedEvent.target && (delegatedEvent.target as Element).matches(eventConfig.selector)) {
+				eventConfig.listener.call(listenerContext, delegatedEvent);
+			}
+		};
+		const subscriptionId = `${eventConfig.type}:${eventConfig.selector}`;
+		interactionTarget.addEventListener(eventConfig.type, delegatedListener, eventConfig.options);
+		this.subscriptions.set(subscriptionId, {
+			...eventConfig,
+			listener: delegatedListener,
+			target: interactionTarget,
+		});
+
+		return () => {
+			this.unsubscribe(subscriptionId);
+		};
+	}
+
+	public hasEventSubscription(subscriptionId: string): boolean {
+		return this.subscriptions.has(subscriptionId);
+	}
+
+	public removeAll(): void {
+		for (const eventSubscription of this.subscriptions.values()) {
+			eventSubscription.target.removeEventListener(
+				eventSubscription.type,
+				eventSubscription.listener,
+				eventSubscription.options,
+			);
+		}
+		this.subscriptions.clear();
+	}
+
+	private unsubscribe(id: string): void {
+		const eventSubscription = this.subscriptions.get(id);
+		if (eventSubscription) {
+			eventSubscription.target.removeEventListener(
+				eventSubscription.type,
+				eventSubscription.listener,
+				eventSubscription.options,
+			);
+			this.subscriptions.delete(id);
+		}
+	}
+}

--- a/packages/radiant/src/core/reactive-prop-core.ts
+++ b/packages/radiant/src/core/reactive-prop-core.ts
@@ -34,6 +34,8 @@ export type ReactiveBindingOption = boolean | string;
 
 export type ReactiveFieldOptions = {
 	bind?: ReactiveBindingOption;
+	/** When true, skip the initial notifyUpdate emitted while defining the field. */
+	suppressInitialNotify?: boolean;
 };
 
 export type ReactiveField<T = unknown> = {

--- a/packages/radiant/src/core/reactive-property-state.ts
+++ b/packages/radiant/src/core/reactive-property-state.ts
@@ -1,0 +1,119 @@
+import {
+	createReactivePropertyMapping,
+	type ReactiveAccessorDefinition,
+	type ReactiveProperty,
+	type ReactivePropertyOptions,
+	validateReactivePropertyDefault,
+} from './reactive-prop-core';
+import { type AttributeTypeConstant } from '../utils/attribute-utils';
+
+export type ReactivePropertyStateHost = HTMLElement & {
+	notifyUpdate(changedProperty: string, oldValue: unknown, value: unknown): void;
+};
+
+export class ReactivePropertyState {
+	private readonly properties = new Map<string, ReactiveProperty>();
+	private readonly preUpgradePropertyValues = new Map<string, unknown>();
+
+	constructor(private readonly host: ReactivePropertyStateHost) {
+		for (const propertyName of Object.getOwnPropertyNames(host)) {
+			this.preUpgradePropertyValues.set(propertyName, Reflect.get(host, propertyName));
+		}
+	}
+
+	public register(config: ReactiveProperty): void {
+		this.properties.set(config.name, config);
+	}
+
+	public getAll(): ReactiveProperty[] {
+		return Array.from(this.properties.values());
+	}
+
+	public applyAttributeChange(name: string, oldValue: string | null, newValue: string | null): void {
+		const config = this.properties.get(name);
+
+		if (!config) {
+			return;
+		}
+
+		const transformedValue = this.transformAttributeValue(newValue, config);
+		const transformedOldValue = this.transformAttributeValue(oldValue, config);
+
+		Reflect.set(this.host, config.attribute, transformedValue);
+		this.host.notifyUpdate(name, transformedOldValue, transformedValue);
+	}
+
+	public create<T>(
+		propertyName: string,
+		options: ReactivePropertyOptions<T>,
+		resolveInitialValue: (type: AttributeTypeConstant, attributeKey: string, defaultValue: unknown) => T,
+		defineReactiveAccessor: (propertyName: string, config: ReactiveAccessorDefinition<T>) => void,
+	): void {
+		const { type, attribute, reflect, defaultValue } = options;
+		const attributeKey = attribute ?? propertyName;
+		const hasPreUpgradeValue = this.preUpgradePropertyValues.has(propertyName);
+		const preUpgradeValue = hasPreUpgradeValue ? (this.preUpgradePropertyValues.get(propertyName) as T) : undefined;
+
+		validateReactivePropertyDefault(type, defaultValue);
+
+		const initialValue: T | undefined = hasPreUpgradeValue
+			? preUpgradeValue
+			: resolveInitialValue(type, attributeKey, defaultValue);
+
+		if (this.host.hasAttribute(attributeKey) && (!reflect || initialValue == null || initialValue === '')) {
+			this.host.removeAttribute(attributeKey);
+		}
+
+		if (hasPreUpgradeValue && Object.prototype.hasOwnProperty.call(this.host, propertyName)) {
+			Reflect.deleteProperty(this.host, propertyName);
+		}
+
+		const propertyMapping = createReactivePropertyMapping(propertyName, attributeKey, type, initialValue);
+
+		this.register(propertyMapping);
+
+		defineReactiveAccessor(propertyName, {
+			bind: options.bind,
+			getValue: () => this.properties.get(propertyName)?.value as T | undefined,
+			setValue: (newValue: T) => {
+				this.properties.set(propertyName, { ...propertyMapping, value: newValue });
+				this.reflectValue(attributeKey, reflect, propertyMapping, newValue);
+			},
+		});
+
+		if (initialValue !== undefined) {
+			queueMicrotask(() => {
+				const currentValue = this.properties.get(propertyName)?.value as T | undefined;
+				if (currentValue === undefined) {
+					return;
+				}
+
+				this.reflectValue(attributeKey, reflect, propertyMapping, currentValue);
+				this.host.notifyUpdate(propertyName, undefined, currentValue);
+			});
+		}
+	}
+
+	private transformAttributeValue(value: string | null, config: ReactiveProperty): unknown {
+		return value !== null ? config.converter.fromAttribute(value) : value;
+	}
+
+	private reflectValue<T>(
+		attributeKey: string,
+		reflect: boolean | undefined,
+		property: ReactiveProperty<T>,
+		value: T,
+	): void {
+		if (!reflect) {
+			return;
+		}
+
+		if (value == null || value === '' || value === false) {
+			this.host.removeAttribute(attributeKey);
+			return;
+		}
+
+		const attributeValue = property.converter.toAttribute(value);
+		this.host.setAttribute(attributeKey, attributeValue);
+	}
+}

--- a/packages/radiant/src/decorators/legacy/on-updated.ts
+++ b/packages/radiant/src/decorators/legacy/on-updated.ts
@@ -1,7 +1,7 @@
 type LegacyUpdatedHost = {
 	registerCleanupCallback(callback: () => void): void;
 	registerConnectedCallback(callback: () => void): void;
-	registerUpdateCallback(key: string, update: (...rest: any[]) => any): () => void;
+	registerUpdateCallback(key: string, update: () => void): () => void;
 };
 
 import { registerLegacyInstanceInitializer } from './instance-initializers';

--- a/packages/radiant/src/decorators/standard/reactive-field.ts
+++ b/packages/radiant/src/decorators/standard/reactive-field.ts
@@ -1,40 +1,21 @@
 import type { ReactiveHostLike } from '../../core/reactive-host';
 
 export function reactiveField<T extends ReactiveHostLike, V>(_: undefined, context: ClassFieldDecoratorContext<T, V>) {
-	const privatePropertyKey = Symbol(`__${String(context.name)}__value`);
-
 	const contextName = String(context.name);
+	const initializerValueKey = Symbol(`@ecopages/radiant/state:${contextName}:initializer`);
 
 	context.addInitializer(function (this: T) {
-		this.defineReactiveBinding(
-			contextName,
-			(this as unknown as { shouldAutoBindReactiveMembers?: () => boolean }).shouldAutoBindReactiveMembers?.() ??
+		const initializerValue = (this as Record<PropertyKey, V | undefined>)[initializerValueKey];
+		this.createReactiveField(contextName, initializerValue as V, {
+			bind:
+				(this as unknown as { shouldAutoBindReactiveMembers?: () => boolean }).shouldAutoBindReactiveMembers?.() ??
 				false,
-		);
-		this.registerReactiveDependencyReader(
-			contextName,
-			() => (this as unknown as Record<PropertyKey, unknown>)[privatePropertyKey],
-		);
-
-		Object.defineProperty(this, context.name, {
-			get() {
-				(this as ReactiveHostLike).trackReactiveRead(contextName);
-				return (this as unknown as Record<PropertyKey, unknown>)[privatePropertyKey];
-			},
-			set(newValue: unknown) {
-				const oldValue = (this as unknown as Record<PropertyKey, unknown>)[privatePropertyKey];
-				if (oldValue !== newValue) {
-					(this as unknown as Record<PropertyKey, unknown>)[privatePropertyKey] = newValue;
-					(this as ReactiveHostLike).notifyUpdate(contextName, oldValue, newValue);
-				}
-			},
-			enumerable: true,
-			configurable: true,
+			suppressInitialNotify: true,
 		});
 	});
 
 	return function (this: T, value: V) {
-		(this as any)[privatePropertyKey] = value;
+		(this as Record<PropertyKey, V | undefined>)[initializerValueKey] = value;
 		return value;
 	};
 }

--- a/packages/radiant/src/server/host-attribute-serialization.ts
+++ b/packages/radiant/src/server/host-attribute-serialization.ts
@@ -13,8 +13,8 @@ export type HostAttributeSource = {
 	getReactiveProperties: () => ReactiveProperty[];
 	getReactivePropDefinitions: () => ReactivePropDefinition[];
 	getPropertyValue: (name: string) => unknown;
-	getAttributeNames: () => string[];
-	getAttribute: (name: string) => string | null;
+	listAttributeNames: () => string[];
+	getAttributeValue: (name: string) => string | null;
 };
 
 /**
@@ -121,8 +121,8 @@ function appendReactivePropDefinitionAttributes(
  * markup, that intent takes precedence over reactive property reflection.
  */
 function appendAuthoredAttributes(host: HostAttributeSource, attributes: Record<string, string>): void {
-	for (const attributeName of host.getAttributeNames()) {
-		const attributeValue = host.getAttribute(attributeName);
+	for (const attributeName of host.listAttributeNames()) {
+		const attributeValue = host.getAttributeValue(attributeName);
 		if (attributeValue !== null) {
 			attributes[attributeName] = attributeValue;
 		}

--- a/packages/radiant/src/server/host-attribute-serialization.ts
+++ b/packages/radiant/src/server/host-attribute-serialization.ts
@@ -1,6 +1,7 @@
 import type { ReactiveProperty } from '../core/reactive-prop-core';
 import type { ReactivePropDefinition } from '../core/reactive-prop-metadata';
 import { writeAttributeValue } from '../utils/attribute-utils';
+import { escapeHtmlAttribute } from '../utils/escape-html-attribute';
 
 /**
  * Minimal host shape needed by the attribute serialization policy.
@@ -12,8 +13,8 @@ export type HostAttributeSource = {
 	getReactiveProperties: () => ReactiveProperty[];
 	getReactivePropDefinitions: () => ReactivePropDefinition[];
 	getPropertyValue: (name: string) => unknown;
-	listAttributeNames: () => string[];
-	getAttributeValue: (name: string) => string | null;
+	getAttributeNames: () => string[];
+	getAttribute: (name: string) => string | null;
 };
 
 /**
@@ -58,7 +59,7 @@ export function resolveHostAttributes(host: HostAttributeSource): Record<string,
  */
 export function stringifyHostAttributes(attributes: Record<string, string>): string {
 	return Object.entries(attributes)
-		.map(([name, value]) => ` ${name}="${escapeAttribute(value)}"`)
+		.map(([name, value]) => ` ${name}="${escapeHtmlAttribute(value)}"`)
 		.join('');
 }
 
@@ -120,14 +121,11 @@ function appendReactivePropDefinitionAttributes(
  * markup, that intent takes precedence over reactive property reflection.
  */
 function appendAuthoredAttributes(host: HostAttributeSource, attributes: Record<string, string>): void {
-	for (const attributeName of host.listAttributeNames()) {
-		const attributeValue = host.getAttributeValue(attributeName);
+	for (const attributeName of host.getAttributeNames()) {
+		const attributeValue = host.getAttribute(attributeName);
 		if (attributeValue !== null) {
 			attributes[attributeName] = attributeValue;
 		}
 	}
 }
 
-function escapeAttribute(value: string): string {
-	return value.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-}

--- a/packages/radiant/src/server/render-fragment.ts
+++ b/packages/radiant/src/server/render-fragment.ts
@@ -1,0 +1,40 @@
+import type {
+	RenderedComponent,
+	RenderedComponentPayload,
+	RenderedComponentWithPreview,
+} from './render-component';
+
+/** Returns the current time for deterministic SSR metadata in tests. */
+export function createDefaultRenderTimestamp(): Date {
+	return new Date();
+}
+
+/** Converts a canonical render result into a flat transport payload. */
+export function toRenderedComponentPayload(
+	render: RenderedComponentWithPreview | RenderedComponent,
+): RenderedComponentPayload {
+	if ('metadata' in render) {
+		return {
+			assets: render.metadata.assets,
+			clientModuleSrc: render.metadata.clientModuleUrl,
+			generatedAt: render.metadata.generatedAt,
+			markup: render.markup,
+			tagName: render.metadata.tagName,
+		};
+	}
+
+	const { preview: _preview, ...payload } = render;
+	return payload;
+}
+
+/** Adds preview fields to a canonical render result. */
+export function toRenderedComponentWithPreview(render: RenderedComponent): RenderedComponentWithPreview {
+	return {
+		assets: render.metadata.assets,
+		clientModuleSrc: render.metadata.clientModuleUrl,
+		generatedAt: render.metadata.generatedAt,
+		markup: render.markup,
+		preview: render.preview,
+		tagName: render.metadata.tagName,
+	};
+}

--- a/packages/radiant/src/utils/escape-html-attribute.ts
+++ b/packages/radiant/src/utils/escape-html-attribute.ts
@@ -1,0 +1,4 @@
+/** Escapes a string for safe interpolation inside a double-quoted HTML attribute value. */
+export function escapeHtmlAttribute(value: string): string {
+	return value.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}

--- a/packages/radiant/test/core/radiant-element.test.ts
+++ b/packages/radiant/test/core/radiant-element.test.ts
@@ -98,10 +98,8 @@ describe('RadiantElement', () => {
 				listener: () => {},
 			},
 		]);
-		// @ts-expect-error: private property
-		expect(customElement.eventSubscriptions.has('click:[data-ref="click-me"]')).toBeTruthy();
-		// @ts-expect-error: private property
-		expect(customElement.eventSubscriptions.has('click:[data-ref="click-it"]')).toBeTruthy();
+		expect(customElement.hasEventSubscription('click:[data-ref="click-me"]')).toBeTruthy();
+		expect(customElement.hasEventSubscription('click:[data-ref="click-it"]')).toBeTruthy();
 	});
 
 	test('it can unsubscribe from events', () => {
@@ -122,10 +120,8 @@ describe('RadiantElement', () => {
 
 		unsubscribeClickMe();
 
-		// @ts-expect-error: private property
-		expect(customElement.eventSubscriptions.has('click:[data-ref="click-me"]')).toBeFalsy();
-		// @ts-expect-error: private property
-		expect(customElement.eventSubscriptions.has('click:[data-ref="click-it"]')).toBeTruthy();
+		expect(customElement.hasEventSubscription('click:[data-ref="click-me"]')).toBeFalsy();
+		expect(customElement.hasEventSubscription('click:[data-ref="click-it"]')).toBeTruthy();
 	});
 
 	test('it can create a reactive property', () => {

--- a/packages/radiant/test/decorators/state-standard-legacy-parity.test.ts
+++ b/packages/radiant/test/decorators/state-standard-legacy-parity.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from 'vitest';
+import { RadiantElement } from '../../src/core/radiant-element';
+import { reactiveField as legacyReactiveField } from '../../src/decorators/legacy/reactive-field';
+import { reactiveField as standardReactiveField } from '../../src/decorators/standard/reactive-field';
+import { state } from '../../src/decorators/state';
+
+function defineLegacyStateElement(tagName: string) {
+	class LegacyStateElement extends RadiantElement {
+		count = 0;
+	}
+
+	legacyReactiveField(LegacyStateElement.prototype, 'count');
+	customElements.define(tagName, LegacyStateElement);
+	return LegacyStateElement;
+}
+
+function defineStandardStateElement(tagName: string) {
+	class StandardStateElement extends RadiantElement {
+		@state count = 0;
+	}
+
+	customElements.define(tagName, StandardStateElement);
+	return StandardStateElement;
+}
+
+describe('@state standard vs legacy parity', () => {
+	test('RadiantElement exposes bindings and notifies on change', () => {
+		const LegacyStateElement = defineLegacyStateElement('legacy-state-parity-element');
+		const StandardStateElement = defineStandardStateElement('standard-state-parity-element');
+
+		const legacyElement = document.createElement('legacy-state-parity-element') as InstanceType<
+			typeof LegacyStateElement
+		> & { $count: ReturnType<LegacyStateElement['bind']> };
+		const standardElement = document.createElement('standard-state-parity-element') as InstanceType<
+			typeof StandardStateElement
+		> & { $count: ReturnType<StandardStateElement['bind']> };
+
+		document.body.append(legacyElement, standardElement);
+
+		expect(legacyElement.count).toBe(0);
+		expect(standardElement.count).toBe(0);
+		expect(legacyElement.$count.getValue()).toBe(0);
+		expect(standardElement.$count.getValue()).toBe(0);
+
+		legacyElement.count = 2;
+		standardElement.count = 2;
+
+		expect(legacyElement.$count.getValue()).toBe(2);
+		expect(standardElement.$count.getValue()).toBe(2);
+
+		legacyElement.remove();
+		standardElement.remove();
+	});
+
+	test('standard reactiveField export routes through createReactiveField', () => {
+		expect(standardReactiveField).toBeTypeOf('function');
+	});
+});


### PR DESCRIPTION
## Summary
- Extract `ReactivePropertyState` and `EventSubscriptionRegistry` from `radiant-element.ts`
- Route standard `@state` through `createReactiveField` with `suppressInitialNotify`
- Add shared `render-fragment.ts` and `escape-html-attribute.ts`

## Test plan
- [x] `cd packages/radiant && bun run test:lib`
- [x] `cd packages/radiant && bun run build:types`