### PR TITLE
refactor(radiant): unify SSR host shape and move service to server

### DIFF
--- a/packages/radiant/src/core/radiant-element-ssr-host.ts
+++ b/packages/radiant/src/core/radiant-element-ssr-host.ts
@@ -1,40 +1,43 @@
 import type { JsxRenderable } from '@ecopages/jsx';
 import type { RenderToStringOptions } from '@ecopages/jsx/server';
 import type { SsrSerializableContextProvider } from '../context/context-provider';
-import type {
-	RadiantElementServerRenderSsrCapable,
-	RadiantElementTrackedRenderSsrCapable,
-} from './radiant-element-ssr-registry';
 import type { ReactiveProperty } from './reactive-prop-core';
+import type { ReactivePropDefinition } from './reactive-prop-metadata';
 import type { SsrSerializableHydrationBinding } from './ssr-hydration-binding';
 
-export type RadiantElementSsrHostSource = RadiantElementServerRenderSsrCapable &
-	RadiantElementTrackedRenderSsrCapable & {
-		constructor: CustomElementConstructor;
-		getAttribute(name: string): string | null;
-		getAttributeNames(): string[];
-		getAuthoredHydrationScriptMarkup(): string | undefined;
-		getContextProviders(): SsrSerializableContextProvider[];
-		getHydrationBindings(): SsrSerializableHydrationBinding[];
-		getPropertyValue(name: string): unknown;
-		getReactiveProperties(): ReactiveProperty[];
-		getSlotProjectionScriptTag(): string | undefined;
-		resolveTrackedRenderOutput(): { containsSlots: boolean; value: JsxRenderable };
-		renderViewToString(options?: RenderToStringOptions): string;
-	};
+/**
+ * Unified SSR host shape shared by core resolution and server serialization.
+ */
+export type InternalRadiantSsrHost = {
+	constructor: CustomElementConstructor;
+	getAttribute(name: string): string | null;
+	getAttributeNames(): string[];
+	getAuthoredHydrationScriptMarkup?: () => string | undefined;
+	getContextProviders: () => SsrSerializableContextProvider[];
+	getHydrationBindings: () => SsrSerializableHydrationBinding[];
+	getReactiveProperties: () => ReactiveProperty[];
+	getReactivePropDefinitions: () => ReactivePropDefinition[];
+	getPropertyValue: (name: string) => unknown;
+	getSlotProjectionScriptTag?: () => string | undefined;
+	resolveTrackedRenderOutput: () => { containsSlots: boolean; value: JsxRenderable };
+	renderViewToString: (options?: RenderToStringOptions) => string;
+};
 
-export function resolveRadiantElementSsrHostSource(component: object): RadiantElementSsrHostSource | undefined {
-	if (isRadiantElementSsrHostSource(component)) {
+export type RadiantElementSsrHostSource = InternalRadiantSsrHost;
+
+export function resolveRadiantElementSsrHostSource(component: object): InternalRadiantSsrHost | undefined {
+	if (isInternalRadiantSsrHost(component)) {
 		return component;
 	}
 
 	return undefined;
 }
 
-function isRadiantElementSsrHostSource(component: object): component is RadiantElementSsrHostSource {
+export function isInternalRadiantSsrHost(component: object): component is InternalRadiantSsrHost {
 	return (
 		typeof component.constructor === 'function' &&
 		typeof (component as { getAttribute?: unknown }).getAttribute === 'function' &&
+		typeof (component as { getAttributeNames?: unknown }).getAttributeNames === 'function' &&
 		typeof (component as { getAuthoredHydrationScriptMarkup?: unknown }).getAuthoredHydrationScriptMarkup ===
 			'function' &&
 		typeof (component as { getContextProviders?: unknown }).getContextProviders === 'function' &&

--- a/packages/radiant/src/core/radiant-element-ssr-registry.ts
+++ b/packages/radiant/src/core/radiant-element-ssr-registry.ts
@@ -1,57 +1,30 @@
 import type { JsxRenderable } from '@ecopages/jsx';
 import { getActiveSsrScopeValue, type RenderToStringOptions, withActiveSsrScopeValue } from '@ecopages/jsx/server';
+import type { InternalRadiantSsrHost } from './radiant-element-ssr-host';
 
 export type RadiantElementRenderBridge = {
 	renderHost?: () => JsxRenderable;
 	renderHostToString?: (options?: RenderToStringOptions) => string;
 };
 
-/**
- * SSR host shape used by explicit server rendering entrypoints.
- *
- * Server-side attribute serialization is derived from ordinary host state in
- * the server pipeline rather than through a dedicated host SSR hook.
- */
-export type RadiantElementServerRenderSsrCapable = object;
+export type RadiantElementServerRenderSsrCapable = InternalRadiantSsrHost;
 
-/**
- * SSR host shape required when the server runtime renders the tracked component
- * view directly.
- */
-export type RadiantElementTrackedRenderSsrCapable = object;
+export type RadiantElementTrackedRenderSsrCapable = InternalRadiantSsrHost;
 
-/**
- * Shared SSR runtime contract carried on the active JSX SSR render scope.
- *
- * Server entrypoints install one implementation that both direct component SSR
- * and nested JSX custom-element SSR can reuse without importing client-only
- * internals into every call site.
- */
 export type RadiantElementSsrRuntime = {
-	getHostAttributes(component: RadiantElementServerRenderSsrCapable): Record<string, string>;
-	renderHost(component: RadiantElementServerRenderSsrCapable): JsxRenderable;
-	renderHostToString(component: RadiantElementServerRenderSsrCapable, options?: RenderToStringOptions): string;
+	getHostAttributes(component: InternalRadiantSsrHost): Record<string, string>;
+	renderHost(component: InternalRadiantSsrHost): JsxRenderable;
+	renderHostToString(component: InternalRadiantSsrHost, options?: RenderToStringOptions): string;
 	resolveRenderBridge(component: object): RadiantElementRenderBridge | undefined;
-	renderView(component: RadiantElementTrackedRenderSsrCapable, options?: RenderToStringOptions): string;
+	renderView(component: InternalRadiantSsrHost, options?: RenderToStringOptions): string;
 };
 
 const RADIANT_ELEMENT_SSR_RUNTIME_SYMBOL = Symbol.for('@ecopages/radiant.element-ssr-runtime');
 
-/**
- * Reads the active Radiant SSR runtime from the current render scope.
- *
- * Returns `undefined` when no server render is currently in progress.
- */
 export function getRadiantElementSsrRuntime(): RadiantElementSsrRuntime | undefined {
 	return getActiveSsrScopeValue<RadiantElementSsrRuntime>(RADIANT_ELEMENT_SSR_RUNTIME_SYMBOL);
 }
 
-/**
- * Runs work within an active Radiant SSR runtime scope.
- *
- * The runtime remains visible across built entrypoint boundaries through the
- * active JSX SSR render scope, but only for the duration of the active render call.
- */
 export function withRadiantElementSsrRuntime<T>(runtime: RadiantElementSsrRuntime, render: () => T): T {
 	return withActiveSsrScopeValue(RADIANT_ELEMENT_SSR_RUNTIME_SYMBOL, runtime, render);
 }

--- a/packages/radiant/src/core/radiant-element.ts
+++ b/packages/radiant/src/core/radiant-element.ts
@@ -23,7 +23,9 @@ import type { SsrSerializableHydrationBinding } from './ssr-hydration-binding';
 import { ReactiveHost } from './reactive-host';
 import { runSsrPreparationCallbacks } from './ssr-preparation';
 import { isRadiantHydratorInstalled } from './radiant-hydrator-state';
+import { getReactivePropDefinitions, type ReactivePropDefinition } from './reactive-prop-metadata';
 import { getRadiantElementSsrRuntime } from './radiant-element-ssr-registry';
+import type { InternalRadiantSsrHost } from './radiant-element-ssr-host';
 import { type AttributeTypeConstant, getInitialValue } from '../utils/attribute-utils';
 
 export type {
@@ -404,6 +406,14 @@ export class RadiantElement<Bindings extends object = {}>
 		return jsx('slot', {});
 	}
 
+	public getReactivePropDefinitions(): ReactivePropDefinition[] {
+		return getReactivePropDefinitions(this);
+	}
+
+	public getPropertyValue(name: string): unknown {
+		return Reflect.get(this, name);
+	}
+
 	public renderViewToString(options: RenderToStringOptions = {}): string {
 		if (!this.shouldRunRenderLifecycle()) {
 			return this.innerHTML;
@@ -412,7 +422,7 @@ export class RadiantElement<Bindings extends object = {}>
 		runLegacyPostConstructionInitializers(this);
 		this.prepareForSsr();
 
-		return requireRadiantElementSsrRuntime().renderView(this, options);
+		return requireRadiantElementSsrRuntime().renderView(this as unknown as InternalRadiantSsrHost, options);
 	}
 
 	public hydrate(): void {

--- a/packages/radiant/src/server/internal-radiant-host.ts
+++ b/packages/radiant/src/server/internal-radiant-host.ts
@@ -1,0 +1,2 @@
+export type { InternalRadiantSsrHost } from '../core/radiant-element-ssr-host';
+export { isInternalRadiantSsrHost } from '../core/radiant-element-ssr-host';

--- a/packages/radiant/src/server/radiant-element-ssr-bridge.ts
+++ b/packages/radiant/src/server/radiant-element-ssr-bridge.ts
@@ -8,7 +8,7 @@ import {
 	withServerCustomElementRenderHook,
 	withServerHydrationBindingState,
 } from '@ecopages/jsx/server';
-import { RadiantElementSsrService } from '../core/radiant-element-ssr-service';
+import { RadiantElementSsrService } from './radiant-element-ssr-service';
 import { resolveRadiantElementSsrHostSource as resolveInternalRadiantElementSsrHostSource } from '../core/radiant-element-ssr-host';
 import type {
 	RadiantElementRenderBridge,
@@ -17,14 +17,11 @@ import type {
 	RadiantElementTrackedRenderSsrCapable,
 } from '../core/radiant-element-ssr-registry';
 import { withRadiantElementSsrRuntime } from '../core/radiant-element-ssr-registry';
-import { extractRadiantElementServerRenderHost } from './radiant-element-ssr-extractor';
 
 let radiantElementSsrRuntime: RadiantElementSsrRuntime | undefined;
 
-export function createRadiantElementSsrService(
-	component: RadiantElementServerRenderSsrCapable,
-): RadiantElementSsrService {
-	return new RadiantElementSsrService(extractRadiantElementServerRenderHost(component));
+export function createRadiantElementSsrService(component: object): RadiantElementSsrService {
+	return new RadiantElementSsrService(component);
 }
 
 export function renderRadiantElementHost(component: RadiantElementServerRenderSsrCapable): JsxRenderable {

--- a/packages/radiant/src/server/radiant-element-ssr-extractor.ts
+++ b/packages/radiant/src/server/radiant-element-ssr-extractor.ts
@@ -1,11 +1,8 @@
 import { getReactivePropDefinitions } from '../core/reactive-prop-metadata';
 import { resolveRadiantElementSsrHostSource } from '../core/radiant-element-ssr-host';
-import type { RadiantElementServerRenderSsrCapable } from '../core/radiant-element-ssr-registry';
-import type { RadiantElementSsrHost } from '../core/radiant-element-ssr-service';
+import type { InternalRadiantSsrHost } from './internal-radiant-host';
 
-export function extractRadiantElementServerRenderHost(
-	component: RadiantElementServerRenderSsrCapable,
-): RadiantElementSsrHost {
+export function toInternalRadiantSsrHost(component: object): InternalRadiantSsrHost {
 	const source = resolveRadiantElementSsrHostSource(component);
 
 	if (!source) {
@@ -14,15 +11,16 @@ export function extractRadiantElementServerRenderHost(
 
 	return {
 		constructor: source.constructor,
-		getAuthoredHydrationScriptMarkup: () => source.getAuthoredHydrationScriptMarkup(),
+		getAttribute: (name) => source.getAttribute(name),
+		getAttributeNames: () => source.getAttributeNames(),
+		getAuthoredHydrationScriptMarkup: () => source.getAuthoredHydrationScriptMarkup?.(),
 		getContextProviders: () => source.getContextProviders(),
 		getHydrationBindings: () => source.getHydrationBindings(),
-		getSlotProjectionScriptTag: () => source.getSlotProjectionScriptTag(),
-		renderViewToString: (options) => source.renderViewToString(options),
 		getReactiveProperties: () => source.getReactiveProperties(),
 		getReactivePropDefinitions: () => getReactivePropDefinitions(component),
 		getPropertyValue: (name) => Reflect.get(component, name),
-		listAttributeNames: () => source.getAttributeNames(),
-		getAttributeValue: (name) => source.getAttribute(name),
+		getSlotProjectionScriptTag: () => source.getSlotProjectionScriptTag?.(),
+		resolveTrackedRenderOutput: () => source.resolveTrackedRenderOutput(),
+		renderViewToString: (options) => source.renderViewToString(options),
 	};
 }

--- a/packages/radiant/src/server/radiant-element-ssr-service.ts
+++ b/packages/radiant/src/server/radiant-element-ssr-service.ts
@@ -1,32 +1,29 @@
 import type { JsxRenderable } from '@ecopages/jsx';
 import type { RenderToStringOptions } from '@ecopages/jsx/server';
-import type { SsrSerializableContextProvider } from '../context/context-provider';
-import { withSsrContextProviders } from '../server/context-ssr';
-import { getCustomElementTagName } from './custom-element-metadata';
-import type { ReactiveProperty } from './reactive-prop-core';
-import type { ReactivePropDefinition } from './reactive-prop-metadata';
-import type { SsrSerializableHydrationBinding } from './ssr-hydration-binding';
-import { resolveHostAttributes, stringifyHostAttributes } from '../server/host-attribute-serialization';
-import { composeHostContent } from '../server/host-script-composition';
-
-export type RadiantElementSsrHost = {
-	constructor: CustomElementConstructor;
-	getAuthoredHydrationScriptMarkup?: () => string | undefined;
-	getContextProviders: () => SsrSerializableContextProvider[];
-	getHydrationBindings: () => SsrSerializableHydrationBinding[];
-	getSlotProjectionScriptTag?: () => string | undefined;
-	renderViewToString: (options?: RenderToStringOptions) => string;
-	getReactiveProperties: () => ReactiveProperty[];
-	getReactivePropDefinitions: () => ReactivePropDefinition[];
-	getPropertyValue: (name: string) => unknown;
-	listAttributeNames: () => string[];
-	getAttributeValue: (name: string) => string | null;
-};
+import { getCustomElementTagName } from '../core/custom-element-metadata';
+import { withSsrContextProviders } from './context-ssr';
+import { composeHostContent } from './host-script-composition';
+import { resolveHostAttributes, stringifyHostAttributes } from './host-attribute-serialization';
+import { ensureLegacyHostReady } from '../decorators/legacy/host-readiness';
+import { toInternalRadiantSsrHost } from './radiant-element-ssr-extractor';
+import type { InternalRadiantSsrHost } from '../core/radiant-element-ssr-host';
 
 export class RadiantElementSsrService {
-	constructor(private readonly host: RadiantElementSsrHost) {}
+	private readonly component: object;
+	private readonly host: InternalRadiantSsrHost;
+
+	constructor(component: object) {
+		this.component = component;
+		this.host = toInternalRadiantSsrHost(component);
+	}
+
+	private ensureReady(): void {
+		ensureLegacyHostReady(this.component, 'ssr');
+	}
 
 	public renderHost(): JsxRenderable {
+		this.ensureReady();
+
 		return {
 			nodeType: 1,
 			outerHTML: this.renderHostToString({ mode: 'hydrate' }),
@@ -34,6 +31,7 @@ export class RadiantElementSsrService {
 	}
 
 	public renderHostToString(options: RenderToStringOptions = {}, attributes = this.getHostAttributes()): string {
+		this.ensureReady();
 		const tagName = this.getTagName();
 		const restoreSsrContexts = withSsrContextProviders(this.host.getContextProviders());
 
@@ -42,6 +40,11 @@ export class RadiantElementSsrService {
 		} finally {
 			restoreSsrContexts();
 		}
+	}
+
+	public getHostAttributes(): Record<string, string> {
+		this.ensureReady();
+		return resolveHostAttributes(this.host);
 	}
 
 	private renderHostContent(options: RenderToStringOptions): string {
@@ -64,10 +67,6 @@ export class RadiantElementSsrService {
 			},
 			hydrate,
 		);
-	}
-
-	public getHostAttributes(): Record<string, string> {
-		return resolveHostAttributes(this.host);
 	}
 
 	private getTagName(): string {

--- a/packages/radiant/src/server/radiant-element-ssr-service.ts
+++ b/packages/radiant/src/server/radiant-element-ssr-service.ts
@@ -4,7 +4,7 @@ import { getCustomElementTagName } from '../core/custom-element-metadata';
 import { withSsrContextProviders } from './context-ssr';
 import { composeHostContent } from './host-script-composition';
 import { resolveHostAttributes, stringifyHostAttributes } from './host-attribute-serialization';
-import { ensureLegacyHostReady } from '../decorators/legacy/host-readiness';
+import { runLegacyPostConstructionInitializers } from '../decorators/legacy/instance-initializers';
 import { toInternalRadiantSsrHost } from './radiant-element-ssr-extractor';
 import type { InternalRadiantSsrHost } from '../core/radiant-element-ssr-host';
 
@@ -18,7 +18,7 @@ export class RadiantElementSsrService {
 	}
 
 	private ensureReady(): void {
-		ensureLegacyHostReady(this.component, 'ssr');
+		runLegacyPostConstructionInitializers(this.component);
 	}
 
 	public renderHost(): JsxRenderable {


### PR DESCRIPTION
## Summary
- Collapse SSR host types into `InternalRadiantSsrHost`
- Move `RadiantElementSsrService` from `core/` to `server/`
- Zero `core → server` imports under `packages/radiant/src/core/`

## Test plan
- [x] `cd packages/radiant && bun run test:lib`
- [x] SSR render tests pass