### PR TITLE
refactor(radiant): centralize legacy host readiness

### DIFF
--- a/packages/radiant/src/decorators/legacy/signal.ts
+++ b/packages/radiant/src/decorators/legacy/signal.ts
@@ -1,6 +1,7 @@
 import type { ReactiveBindingOption } from '../../core/reactive-prop-core';
 import type { ReactiveHostLike } from '../../core/reactive-host';
 import { createHostSignal, HostSignal, isWritableSignalLike } from '../../signals/host-signal';
+import { isHydrationCapableHost } from '../../core/hydration-capable-host';
 import { registerLegacyPostConstructionInitializer } from './instance-initializers';
 import type { AttributeTypeConstant } from '../../utils/attribute-utils';
 import type { WritableSignal } from '@ecopages/signals';
@@ -56,7 +57,7 @@ export function signal<Value = unknown>(options: SignalDecoratorOptions<Value> =
 				hostSignal.disconnectFromSource();
 			});
 
-			if (options.hydrate) {
+			if (options.hydrate && isHydrationCapableHost(element)) {
 				element.registerHydrationBinding(propertyName, hostSignal);
 			}
 

--- a/packages/radiant/src/decorators/standard/signal.ts
+++ b/packages/radiant/src/decorators/standard/signal.ts
@@ -2,6 +2,7 @@ import type { WritableSignal } from '@ecopages/signals';
 import type { ReactiveBindingOption } from '../../core/reactive-prop-core';
 import type { ReactiveHostLike } from '../../core/reactive-host';
 import { createHostSignal, isWritableSignalLike } from '../../signals/host-signal';
+import { isHydrationCapableHost } from '../../core/hydration-capable-host';
 import type { AttributeTypeConstant } from '../../utils/attribute-utils';
 
 /** Options for the `@signal` decorator. */
@@ -76,7 +77,7 @@ export function signal<Value = unknown>(options: SignalDecoratorOptions<Value> =
 				hostSignal.disconnectFromSource();
 			});
 
-			if (options.hydrate) {
+			if (options.hydrate && isHydrationCapableHost(this)) {
 				this.registerHydrationBinding(propertyName, hostSignal);
 			}
 

--- a/packages/radiant/src/server/render-component.ts
+++ b/packages/radiant/src/server/render-component.ts
@@ -12,7 +12,7 @@ import {
 	renderRegisteredRadiantElementHostToString,
 } from './radiant-element-ssr-bridge';
 import { withRadiantElementSsrRuntime } from '../core/radiant-element-ssr-registry';
-import { getOrCreateRadiantElementSsrRuntime } from './radiant-element-ssr';
+import { getOrCreateRadiantElementSsrRuntime } from './radiant-element-ssr-runtime';
 import {
 	createDefaultRenderTimestamp,
 	toRenderedComponentPayload,

--- a/packages/radiant/src/server/render-component.ts
+++ b/packages/radiant/src/server/render-component.ts
@@ -4,7 +4,7 @@ import type { SsrSerializableContextProvider } from '../context/context-provider
 import { withSsrContextProviders } from './context-ssr';
 import type { ContextType, UnknownContext } from '../context/types';
 import { getCustomElementTagName } from '../core/custom-element-metadata';
-import { runLegacyPostConstructionInitializers } from '../decorators/legacy/instance-initializers';
+import { ensureLegacyHostReady } from '../decorators/legacy/host-readiness';
 import { createServerRenderEnvironment, type ServerRenderEnvironment } from './light-dom-shim';
 import {
 	resolveRegisteredRadiantElementPreview,
@@ -12,9 +12,15 @@ import {
 	renderRegisteredRadiantElementHostToString,
 } from './radiant-element-ssr-bridge';
 import { withRadiantElementSsrRuntime } from '../core/radiant-element-ssr-registry';
-import { getOrCreateRadiantElementSsrRuntime } from './radiant-element-ssr-runtime';
+import { getOrCreateRadiantElementSsrRuntime } from './radiant-element-ssr';
+import {
+	createDefaultRenderTimestamp,
+	toRenderedComponentPayload,
+	toRenderedComponentWithPreview,
+} from './render-fragment';
 
-/** Asset dependency emitted by a rendered fragment. */
+export { createDefaultRenderTimestamp, toRenderedComponentPayload, toRenderedComponentWithPreview } from './render-fragment';
+
 export type RenderedComponentAsset =
 	| {
 			/** Browser module specifier that must be loaded to activate the fragment. */
@@ -302,7 +308,7 @@ async function renderResolvedComponent<TComponent extends ServerRenderableCompon
 			const Component =
 				'component' in normalizedOptions ? normalizedOptions.component : await normalizedOptions.load();
 			const component = new Component();
-			runLegacyPostConstructionInitializers(component);
+			ensureLegacyHostReady(component, 'ssr');
 			prepareRenderedComponentHost(
 				environment,
 				component,
@@ -395,41 +401,6 @@ function createAmbientSsrContextProviders(
 		renderHydrationScript: () => undefined,
 		renderHydrationScriptTag: () => undefined,
 	}));
-}
-
-/**
- * Drops the preview renderable so the result can be sent through lightweight
- * framework adapters or JSON/HTML fragment endpoints.
- */
-export function toRenderedComponentPayload(
-	render: RenderedComponentWithPreview | RenderedComponent,
-): RenderedComponentPayload {
-	if ('metadata' in render) {
-		return {
-			assets: render.metadata.assets,
-			clientModuleSrc: render.metadata.clientModuleUrl,
-			generatedAt: render.metadata.generatedAt,
-			markup: render.markup,
-			tagName: render.metadata.tagName,
-		};
-	}
-
-	const { preview: _preview, ...payload } = render;
-	return payload;
-}
-function toRenderedComponentWithPreview(render: RenderedComponent): RenderedComponentWithPreview {
-	return {
-		assets: render.metadata.assets,
-		clientModuleSrc: render.metadata.clientModuleUrl,
-		generatedAt: render.metadata.generatedAt,
-		markup: render.markup,
-		preview: render.preview,
-		tagName: render.metadata.tagName,
-	};
-}
-
-function createDefaultRenderTimestamp(): Date {
-	return new Date();
 }
 
 function createRenderedComponentClientModuleAssets(

--- a/packages/radiant/src/server/render-controller.ts
+++ b/packages/radiant/src/server/render-controller.ts
@@ -3,21 +3,24 @@ import { getControllerIdentifier } from '../core/controller-metadata';
 import { withRadiantElementSsrRuntime } from '../core/radiant-element-ssr-registry';
 import type { RadiantController } from '../core/radiant-controller';
 import { CONTROLLER_ATTRIBUTE } from '../controller-registry';
-import { runLegacyPostConstructionInitializers } from '../decorators/legacy/instance-initializers';
+import { ensureLegacyHostReady } from '../decorators/legacy/host-readiness';
 import { withSsrContextProviders } from './context-ssr';
 import { ensureLightDomShim } from './light-dom-shim';
 import { withRadiantServerCustomElementRenderBridge } from './radiant-element-ssr-bridge';
-import { getOrCreateRadiantElementSsrRuntime } from './radiant-element-ssr-runtime';
+import { getOrCreateRadiantElementSsrRuntime } from './radiant-element-ssr';
 import {
 	mergeRenderedComponentAssets,
 	normalizeRenderOptions,
 	resolvePrimaryClientModuleSrc,
 	toRenderedComponentPayload,
+	toRenderedComponentWithPreview,
+	createDefaultRenderTimestamp,
 	type RenderedComponent,
 	type RenderedComponentAsset,
 	type RenderedComponentPayload,
 	type RenderedComponentWithPreview,
 } from './render-component';
+import { escapeHtmlAttribute } from '../utils/escape-html-attribute';
 
 /** Constructor shape for a server-renderable controller. */
 export type ServerRenderableControllerConstructor<TController extends RadiantController = RadiantController> = new (
@@ -130,7 +133,7 @@ async function renderResolvedController<TController extends RadiantController>(
 			normalizeRenderedControllerHostAttributes(Controller, options),
 		);
 		const controller = new Controller(host);
-		runLegacyPostConstructionInitializers(controller);
+		ensureLegacyHostReady(controller, 'ssr');
 
 		try {
 			options.initialize?.(controller);
@@ -159,21 +162,6 @@ async function renderResolvedController<TController extends RadiantController>(
 			controller.disconnect();
 		}
 	});
-}
-
-function toRenderedComponentWithPreview(render: RenderedComponent): RenderedComponentWithPreview {
-	return {
-		assets: render.metadata.assets,
-		clientModuleSrc: render.metadata.clientModuleUrl,
-		generatedAt: render.metadata.generatedAt,
-		markup: render.markup,
-		preview: render.preview,
-		tagName: render.metadata.tagName,
-	};
-}
-
-function createDefaultRenderTimestamp(): Date {
-	return new Date();
 }
 
 function normalizeRenderedControllerTagName(tagName: string): string {
@@ -352,9 +340,6 @@ function serializeRenderedControllerAttribute(name: string, value: string | null
 		return ` ${name}`;
 	}
 
-	return ` ${name}="${escapeRenderedControllerAttributeValue(value ?? '')}"`;
+	return ` ${name}="${escapeHtmlAttribute(value ?? '')}"`;
 }
 
-function escapeRenderedControllerAttributeValue(value: string): string {
-	return value.replaceAll('&', '&amp;').replaceAll('"', '&quot;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
-}

--- a/packages/radiant/src/server/render-controller.ts
+++ b/packages/radiant/src/server/render-controller.ts
@@ -7,7 +7,7 @@ import { ensureLegacyHostReady } from '../decorators/legacy/host-readiness';
 import { withSsrContextProviders } from './context-ssr';
 import { ensureLightDomShim } from './light-dom-shim';
 import { withRadiantServerCustomElementRenderBridge } from './radiant-element-ssr-bridge';
-import { getOrCreateRadiantElementSsrRuntime } from './radiant-element-ssr';
+import { getOrCreateRadiantElementSsrRuntime } from './radiant-element-ssr-runtime';
 import {
 	mergeRenderedComponentAssets,
 	normalizeRenderOptions,

--- a/packages/radiant/test/core/legacy-post-construction.test.ts
+++ b/packages/radiant/test/core/legacy-post-construction.test.ts
@@ -8,6 +8,7 @@ import {
 	registerLegacyPostConstructionInitializer,
 	runLegacyPostConstructionInitializers,
 } from '../../src/decorators/legacy/instance-initializers';
+import { ensureLegacyHostReady } from '../../src/decorators/legacy/host-readiness';
 import { signal } from '../../src/decorators/signal';
 import { renderController } from '../../src/server/render-controller';
 
@@ -46,6 +47,8 @@ describe('legacy post-construction decorator setup', () => {
 			'legacy-post-construction-element-test',
 		) as LegacyPostConstructionElement;
 
+		ensureLegacyHostReady(element, 'ssr');
+
 		const providers = element.getContextProviders();
 		const bindings = element.getHydrationBindings();
 
@@ -60,6 +63,8 @@ describe('legacy post-construction decorator setup', () => {
 		const element = document.createElement(
 			'legacy-post-construction-element-test',
 		) as LegacyPostConstructionElement;
+
+		ensureLegacyHostReady(element, 'ssr');
 
 		const firstProviders = element.getContextProviders();
 		const firstBindings = element.getHydrationBindings();


### PR DESCRIPTION
## Summary
- Add `ensureLegacyHostReady(host, phase)` coordinator
- Add `dispatchContextSelectorDecorator` for context decorators
- Remove getter-side `runLegacyPostConstructionInitializers`

## Test plan
- [x] `cd packages/radiant && bun run test:lib`
- [x] `test/core/legacy-post-construction.test.ts`