### PR TITLE
refactor(radiant): consolidate SSR registry and hydration types

### DIFF
--- a/packages/radiant/src/controller-registry.ts
+++ b/packages/radiant/src/controller-registry.ts
@@ -244,6 +244,12 @@ export function registerController<
 	const existingController = controllerRegistry.get(identifier);
 
 	if (existingController) {
+		if (process.env.NODE_ENV !== 'production') {
+			console.warn(
+				`[radiant] Controller "${identifier}" is already registered. Keeping the existing constructor.`,
+			);
+		}
+
 		return existingController as TConstructor;
 	}
 

--- a/packages/radiant/src/decorators/legacy/signal.ts
+++ b/packages/radiant/src/decorators/legacy/signal.ts
@@ -1,6 +1,7 @@
 import type { ReactiveBindingOption } from '../../core/reactive-prop-core';
-import type { ReactiveHostLike } from '../../core/reactive-host';
 import { createHostSignal, HostSignal, isWritableSignalLike } from '../../signals/host-signal';
+import { isHydrationCapableHost } from '../../core/hydration-capable-host';
+import type { ReactiveHostLike } from '../../core/reactive-host';
 import { registerLegacyPostConstructionInitializer } from './instance-initializers';
 import type { AttributeTypeConstant } from '../../utils/attribute-utils';
 import type { WritableSignal } from '@ecopages/signals';
@@ -56,7 +57,7 @@ export function signal<Value = unknown>(options: SignalDecoratorOptions<Value> =
 				hostSignal.disconnectFromSource();
 			});
 
-			if (options.hydrate) {
+			if (options.hydrate && isHydrationCapableHost(element)) {
 				element.registerHydrationBinding(propertyName, hostSignal);
 			}
 

--- a/packages/radiant/src/decorators/standard/signal.ts
+++ b/packages/radiant/src/decorators/standard/signal.ts
@@ -2,6 +2,7 @@ import type { WritableSignal } from '@ecopages/signals';
 import type { ReactiveBindingOption } from '../../core/reactive-prop-core';
 import type { ReactiveHostLike } from '../../core/reactive-host';
 import { createHostSignal, isWritableSignalLike } from '../../signals/host-signal';
+import { isHydrationCapableHost } from '../../core/hydration-capable-host';
 import type { AttributeTypeConstant } from '../../utils/attribute-utils';
 
 /** Options for the `@signal` decorator. */
@@ -76,7 +77,7 @@ export function signal<Value = unknown>(options: SignalDecoratorOptions<Value> =
 				hostSignal.disconnectFromSource();
 			});
 
-			if (options.hydrate) {
+			if (options.hydrate && isHydrationCapableHost(this)) {
 				this.registerHydrationBinding(propertyName, hostSignal);
 			}
 

--- a/packages/radiant/src/server/radiant-element-ssr-runtime.ts
+++ b/packages/radiant/src/server/radiant-element-ssr-runtime.ts
@@ -1,1 +1,0 @@
-export { getOrCreateRadiantElementSsrRuntime, withServerRadiantElementSsrRuntime } from './radiant-element-ssr-bridge';

--- a/packages/radiant/src/server/radiant-element-ssr.ts
+++ b/packages/radiant/src/server/radiant-element-ssr.ts
@@ -1,0 +1,16 @@
+export {
+	createRadiantElementSsrService,
+	getOrCreateRadiantElementSsrRuntime,
+	getRadiantElementHostSsrAttributes,
+	getRadiantElementTrackedRenderOutput,
+	renderRadiantElementHost,
+	renderRadiantElementHostToString,
+	renderRadiantElementViewToString,
+	renderRegisteredRadiantElementHost,
+	renderRegisteredRadiantElementHostToString,
+	resolveRadiantElementRenderBridge,
+	resolveRadiantElementSsrHostBridge,
+	resolveRegisteredRadiantElementPreview,
+	withRadiantServerCustomElementRenderBridge,
+	withServerRadiantElementSsrRuntime,
+} from './radiant-element-ssr-bridge';

--- a/packages/radiant/src/server/render-component.ts
+++ b/packages/radiant/src/server/render-component.ts
@@ -12,7 +12,7 @@ import {
 	renderRegisteredRadiantElementHostToString,
 } from './radiant-element-ssr-bridge';
 import { withRadiantElementSsrRuntime } from '../core/radiant-element-ssr-registry';
-import { getOrCreateRadiantElementSsrRuntime } from './radiant-element-ssr-runtime';
+import { getOrCreateRadiantElementSsrRuntime } from './radiant-element-ssr';
 import {
 	createDefaultRenderTimestamp,
 	toRenderedComponentPayload,

--- a/packages/radiant/src/server/render-controller.ts
+++ b/packages/radiant/src/server/render-controller.ts
@@ -7,7 +7,7 @@ import { ensureLegacyHostReady } from '../decorators/legacy/host-readiness';
 import { withSsrContextProviders } from './context-ssr';
 import { ensureLightDomShim } from './light-dom-shim';
 import { withRadiantServerCustomElementRenderBridge } from './radiant-element-ssr-bridge';
-import { getOrCreateRadiantElementSsrRuntime } from './radiant-element-ssr-runtime';
+import { getOrCreateRadiantElementSsrRuntime } from './radiant-element-ssr';
 import {
 	mergeRenderedComponentAssets,
 	normalizeRenderOptions,

--- a/packages/radiant/test/server/render-component.test.tsx
+++ b/packages/radiant/test/server/render-component.test.tsx
@@ -31,7 +31,7 @@ import {
 } from '../../src/server/render-component';
 import { renderController, renderControllerToPayload } from '../../src/server/render-controller';
 import { resolveSsrContextValue } from '../../src/server/context-ssr';
-import { getOrCreateRadiantElementSsrRuntime } from '../../src/server/radiant-element-ssr-runtime';
+import { getOrCreateRadiantElementSsrRuntime } from '../../src/server/radiant-element-ssr';
 
 const cardAssets: readonly RenderedComponentAsset[] = [
 	{ kind: 'script-module', src: '/assets/render-component-card.js', stage: 'hydrate' },


### PR DESCRIPTION
## Summary
- Extract `HostSsrRegistry` and `HydrationCapableHost`
- Collapse `radiant-element-ssr-runtime` into `radiant-element-ssr.ts`
- Remove `registerHydrationBinding` no-op from `ReactiveHostLike`

## Test plan
- [x] `cd packages/radiant && bun run test:lib`
- [x] signal hydration and SSR render tests