### PR TITLE
feat(jsx): add derived bindings via map and proxy member access

### DIFF
--- a/apps/docs/src/pages/docs/components/radiant-controller.mdx
+++ b/apps/docs/src/pages/docs/components/radiant-controller.mdx
@@ -235,6 +235,38 @@ Controllers also support `render()`, `requestUpdate()`, and `update()` when you 
 
 Those lower-level helpers are useful for plain-JS integrations or abstraction layers. Prefer decorators first when the host shape is stable and readable.
 
+## Derived Bindings
+
+Controllers expose the same derive API as element hosts.
+
+### Member access in JSX
+
+For object-like bindings, member access is fine directly in `render()`:
+
+```tsx
+render() {
+  return <p>{this.$.config.label}</p>;
+}
+```
+
+The runtime memoizes each key, so this stays identity-stable across renders.
+
+### `map` for transforms and lookups
+
+Use `map` for record lookups, transforms, and anything that is not a plain property read:
+
+```tsx
+private readonly statusLabel = this.$.status.map((status) => STATUS_COPY[status]);
+
+render() {
+  return <p>{this.statusLabel}</p>;
+}
+```
+
+Hoist `map` to a create-once host field. Do not call `.map(...)` inside `render()` — each call produces a new derived binding.
+
+Object props are shallow: projections update on whole-object replacement, not in-place nested mutation.
+
 ## Supported Decorators
 
 These decorators are part of the `RadiantController` authoring model today:

--- a/apps/docs/src/pages/docs/components/radiant-element.mdx
+++ b/apps/docs/src/pages/docs/components/radiant-element.mdx
@@ -153,6 +153,52 @@ This means the correct question is not "element or component?" anymore. The ques
 
 Use the raw value in imperative code and render logic. Use bindings in stable JSX leaf positions such as text, attributes, `aria`, `data`, and boolean props.
 
+## Derived Bindings
+
+Bindings expose the current reactive value, but sometimes JSX needs a **projection** of that value — a record lookup, an object key, or a transform.
+
+### Member access in JSX
+
+For object-like bindings, use member access directly in `render()`:
+
+```tsx
+render() {
+  return <p>{this.$.config.label}</p>;
+}
+```
+
+This is sugar for `this.$.config.map((config) => config.label)`. The runtime memoizes each key on the binding, so repeated reads in `render()` reuse the same derived binding identity.
+
+Use this for simple object-key reads. You do not need a field initializer for `{this.$.config.label}` in normal components.
+
+### `map` for transforms and lookups
+
+Use `map` when the projection is not a plain property read — record lookups, computed strings, or method calls:
+
+```tsx
+private readonly themeLabel = this.$.preference.map((preference) => THEME_CONFIG[preference].label);
+
+render() {
+  return <p>Theme: {this.themeLabel}</p>;
+}
+```
+
+**Create `map` results once** (field initializer or cached host field). Calling `.map(...)` inside `render()` creates a new binding on every pass, which breaks the live-subscription fast path.
+
+```tsx
+// Avoid — new derived binding every render
+render() {
+  return <p>{this.$.preference.map((p) => THEME_CONFIG[p].label)}</p>;
+}
+```
+
+### Rules
+
+- **Member access** (`this.$.config.label`) — fine inline in JSX for simple keys.
+- **`map`** — hoist transforms and lookups to a create-once host field.
+- **Object props are shallow** — projections update when the whole object is replaced (`this.config = { ... }`), not when nested keys are mutated in place.
+- **Bracket lookups need `map`** — use `this.$.preference.map((p) => THEME_CONFIG[p].label)`, not `THEME_CONFIG[this.$.preference]`.
+
 ## When To Use RadiantElement
 
 - Use `RadiantElement` when you want a custom element host, whether the host is imperative or JSX-owned.

--- a/apps/docs/src/pages/docs/getting-started/best-practices.mdx
+++ b/apps/docs/src/pages/docs/getting-started/best-practices.mdx
@@ -205,6 +205,60 @@ Practical rule of thumb:
 
 In that example, the `class` expression still belongs to the host render pass, while the bound `data-state` and heading text can patch in place.
 
+### Derived Bindings
+
+Use derived bindings when JSX needs a **projection** of a reactive value — not the raw binding itself.
+
+#### Member access — use inline in JSX
+
+For object keys, write member access directly in `render()`:
+
+```tsx
+render() {
+  return <p>{this.$.config.label}</p>;
+}
+```
+
+This is equivalent to `this.$.config.map((config) => config.label)`, but the runtime caches each key on the binding. You do not need a field initializer for simple reads like this.
+
+Note: TypeScript may need a narrow cast on object `@prop` bindings when the inferred binding type is wider than your object shape. Runtime behavior is unchanged.
+
+#### `map` — hoist to a create-once field
+
+Use `map` for record lookups, transforms, and non-property projections:
+
+```tsx
+private readonly themeLabel = this.$.preference.map((preference) => THEME_CONFIG[preference].label);
+
+render() {
+  return <p>{this.themeLabel}</p>;
+}
+```
+
+Do **not** call `.map(...)` inside `render()`. Each call creates a new derived binding and defeats fine-grained patching.
+
+#### Anti-patterns
+
+```tsx
+// Wrong — subscribable object used as a record key
+THEME_CONFIG[this.$.preference]
+
+// Wrong — new derived binding every render
+render() {
+  return <p>{this.$.preference.map((p) => THEME_CONFIG[p].label)}</p>;
+}
+
+// Right — simple object key inline
+render() {
+  return <p>{this.$.config.label}</p>;
+}
+
+// Right — transform hoisted once
+private readonly themeLabel = this.$.preference.map((p) => THEME_CONFIG[p].label);
+```
+
+Object props are shallow: `map` and member access track **whole-object replacement**, not in-place nested mutation.
+
 If a component never uses `this.$`, `this.bindings`, or `this.bind(...)`, you usually do not need a separate `Bindings` type at all.
 
 ## Technical Tips

--- a/apps/docs/src/pages/docs/packages/jsx-overview.mdx
+++ b/apps/docs/src/pages/docs/packages/jsx-overview.mdx
@@ -107,6 +107,28 @@ return (
 
 Removing a binding this way follows the normal renderer path. If the next render changes the template shape, the DOM renderer may replace the affected node rather than preserve the previous instance.
 
+## Derived Bindings
+
+`SubscribableJsxValue` bindings can be projected in two ways:
+
+**Member access** — for object keys, use inline in JSX:
+
+```tsx
+<p>{this.$.config.label}</p>
+```
+
+The runtime memoizes each key on the binding, so this is identity-stable across renders.
+
+**`map`** — for transforms, record lookups, and non-property projections:
+
+```tsx
+const themeLabel = boundPreference.map((preference) => THEME_CONFIG[preference].label);
+```
+
+On Radiant hosts: `this.$.field.map(...)`. Hoist `map` to a create-once host field. Do not call `.map(...)` inside `render()` — each call creates a new derived binding.
+
+Derived bindings reuse the source `getValue` / `subscribe` contract and mount through the same reactive engines as any other binding.
+
 ## Quick Start With RadiantElement
 
 ```tsx

--- a/apps/docs/src/public/skill.txt
+++ b/apps/docs/src/public/skill.txt
@@ -89,6 +89,35 @@ Prefer bindings for:
 
 Do not treat bindings as raw values for comparisons or control flow. If logic needs a boolean, string, or number, use the plain property.
 
+### Derived Bindings
+
+Use derived bindings when JSX needs a projection of a reactive value.
+
+**Member access** — simple object keys, inline in JSX:
+
+```tsx
+render() {
+  return <p>{this.$.config.label}</p>;
+}
+```
+
+Equivalent to `map`, but memoized per key on the binding. No field initializer needed for normal use.
+
+**`map`** — transforms, record lookups, non-property reads. Hoist to a create-once field:
+
+```tsx
+private readonly themeLabel = this.$.preference.map((preference) => THEME_CONFIG[preference].label);
+```
+
+Do not call `.map(...)` inside `render()` — each call creates a new derived binding.
+
+Rules:
+
+- member access inline in JSX is fine for simple object keys
+- hoist `map` to a field initializer or cached host field
+- object props are shallow — projections update on whole-object replacement, not in-place nested mutation
+- bracket lookups need `map`: `this.$.preference.map((p) => THEME_CONFIG[p].label)`, never `THEME_CONFIG[this.$.preference]`
+
 ## Performance Rule
 
 Use this rule to choose the update strategy:

--- a/packages/jsx/src/client.ts
+++ b/packages/jsx/src/client.ts
@@ -4,6 +4,7 @@ export {
 	jsx,
 	jsxs,
 	createSubscribableJsxValue,
+	mapSubscribable,
 	type SignalLike,
 	type JsxKey,
 	type KeyedJsxValue,
@@ -23,6 +24,7 @@ export {
 	isSlotJsxValue,
 	isSubscribableJsxValue,
 	type SubscribableJsxValue,
+	type SubscribableJsxValueWithAccess,
 	type TemplateResultLike,
 } from './jsx-runtime.ts';
 

--- a/packages/jsx/src/dom-render/template-compiler.ts
+++ b/packages/jsx/src/dom-render/template-compiler.ts
@@ -9,9 +9,7 @@ import type {
 	BindingDescriptor,
 	ChildTemplatePart,
 	CompiledTemplate,
-	DeferredPropertyBinding,
 	LiveTemplatePart,
-	TemplateInstance,
 	TemplatePart,
 } from './types.ts';
 

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -8,6 +8,7 @@ export {
 	jsxDEV,
 	jsxs,
 	createSubscribableJsxValue,
+	mapSubscribable,
 	type JsxFragment,
 	isKeyedJsxValue,
 	isSlotJsxValue,
@@ -43,5 +44,6 @@ export type {
 	StylePropertyValue,
 	StyleValue,
 	SubscribableJsxValue,
+	SubscribableJsxValueWithAccess,
 	TemplateResultLike,
 } from './types.ts';

--- a/packages/jsx/src/jsx-runtime.ts
+++ b/packages/jsx/src/jsx-runtime.ts
@@ -1,11 +1,14 @@
 import { createJsxElement, createMarkupNodeLike, fragmentSymbol, type JsxFragment } from './jsx-factory.ts';
-import { SUBSCRIBABLE_JSX_VALUE_SYMBOL, SLOT_JSX_VALUE_SYMBOL } from './types.ts';
+import { isSubscribableJsxValue } from './renderable-guards.ts';
+import { SLOT_JSX_VALUE_SYMBOL, SUBSCRIBABLE_JSX_VALUE_SYMBOL } from './types.ts';
 import type {
 	JsxComponent,
 	JsxCustomIntrinsicElements,
 	JsxIntrinsicAttributes,
 	JsxRenderable,
+	SignalLike,
 	SubscribableJsxValue,
+	SubscribableJsxValueWithAccess,
 	SlotJsxValue,
 } from './types.ts';
 
@@ -48,6 +51,7 @@ export type {
 	StylePropertyValue,
 	StyleValue,
 	SubscribableJsxValue,
+	SubscribableJsxValueWithAccess,
 	TemplateResultLike,
 } from './types.ts';
 
@@ -125,18 +129,99 @@ export function isSlotJsxValue(value: unknown): value is SlotJsxValue {
 	return typeof value === 'object' && value !== null && SLOT_JSX_VALUE_SYMBOL in value;
 }
 
+type MapSource<Value extends JsxRenderable> = SubscribableJsxValue<Value> | SignalLike<Value>;
+
+type MappableSubscribable<Value extends JsxRenderable> = SubscribableJsxValue<Value>;
+
+function readMapSourceValue<Value extends JsxRenderable>(source: MapSource<Value>): Value {
+	if (isSubscribableJsxValue(source)) {
+		return source.getValue();
+	}
+
+	return source.get();
+}
+
+function createDerivedSubscribable<Value extends JsxRenderable, Out extends JsxRenderable>(
+	source: MapSource<Value>,
+	project: (value: Value) => Out,
+): MappableSubscribable<Out> {
+	return {
+		[SUBSCRIBABLE_JSX_VALUE_SYMBOL]: true,
+		getValue: () => project(readMapSourceValue(source)),
+		subscribe: (notify) => source.subscribe((value) => notify(project(value))),
+		map: <Out2 extends JsxRenderable>(project2: (value: Out) => Out2) =>
+			mapSubscribable(source, (value) => project2(project(value))),
+	};
+}
+
+/**
+ * Derives a new {@link SubscribableJsxValue} by projecting `source` through `project`.
+ *
+ * The returned binding reuses the source's `getValue`/`subscribe` contract, so live updates
+ * flow from the source and SSR/hydration transparency is inherited for free. It is the
+ * standalone twin of {@link SubscribableJsxValue.map} and additionally accepts a `SignalLike`.
+ *
+ * Create the derived binding once (e.g. a host field) rather than inside `render()`, because the
+ * live-subscription fast path keys on source identity.
+ *
+ * @param source The reactive source to derive from (`SubscribableJsxValue` or `SignalLike`).
+ * @param project Projects the current source value into the derived value.
+ * @returns A derived {@link SubscribableJsxValue} with the same mount semantics as any other.
+ */
+export function mapSubscribable<Value extends JsxRenderable, Out extends JsxRenderable>(
+	source: MapSource<Value>,
+	project: (value: Value) => Out,
+): SubscribableJsxValueWithAccess<Out> {
+	return makeMemberAccessProxy(createDerivedSubscribable(source, project));
+}
+
+/**
+ * Get-trap that forwards the core contract (`getValue`/`subscribe`/`map`) and turns unknown
+ * string keys on object-like values into derived bindings (`value.key` ===
+ * `value.map(v => v[key])`), memoized per key.
+ *
+ * Bracket keys and method calls are intentionally not covered — use `map` for those.
+ */
+function makeMemberAccessProxy<Value extends JsxRenderable>(
+	base: MappableSubscribable<Value>,
+): SubscribableJsxValueWithAccess<Value> {
+	const memberCache = new Map<string, SubscribableJsxValueWithAccess<JsxRenderable>>();
+	const handler: ProxyHandler<MappableSubscribable<Value>> = {
+		get(target, key, receiver) {
+			if (typeof key === 'symbol') {
+				return Reflect.get(target, key, receiver);
+			}
+			if (Reflect.has(target, key)) {
+				return Reflect.get(target, key, receiver);
+			}
+			let derived = memberCache.get(key);
+			if (!derived) {
+				derived = target.map((value) => (value as unknown as Record<string, unknown>)[key] as JsxRenderable);
+				memberCache.set(key, derived);
+			}
+			return derived;
+		},
+	};
+	return new Proxy(base, handler) as SubscribableJsxValueWithAccess<Value>;
+}
+
 /**
  * Creates a subscribable JSX child value.
+ *
+ * The returned value is wrapped in a Proxy so object-like bindings expose ergonomic
+ * member access (`this.$.config.label`). Each member access delegates to `map`.
  */
 export function createSubscribableJsxValue<Value extends JsxRenderable>(config: {
 	getValue: () => Value;
 	subscribe: (notify: (value: Value) => void) => () => void;
-}): SubscribableJsxValue<Value> {
-	return {
+}): SubscribableJsxValueWithAccess<Value> {
+	const subscribable: MappableSubscribable<Value> = {
 		[SUBSCRIBABLE_JSX_VALUE_SYMBOL]: true,
 		getValue: config.getValue,
 		subscribe: config.subscribe,
+		map: (project) => mapSubscribable(subscribable, project),
 	};
+	return makeMemberAccessProxy(subscribable);
 }
 
 export { createMarkupNodeLike };

--- a/packages/jsx/src/renderable-types.ts
+++ b/packages/jsx/src/renderable-types.ts
@@ -89,7 +89,36 @@ export interface SubscribableJsxValue<Value extends JsxRenderable = JsxRenderabl
 	readonly [SUBSCRIBABLE_JSX_VALUE_SYMBOL]: true;
 	getValue: () => Value;
 	subscribe: (notify: (value: Value) => void) => () => void;
+	/**
+	 * Projects the current value through `project` into a new derived binding.
+	 *
+	 * The returned binding keeps the same `getValue`/`subscribe`/`SUBSCRIBABLE_JSX_VALUE_SYMBOL`
+	 * contract, so it mounts through the existing reactive child/attribute engines with no
+	 * special-casing. Because the result is itself a `SubscribableJsxValue`, derivations can be
+	 * chained (`.map(a).map(b)`). Create the derived binding once (e.g. a host field) rather than
+	 * inside `render()`, because the live-subscription fast path keys on source identity.
+	 */
+	map<Out extends JsxRenderable>(project: (value: Value) => Out): SubscribableJsxValueWithAccess<Out>;
 }
+
+/**
+ * Maps a binding value to a subscribable per member key. For object-like values
+ * this is the type behind ergonomic member access (`value.key`); the runtime
+ * Proxy in `createSubscribableJsxValue` provides the matching behavior.
+ */
+type SubscribableMemberAccess<Value> = Value extends object
+	? {
+			readonly [K in keyof Value]: SubscribableJsxValue<Extract<Value[K], JsxRenderable>>;
+		}
+	: Record<string, never>;
+
+/**
+ * `SubscribableJsxValue` enriched with ergonomic per-key member access
+ * (`value.key`) for object-like values. Returned by `createSubscribableJsxValue`
+ * and `mapSubscribable`; the runtime Proxy provides the matching behavior.
+ */
+export type SubscribableJsxValueWithAccess<Value extends JsxRenderable = JsxRenderable> = SubscribableJsxValue<Value> &
+	SubscribableMemberAccess<Value>;
 
 /**
  * Internal placeholder emitted from literal `<slot>` JSX tags.

--- a/packages/jsx/test/dom-render-reconciliation.test.tsx
+++ b/packages/jsx/test/dom-render-reconciliation.test.tsx
@@ -1285,4 +1285,268 @@ describe('Radiant JSX DOM reconciliation behavior', () => {
 		}).not.toThrow();
 		expect((container.querySelector('input') as HTMLInputElement | null)?.checked).toBe(true);
 	});
+
+	test('map derives a record lookup and patches only the text node without rerendering', async () => {
+		const [{ createSubscribableJsxValue, jsxs }, { createRoot }] = await Promise.all([
+			loadJsxRuntime(),
+			loadJsxModule(),
+		]);
+		const container = document.createElement('div');
+		const root = createRoot(container);
+		const THEME_CONFIG = {
+			light: { label: 'Light', icon: 'sun' },
+			dark: { label: 'Dark', icon: 'moon' },
+		} as const;
+		type ThemeKey = keyof typeof THEME_CONFIG;
+		const subscribers = new Set<(value: ThemeKey) => void>();
+		let preference: ThemeKey = 'light';
+		const boundPreference = createSubscribableJsxValue({
+			getValue: () => preference,
+			subscribe: (notify) => {
+				subscribers.add(notify);
+				return () => {
+					subscribers.delete(notify);
+				};
+			},
+		});
+		const themeLabel = boundPreference.map((p) => THEME_CONFIG[p].label);
+
+		root.render(jsxs('p', { children: ['Theme: ', themeLabel] }));
+		expect(container.innerHTML).toBe('<p>Theme: Light</p>');
+
+		const mutations: MutationRecord[] = [];
+		const observer = new MutationObserver((records) => {
+			mutations.push(...records);
+		});
+
+		observer.observe(container, {
+			characterData: true,
+			characterDataOldValue: true,
+			childList: true,
+			subtree: true,
+		});
+
+		preference = 'dark';
+
+		for (const subscriber of subscribers) {
+			subscriber(preference);
+		}
+
+		await Promise.resolve();
+		observer.disconnect();
+
+		expect(container.innerHTML).toBe('<p>Theme: Dark</p>');
+		expect(mutations.filter((mutation) => mutation.type === 'childList')).toHaveLength(0);
+		expect(mutations.filter((mutation) => mutation.type === 'characterData')).toHaveLength(1);
+		expect(mutations.find((mutation) => mutation.type === 'characterData')?.oldValue).toBe('Light');
+	});
+
+	test('map projects an object prop key and patches on whole-object replacement', async () => {
+		const [{ createSubscribableJsxValue, jsxs }, { createRoot }] = await Promise.all([
+			loadJsxRuntime(),
+			loadJsxModule(),
+		]);
+		const container = document.createElement('div');
+		const root = createRoot(container);
+		type ConfigValue = { label: string };
+		const subscribers = new Set<(value: import('../src/jsx-runtime.ts').JsxRenderable) => void>();
+		let config: unknown = { label: 'Hello' };
+		const boundConfig = createSubscribableJsxValue<import('../src/jsx-runtime.ts').JsxRenderable>({
+			getValue: () => config as import('../src/jsx-runtime.ts').JsxRenderable,
+			subscribe: (notify) => {
+				subscribers.add(notify);
+				return () => {
+					subscribers.delete(notify);
+				};
+			},
+		});
+		const configLabel = boundConfig.map((c) => (c as unknown as ConfigValue).label);
+
+		root.render(jsxs('p', { children: ['Config: ', configLabel] }));
+		expect(container.innerHTML).toBe('<p>Config: Hello</p>');
+
+		const mutations: MutationRecord[] = [];
+		const observer = new MutationObserver((records) => {
+			mutations.push(...records);
+		});
+
+		observer.observe(container, {
+			characterData: true,
+			characterDataOldValue: true,
+			childList: true,
+			subtree: true,
+		});
+
+		config = { label: 'Next' };
+
+		for (const subscriber of subscribers) {
+			subscriber(config as import('../src/jsx-runtime.ts').JsxRenderable);
+		}
+
+		await Promise.resolve();
+		observer.disconnect();
+
+		expect(container.innerHTML).toBe('<p>Config: Next</p>');
+		expect(mutations.filter((mutation) => mutation.type === 'childList')).toHaveLength(0);
+		expect(mutations.filter((mutation) => mutation.type === 'characterData')).toHaveLength(1);
+		expect(mutations.find((mutation) => mutation.type === 'characterData')?.oldValue).toBe('Hello');
+	});
+
+	test('mapSubscribable derives over a signal-like source and patches in place', async () => {
+		const [{ jsxs, mapSubscribable }, { createRoot }] = await Promise.all([loadJsxRuntime(), loadJsxModule()]);
+		const container = document.createElement('div');
+		const root = createRoot(container);
+		const subscribers = new Set<(value: number) => void>();
+		let count = 3;
+		const countSignal = {
+			get: () => count,
+			subscribe: (notify: (value: number) => void) => {
+				subscribers.add(notify);
+				return () => {
+					subscribers.delete(notify);
+				};
+			},
+		};
+		const doubled = mapSubscribable(countSignal, (value) => value * 2);
+
+		root.render(jsxs('p', { children: ['Double: ', doubled] }));
+		expect(container.innerHTML).toBe('<p>Double: 6</p>');
+
+		count = 5;
+
+		for (const subscriber of subscribers) {
+			subscriber(count);
+		}
+
+		await Promise.resolve();
+		expect(container.innerHTML).toBe('<p>Double: 10</p>');
+	});
+
+	test('a derived binding created once reuses its live subscription across re-renders', async () => {
+		const [{ createSubscribableJsxValue, jsxs }, { createRoot }] = await Promise.all([
+			loadJsxRuntime(),
+			loadJsxModule(),
+		]);
+		const container = document.createElement('div');
+		const root = createRoot(container);
+		let subscribeCount = 0;
+		let unsubscribeCount = 0;
+		const subscribers = new Set<(value: number) => void>();
+		let count = 1;
+		const boundCount = createSubscribableJsxValue({
+			getValue: () => count,
+			subscribe: (notify) => {
+				subscribeCount += 1;
+				subscribers.add(notify);
+				return () => {
+					unsubscribeCount += 1;
+					subscribers.delete(notify);
+				};
+			},
+		});
+		const doubled = boundCount.map((value) => value * 2);
+
+		const render = () => root.render(jsxs('p', { children: ['Double: ', doubled] }));
+		render();
+		expect(container.innerHTML).toBe('<p>Double: 2</p>');
+		render();
+		expect(container.innerHTML).toBe('<p>Double: 2</p>');
+		expect(subscribeCount).toBe(1);
+		expect(unsubscribeCount).toBe(0);
+
+		count = 4;
+
+		for (const subscriber of subscribers) {
+			subscriber(count);
+		}
+
+		await Promise.resolve();
+		expect(container.innerHTML).toBe('<p>Double: 8</p>');
+	});
+
+	test('proxy member access derives an object prop and patches on whole-object replacement', async () => {
+		const [{ createSubscribableJsxValue, jsxs }, { createRoot }] = await Promise.all([
+			loadJsxRuntime(),
+			loadJsxModule(),
+		]);
+		const container = document.createElement('div');
+		const root = createRoot(container);
+		type ConfigValue = { label: string };
+		const subscribers = new Set<(value: import('../src/jsx-runtime.ts').JsxRenderable) => void>();
+		let config: unknown = { label: 'Hello' };
+		const boundConfig = createSubscribableJsxValue<import('../src/jsx-runtime.ts').JsxRenderable>({
+			getValue: () => config as import('../src/jsx-runtime.ts').JsxRenderable,
+			subscribe: (notify) => {
+				subscribers.add(notify);
+				return () => {
+					subscribers.delete(notify);
+				};
+			},
+		});
+		const configLabel = (boundConfig as unknown as ConfigValue).label;
+
+		root.render(jsxs('p', { children: ['Config: ', configLabel] }));
+		expect(container.innerHTML).toBe('<p>Config: Hello</p>');
+
+		const mutations: MutationRecord[] = [];
+		const observer = new MutationObserver((records) => {
+			mutations.push(...records);
+		});
+
+		observer.observe(container, {
+			characterData: true,
+			characterDataOldValue: true,
+			childList: true,
+			subtree: true,
+		});
+
+		config = { label: 'Next' };
+
+		for (const subscriber of subscribers) {
+			subscriber(config as import('../src/jsx-runtime.ts').JsxRenderable);
+		}
+
+		await Promise.resolve();
+		observer.disconnect();
+
+		expect(container.innerHTML).toBe('<p>Config: Next</p>');
+		expect(mutations.filter((mutation) => mutation.type === 'childList')).toHaveLength(0);
+		expect(mutations.filter((mutation) => mutation.type === 'characterData')).toHaveLength(1);
+		expect(mutations.find((mutation) => mutation.type === 'characterData')?.oldValue).toBe('Hello');
+	});
+
+	test('proxy member access supports chained keys via repeated map delegation', async () => {
+		const [{ createSubscribableJsxValue, jsxs }, { createRoot }] = await Promise.all([
+			loadJsxRuntime(),
+			loadJsxModule(),
+		]);
+		const container = document.createElement('div');
+		const root = createRoot(container);
+		type ThemeValue = { label: string };
+		type ConfigValue = { theme: ThemeValue };
+		const subscribers = new Set<(value: import('../src/jsx-runtime.ts').JsxRenderable) => void>();
+		let config: unknown = { theme: { label: 'Hello' } };
+		const boundConfig = createSubscribableJsxValue<import('../src/jsx-runtime.ts').JsxRenderable>({
+			getValue: () => config as import('../src/jsx-runtime.ts').JsxRenderable,
+			subscribe: (notify) => {
+				subscribers.add(notify);
+				return () => {
+					subscribers.delete(notify);
+				};
+			},
+		});
+		const themeLabel = (boundConfig as unknown as ConfigValue).theme.label;
+
+		root.render(jsxs('p', { children: ['Theme: ', themeLabel] }));
+		expect(container.innerHTML).toBe('<p>Theme: Hello</p>');
+
+		config = { theme: { label: 'Next' } };
+
+		for (const subscriber of subscribers) {
+			subscriber(config as import('../src/jsx-runtime.ts').JsxRenderable);
+		}
+
+		await Promise.resolve();
+		expect(container.innerHTML).toBe('<p>Theme: Next</p>');
+	});
 });

--- a/packages/jsx/test/server-render.test.tsx
+++ b/packages/jsx/test/server-render.test.tsx
@@ -362,7 +362,10 @@ describe('Radiant JSX server render', () => {
 	});
 
 	test('serializes mapSubscribable derived signal values from their projected value', async () => {
-		const [{ jsx, mapSubscribable }, { renderToString }] = await Promise.all([loadJsxRuntime(), loadServerRender()]);
+		const [{ jsx, mapSubscribable }, { renderToString }] = await Promise.all([
+			loadJsxRuntime(),
+			loadServerRender(),
+		]);
 		let count = 3;
 		const countSignal = {
 			get: () => count,

--- a/packages/jsx/test/server-render.test.tsx
+++ b/packages/jsx/test/server-render.test.tsx
@@ -335,6 +335,50 @@ describe('Radiant JSX server render', () => {
 		expect(renderToString(template)).toBe('<p class="component-metric">Count: 12</p>');
 	});
 
+	test('serializes mapped derived JSX child values from their projected value', async () => {
+		const [{ createSubscribableJsxValue, jsx, mapSubscribable }, { renderToString }] = await Promise.all([
+			loadJsxRuntime(),
+			loadServerRender(),
+		]);
+		const THEME_CONFIG = {
+			light: { label: 'Light', icon: 'sun' },
+			dark: { label: 'Dark', icon: 'moon' },
+		} as const;
+		type ThemeKey = keyof typeof THEME_CONFIG;
+		let preference: ThemeKey = 'light';
+		const boundPreference = createSubscribableJsxValue({
+			getValue: () => preference,
+			subscribe: () => () => undefined,
+		});
+		const themeLabel = boundPreference.map((p) => THEME_CONFIG[p].label);
+		const template = jsx('p', {
+			children: ['Theme: ', themeLabel],
+		});
+
+		expect(renderToString(template)).toBe('<p>Theme: Light</p>');
+
+		preference = 'dark';
+		expect(renderToString(template)).toBe('<p>Theme: Dark</p>');
+	});
+
+	test('serializes mapSubscribable derived signal values from their projected value', async () => {
+		const [{ jsx, mapSubscribable }, { renderToString }] = await Promise.all([loadJsxRuntime(), loadServerRender()]);
+		let count = 3;
+		const countSignal = {
+			get: () => count,
+			subscribe: () => () => undefined,
+		};
+		const doubled = mapSubscribable(countSignal, (value) => value * 2);
+		const template = jsx('p', {
+			children: ['Double: ', doubled],
+		});
+
+		expect(renderToString(template)).toBe('<p>Double: 6</p>');
+
+		count = 5;
+		expect(renderToString(template)).toBe('<p>Double: 10</p>');
+	});
+
 	test('serializes signal-like attribute values from their current value', async () => {
 		const [{ jsx }, { renderToString }] = await Promise.all([loadJsxRuntime(), loadServerRender()]);
 		let status = 'idle';

--- a/packages/jsx/test/server-render.test.tsx
+++ b/packages/jsx/test/server-render.test.tsx
@@ -336,7 +336,7 @@ describe('Radiant JSX server render', () => {
 	});
 
 	test('serializes mapped derived JSX child values from their projected value', async () => {
-		const [{ createSubscribableJsxValue, jsx, mapSubscribable }, { renderToString }] = await Promise.all([
+		const [{ createSubscribableJsxValue, jsx }, { renderToString }] = await Promise.all([
 			loadJsxRuntime(),
 			loadServerRender(),
 		]);

--- a/packages/radiant/size-budget.json
+++ b/packages/radiant/size-budget.json
@@ -4,8 +4,8 @@
 			"control": "strict",
 			"label": "root-client-surface",
 			"entrypoint": "./src/index.ts",
-			"maxBytes": 47104,
-			"maxGzipBytes": 12800
+			"maxBytes": 49152,
+			"maxGzipBytes": 13312
 		},
 		{
 			"control": "advisory",

--- a/packages/radiant/src/context/decorators/standard-legacy-dispatch.ts
+++ b/packages/radiant/src/context/decorators/standard-legacy-dispatch.ts
@@ -5,8 +5,14 @@ import type { ContextHostLike } from '../context-host';
  * Dispatches context selector decorators to standard or legacy implementations.
  */
 export function dispatchContextSelectorDecorator<Selected>(
-	standardField: (protoOrTarget: undefined, nameOrContext: ClassFieldDecoratorContext<ContextHostLike, Selected>) => unknown,
-	standardMethod: (protoOrTarget: Method, nameOrContext: ClassMethodDecoratorContext<ContextHostLike, (value: Selected) => unknown>) => unknown,
+	standardField: (
+		protoOrTarget: undefined,
+		nameOrContext: ClassFieldDecoratorContext<ContextHostLike, Selected>,
+	) => unknown,
+	standardMethod: (
+		protoOrTarget: Method,
+		nameOrContext: ClassMethodDecoratorContext<ContextHostLike, (value: Selected) => unknown>,
+	) => unknown,
 	legacyField: (protoOrTarget: ContextHostLike, nameOrContext: string) => unknown,
 	legacyMethod: (
 		protoOrTarget: ContextHostLike,
@@ -29,7 +35,10 @@ export function dispatchContextSelectorDecorator<Selected>(
 				throw new TypeError('@contextSelector field decorators require an undefined target');
 			}
 
-			return standardField(undefined, nameOrContext) as (this: ContextHostLike, initialValue: Selected) => Selected;
+			return standardField(undefined, nameOrContext) as (
+				this: ContextHostLike,
+				initialValue: Selected,
+			) => Selected;
 		}
 
 		if (typeof protoOrTarget !== 'function') {
@@ -44,9 +53,9 @@ export function dispatchContextSelectorDecorator<Selected>(
 			throw new TypeError('@contextSelector legacy method decorators require a host target');
 		}
 
-		return legacyMethod(protoOrTarget, nameOrContext, descriptor) as
-			| TypedPropertyDescriptor<(value: Selected) => unknown>
-			| void;
+		return legacyMethod(protoOrTarget, nameOrContext, descriptor) as TypedPropertyDescriptor<
+			(value: Selected) => unknown
+		> | void;
 	}
 
 	if (typeof protoOrTarget === 'function' || protoOrTarget === undefined) {

--- a/packages/radiant/src/core/radiant-controller.ts
+++ b/packages/radiant/src/core/radiant-controller.ts
@@ -2,9 +2,7 @@ import { render as renderJsx, type JsxRenderable, type SubscribableJsxValue } fr
 import { createReactiveComputed, createReactiveWatcher, type ReactiveComputed } from './reactivity-adapter';
 import type { SsrSerializableContextProvider } from '../context/context-provider';
 import type { UnknownContext } from '../context/types';
-import {
-	ensureLegacyHostReady,
-} from '../decorators/legacy/host-readiness';
+import { ensureLegacyHostReady } from '../decorators/legacy/host-readiness';
 import { ReactiveHost, type ReactiveHostLike } from './reactive-host';
 import type {
 	ReactiveBindingOption,

--- a/packages/radiant/src/core/radiant-element.ts
+++ b/packages/radiant/src/core/radiant-element.ts
@@ -24,7 +24,7 @@ import { runSsrPreparationCallbacks } from './ssr-preparation';
 import { isRadiantHydratorInstalled } from './radiant-hydrator-state';
 import { getRadiantElementSsrRuntime } from './radiant-element-ssr-registry';
 import type { InternalRadiantSsrHost } from './radiant-element-ssr-host';
-import { type AttributeTypeConstant, getInitialValue } from '../utils/attribute-utils';
+import { getInitialValue } from '../utils/attribute-utils';
 
 export type {
 	ReactiveBindingOption,

--- a/packages/radiant/src/decorators/legacy/host-readiness.ts
+++ b/packages/radiant/src/decorators/legacy/host-readiness.ts
@@ -1,7 +1,4 @@
-import {
-	runLegacyInstanceInitializers,
-	runLegacyPostConstructionInitializers,
-} from './instance-initializers';
+import { runLegacyInstanceInitializers, runLegacyPostConstructionInitializers } from './instance-initializers';
 
 export type LegacyHostReadinessPhase = 'construct' | 'connect' | 'ssr';
 

--- a/packages/radiant/src/decorators/standard/reactive-field.ts
+++ b/packages/radiant/src/decorators/standard/reactive-field.ts
@@ -8,8 +8,9 @@ export function reactiveField<T extends ReactiveHostLike, V>(_: undefined, conte
 		const initializerValue = (this as Record<PropertyKey, V | undefined>)[initializerValueKey];
 		this.createReactiveField(contextName, initializerValue as V, {
 			bind:
-				(this as unknown as { shouldAutoBindReactiveMembers?: () => boolean }).shouldAutoBindReactiveMembers?.() ??
-				false,
+				(
+					this as unknown as { shouldAutoBindReactiveMembers?: () => boolean }
+				).shouldAutoBindReactiveMembers?.() ?? false,
 			suppressInitialNotify: true,
 		});
 	});

--- a/packages/radiant/src/server/host-attribute-serialization.ts
+++ b/packages/radiant/src/server/host-attribute-serialization.ts
@@ -128,4 +128,3 @@ function appendAuthoredAttributes(host: HostAttributeSource, attributes: Record<
 		}
 	}
 }
-

--- a/packages/radiant/src/server/light-dom-shim.ts
+++ b/packages/radiant/src/server/light-dom-shim.ts
@@ -1,2 +1,6 @@
-export type { LightDomShimWindow, PrepareServerRenderHostOptions, ServerRenderEnvironment } from './minimal-dom/install';
+export type {
+	LightDomShimWindow,
+	PrepareServerRenderHostOptions,
+	ServerRenderEnvironment,
+} from './minimal-dom/install';
 export { createServerRenderEnvironment, ensureLightDomShim, installLightDomShim } from './minimal-dom/install';

--- a/packages/radiant/src/server/minimal-dom/nodes.ts
+++ b/packages/radiant/src/server/minimal-dom/nodes.ts
@@ -236,7 +236,9 @@ export class MinimalElement extends MinimalNode {
 					};
 				},
 				has: (_target, property) => {
-					return typeof property === 'string' && this.hasAttribute(getHtmlModule().toDataAttributeName(property));
+					return (
+						typeof property === 'string' && this.hasAttribute(getHtmlModule().toDataAttributeName(property))
+					);
 				},
 				ownKeys: () => {
 					return this.getAttributeNames()

--- a/packages/radiant/src/server/render-component.ts
+++ b/packages/radiant/src/server/render-component.ts
@@ -19,7 +19,11 @@ import {
 	toRenderedComponentWithPreview,
 } from './render-fragment';
 
-export { createDefaultRenderTimestamp, toRenderedComponentPayload, toRenderedComponentWithPreview } from './render-fragment';
+export {
+	createDefaultRenderTimestamp,
+	toRenderedComponentPayload,
+	toRenderedComponentWithPreview,
+} from './render-fragment';
 
 export type RenderedComponentAsset =
 	| {

--- a/packages/radiant/src/server/render-controller.ts
+++ b/packages/radiant/src/server/render-controller.ts
@@ -342,4 +342,3 @@ function serializeRenderedControllerAttribute(name: string, value: string | null
 
 	return ` ${name}="${escapeHtmlAttribute(value ?? '')}"`;
 }
-

--- a/packages/radiant/src/server/render-fragment.ts
+++ b/packages/radiant/src/server/render-fragment.ts
@@ -1,8 +1,4 @@
-import type {
-	RenderedComponent,
-	RenderedComponentPayload,
-	RenderedComponentWithPreview,
-} from './render-component';
+import type { RenderedComponent, RenderedComponentPayload, RenderedComponentWithPreview } from './render-component';
 
 /** Returns the current time for deterministic SSR metadata in tests. */
 export function createDefaultRenderTimestamp(): Date {

--- a/playground/vite-nitro/src/components/playground-sections.tsx
+++ b/playground/vite-nitro/src/components/playground-sections.tsx
@@ -33,6 +33,7 @@ export function RadiantElementLabSection() {
 			<div class="component-grid">
 				<radiant-counter count={2} label="Kitchen sink counter" />
 				<radiant-event-binding-lab></radiant-event-binding-lab>
+				<radiant-binding-map-lab></radiant-binding-map-lab>
 				<radiant-context-flow-shell></radiant-context-flow-shell>
 				<radiant-signal-release-board></radiant-signal-release-board>
 				<RadiantControllerDecoratorVisualizer />

--- a/playground/vite-nitro/src/components/radiant-binding-map-lab.script.tsx
+++ b/playground/vite-nitro/src/components/radiant-binding-map-lab.script.tsx
@@ -1,0 +1,79 @@
+import type { JsxCustomElementAttributes, SubscribableJsxValue } from '@ecopages/jsx';
+import { RadiantElement, customElement, prop, state } from '@ecopages/radiant';
+import { THEME_CONFIG, type ConfigValue, type ThemeKey } from './radiant-binding-map-lab.templates';
+
+type RadiantBindingMapLabBindings = {
+	config: ConfigValue;
+	preference: ThemeKey;
+};
+
+@customElement('radiant-binding-map-lab')
+export class RadiantBindingMapLab extends RadiantElement<RadiantBindingMapLabBindings> {
+	@state preference: ThemeKey = 'light';
+	@prop({ type: Object, defaultValue: { label: 'Hello' } }) config: ConfigValue = { label: 'Hello' };
+
+	private readonly themeLabel = this.$.preference.map((preference) => THEME_CONFIG[preference].label);
+	private readonly themeIcon = this.$.preference.map((preference) => THEME_CONFIG[preference].icon);
+	private readonly configLabelViaMap = this.$.config.map((config) => (config as unknown as ConfigValue).label);
+
+	private readonly togglePreference = () => {
+		this.preference = this.preference === 'light' ? 'dark' : 'light';
+	};
+
+	private readonly replaceConfig = () => {
+		const nextLabel = this.config.label === 'Hello' ? 'Next' : 'Hello';
+		this.config = { label: nextLabel };
+	};
+
+	override render() {
+		return (
+			<section class="component-card component-card--bindings">
+				<p class="component-tag">Derived bindings</p>
+				<h3>Binding map lab</h3>
+				<p class="component-copy">
+					Hoist <code>map</code> transforms to field initializers. Member access for object keys can be
+					written inline in <code>render()</code> — the runtime caches each key on the binding.
+				</p>
+				<div class="binding-lab__layout">
+					<section class="binding-lab__lane">
+						<p class="component-meta">Record lookup via map</p>
+						<p class="component-metric" data-ref="binding-theme-label">
+							Theme label: {this.themeLabel}
+						</p>
+						<p class="component-copy" data-ref="binding-theme-icon">
+							Theme icon: {this.themeIcon}
+						</p>
+						<p class="component-copy">
+							Source: <code>this.$.preference.map((p) =&gt; THEME_CONFIG[p].label)</code>
+						</p>
+						<button type="button" on:click={this.togglePreference}>
+							Toggle preference
+						</button>
+					</section>
+					<section class="binding-lab__lane">
+						<p class="component-meta">Object prop projection</p>
+						<p class="component-metric" data-ref="binding-config-map">
+							Config (map): {this.configLabelViaMap}
+						</p>
+						<p class="component-metric" data-ref="binding-config-member">
+							Config (member):{' '}
+							{(this.$.config as unknown as { label: SubscribableJsxValue<string> }).label}
+						</p>
+						<p class="component-copy">
+							Inline member access — equivalent to <code>map</code>, memoized per key.
+						</p>
+						<button type="button" on:click={this.replaceConfig}>
+							Replace config object
+						</button>
+					</section>
+				</div>
+			</section>
+		);
+	}
+}
+
+declare module '@ecopages/jsx/jsx-runtime' {
+	interface JsxCustomIntrinsicElements {
+		'radiant-binding-map-lab': JsxCustomElementAttributes<HTMLElement, Record<never, never>>;
+	}
+}

--- a/playground/vite-nitro/src/components/radiant-binding-map-lab.templates.tsx
+++ b/playground/vite-nitro/src/components/radiant-binding-map-lab.templates.tsx
@@ -1,0 +1,10 @@
+export const THEME_CONFIG = {
+	light: { label: 'Light', icon: 'sun' },
+	dark: { label: 'Dark', icon: 'moon' },
+} as const;
+
+export type ThemeKey = keyof typeof THEME_CONFIG;
+
+export type ConfigValue = {
+	label: string;
+};

--- a/playground/vite-nitro/src/style.css
+++ b/playground/vite-nitro/src/style.css
@@ -335,6 +335,31 @@ strong {
 	background: rgb(241 245 249 / 0.82);
 }
 
+.component-card--bindings {
+	background:
+		radial-gradient(circle at top left, rgb(99 102 241 / 0.14), transparent 28%),
+		radial-gradient(circle at bottom right, rgb(236 72 153 / 0.1), transparent 32%),
+		linear-gradient(180deg, #fdfaff 0%, #f8fafc 100%);
+}
+
+.binding-lab__layout {
+	display: grid;
+	gap: 1rem;
+	margin-top: 1rem;
+}
+
+.binding-lab__lane {
+	padding: 1rem;
+	border-radius: 14px;
+	border: 1px solid #dbe5f0;
+	background: rgb(255 255 255 / 0.84);
+	backdrop-filter: blur(10px);
+}
+
+.binding-lab__lane p {
+	margin: 0.4rem 0;
+}
+
 .signal-story__toolbar {
 	display: flex;
 	flex-wrap: wrap;


### PR DESCRIPTION
## Summary

- Add `mapSubscribable` and `SubscribableJsxValue.map()` so reactive bindings can be transformed (record lookup, key projection) without losing in-place DOM updates
- Add proxy member access on bindings (`this.$.config.label`) as sugar over `map`, with per-key memoization for identity-stable derived bindings
- Cover DOM reconciliation, SSR serialization, playground lab, and docs — including guidance that member access is fine inline in `render()`, but `.map()` transforms should be hoisted to field initializers

## Test plan

- [x] `bun test packages/jsx` — reconciliation tests for `map`, identity stability, proxy member access, chained keys
- [x] SSR tests for mapped derived JSX child values
- [x] `bun run size:check` — root client budget rebaselined (13 KB gzip)
- [x] Manual: open playground binding-map lab and verify record lookup + member access lanes update in place
- [x] Manual: confirm `this.$.config.map(c => c.label)` hoisted on a field updates when the whole object is replaced