### PR TITLE
refactor(jsx): centralize hydration marker index contract

### DIFF
--- a/packages/jsx/README.md
+++ b/packages/jsx/README.md
@@ -380,11 +380,11 @@ Hydrated SSR adds binding markers so `hydrate(...)` can attach listeners and dyn
 
 `hydrate(...)` chooses one of three recovery paths based on the JSX root shape:
 
-| Root shape | Recovery path | Notes |
-|------------|---------------|-------|
-| Single template (`<section>...</section>`) | Template hydration | Reconnects attribute and child parts in place |
-| Iterable / fragment (`<>...</>`) | Iterable hydration | Hydrates each single-root template child against its DOM slice |
-| Other values with markers | Flat marker scan | Reconnects attribute bindings only |
+| Root shape                                 | Recovery path      | Notes                                                          |
+| ------------------------------------------ | ------------------ | -------------------------------------------------------------- |
+| Single template (`<section>...</section>`) | Template hydration | Reconnects attribute and child parts in place                  |
+| Iterable / fragment (`<>...</>`)           | Iterable hydration | Hydrates each single-root template child against its DOM slice |
+| Other values with markers                  | Flat marker scan   | Reconnects attribute bindings only                             |
 
 Iterable fragment hydration supports flat lists of intrinsic template children (for example `<> <button/> <span/> </>`), including subscribable child bindings inside those templates. Nested fragments, bare reactive children at the fragment root, and DOM/script child mismatches fall back to a full client render.
 

--- a/packages/jsx/README.md
+++ b/packages/jsx/README.md
@@ -390,6 +390,81 @@ Iterable fragment hydration supports flat lists of intrinsic template children (
 
 Global SSR marker indexes are shared across all three paths via the binding collection helpers in `hydration-bindings.ts`, so fragment children resolve `data-radiant-jsx-bind-*` attributes against the same namespace used by `renderToString(..., { mode: 'hydrate' })`.
 
+### SSR Marker Lifecycle
+
+Hydration markers are not ad hoc attributes. They are one shared index namespace that connects server serialization to client recovery.
+
+```mermaid
+flowchart TD
+  JSX["JSX view"] --> Serialize["renderToString({ mode: 'hydrate' })"]
+  Serialize --> Markers["data-radiant-jsx-bind-N descriptors"]
+  Markers --> DOM["SSR DOM in the page"]
+  DOM --> Dispatch["hydrate(value, target)"]
+  Dispatch --> Path{"Root shape?"}
+  Path -->|single template| Template["hydrateTemplateInstance"]
+  Path -->|fragment / iterable| Iterable["hydrateIterableRoot"]
+  Path -->|leftover markers| Flat["visitHydrationBindingMarkers"]
+  Template --> Live["Live template parts + subscriptions"]
+  Iterable --> Live
+  Flat --> Attrs["Attribute bindings only"]
+```
+
+**1. Serialize.** `serializeRenderable(...)` walks the JSX tree depth-first. Each attribute interpolation that needs a marker calls `takeNextHydrationMarkerIndex(...)` and writes `data-radiant-jsx-bind-N="kind:name"` through `resolveHydrationMarkerAttributeName(...)`.
+
+**2. Index contract.** `hydration-bindings.ts` owns the marker prefix, descriptor format, index advancement, and DOM walks. Iterable hydration uses `collectTemplateAttributeMarkerIndices(...)` per single-root child so fragment siblings stay aligned with the same global namespace.
+
+**3. Recover.** `hydrate(...)` picks a recovery path from the root shape. Template and iterable paths rebuild live parts in place. Unsupported shapes, or DOM/script mismatches, return a recoverable mismatch and fall back to a full client render.
+
+**Counter-shaped fragment example:**
+
+```tsx
+/** @jsxImportSource @ecopages/jsx */
+import { createSubscribableJsxValue, Fragment, jsx, jsxs } from '@ecopages/jsx';
+import { renderToString } from '@ecopages/jsx/server';
+import { createRoot } from '@ecopages/jsx';
+
+let count = 0;
+
+const boundCount = createSubscribableJsxValue({
+	getValue: () => count,
+	subscribe: (notify) => {
+		/* store + call notify(count) on updates */
+	},
+});
+
+const view = () =>
+	jsxs(Fragment, {
+		children: [
+			jsx('button', { id: 'dec', children: '-' }),
+			jsx('span', { id: 'metric', children: boundCount }),
+			jsx('button', { id: 'inc', children: '+' }),
+		],
+	});
+
+// SSR: one global namespace, allocated depth-first across fragment siblings.
+const html = renderToString(view(), { mode: 'hydrate' });
+
+// Client: iterable hydration reconnects each child template against its DOM slice,
+// including subscribable child text inside <span> without rerendering the fragment root.
+const container = document.querySelector('#counter')!;
+container.innerHTML = html;
+createRoot(container).hydrate(view());
+```
+
+For that fragment, attribute markers are allocated like this:
+
+| Global index | Template child | Binding |
+| ------------ | -------------- | ------- |
+| `0` | `<button id="dec">` | `attr:id` |
+| `1` | `<span id="metric">` | `attr:id` |
+| `2` | `<button id="inc">` | `attr:id` |
+
+Iterable hydration resolves each child with `collectTemplateAttributeMarkerIndices(child, startIndex)` so sibling templates reuse the same numbering that `renderToString(..., { mode: 'hydrate' })` wrote into the HTML.
+
+Attribute markers cover dynamic attributes and listeners. Subscribable child text such as `{boundCount}` does not use `data-radiant-jsx-bind-*`; template compilation places comment markers around the child range, and iterable hydration reconnects those ranges during `hydrateTemplateInstance(...)`.
+
+Nested custom-element hosts fork a fresh binding namespace during SSR so each host hydrates independently. See `withServerHydrationBindingState(...)` and framework bridges such as Radiant's element SSR hook.
+
 ### SSR-Capable Custom Elements
 
 Within the JSX SSR pipeline, any registered intrinsic tag containing `-` is treated as a custom-element candidate.

--- a/packages/jsx/README.md
+++ b/packages/jsx/README.md
@@ -376,6 +376,20 @@ const hydratedHtml = renderToString(view, { mode: 'hydrate' });
 
 Hydrated SSR adds binding markers so `hydrate(...)` can attach listeners and dynamic parts without rebuilding the existing DOM tree.
 
+### Hydration Root Shapes
+
+`hydrate(...)` chooses one of three recovery paths based on the JSX root shape:
+
+| Root shape | Recovery path | Notes |
+|------------|---------------|-------|
+| Single template (`<section>...</section>`) | Template hydration | Reconnects attribute and child parts in place |
+| Iterable / fragment (`<>...</>`) | Iterable hydration | Hydrates each single-root template child against its DOM slice |
+| Other values with markers | Flat marker scan | Reconnects attribute bindings only |
+
+Iterable fragment hydration supports flat lists of intrinsic template children (for example `<> <button/> <span/> </>`), including subscribable child bindings inside those templates. Nested fragments, bare reactive children at the fragment root, and DOM/script child mismatches fall back to a full client render.
+
+Global SSR marker indexes are shared across all three paths via the binding collection helpers in `hydration-bindings.ts`, so fragment children resolve `data-radiant-jsx-bind-*` attributes against the same namespace used by `renderToString(..., { mode: 'hydrate' })`.
+
 ### SSR-Capable Custom Elements
 
 Within the JSX SSR pipeline, any registered intrinsic tag containing `-` is treated as a custom-element candidate.

--- a/packages/jsx/src/dom-render.ts
+++ b/packages/jsx/src/dom-render.ts
@@ -1,6 +1,10 @@
 import { type JsxRenderable, type TemplateResultLike } from './jsx-runtime.ts';
-import { ATTRIBUTE_BINDING_PREFIX, collectHydrationBindings, parseBindingDescriptor } from './hydration-bindings.ts';
-import { shouldSkipHydrationSubtree } from './hydration-subtree-policy.ts';
+import {
+	ATTRIBUTE_BINDING_PREFIX,
+	collectHydrationBindings,
+	parseBindingDescriptor,
+	visitHydrationBindingMarkers,
+} from './hydration-bindings.ts';
 import {
 	HYDRATION_INVALID_BINDING_INDEX_WARNING,
 	HYDRATION_MALFORMED_BINDING_DESCRIPTOR_WARNING,
@@ -68,7 +72,6 @@ type IterableHydrationOutcome =
 	| {
 			deferredProperties: DeferredPropertyBinding[];
 			focusSnapshot: ReturnType<typeof captureFocusSnapshot>;
-			instances: readonly TemplateInstance[];
 			kind: 'safe-reconnect';
 	  }
 	| {
@@ -208,16 +211,14 @@ function attemptIterableHydration(value: Iterable<unknown>, target: HTMLElement)
 
 	const focusSnapshot = captureFocusSnapshot(target);
 	const deferredProperties: DeferredPropertyBinding[] = [];
-	const instances = hydrateIterableRoot(value, target, deferredProperties, { rootTarget: target });
 
-	if (!instances || visitHydrationBindingMarkers(target, () => undefined)) {
+	if (!hydrateIterableRoot(value, target, deferredProperties, { rootTarget: target })) {
 		return { kind: 'recoverable-mismatch' };
 	}
 
 	return {
 		deferredProperties,
 		focusSnapshot,
-		instances,
 		kind: 'safe-reconnect',
 	};
 }
@@ -280,58 +281,6 @@ function attemptFlatHydration(element: JsxRenderable, target: HTMLElement): Flat
  */
 export function hasHydrationMarkers(target: HTMLElement): boolean {
 	return visitHydrationBindingMarkers(target, () => undefined);
-}
-
-/**
- * Walks the subtree rooted at `target` and invokes `visit` for every attribute whose
- * name starts with {@link ATTRIBUTE_BINDING_PREFIX}.
- *
- * Attributes are iterated in reverse index order so that callers may safely call
- * `removeAttribute` inside `visit` without corrupting the live `NamedNodeMap`.
- *
- * @param target Root element to walk.
- * @param visit Callback invoked for each binding marker attribute found.
- * @returns `true` when at least one binding marker was found, `false` otherwise.
- */
-function visitHydrationBindingMarkers(
-	target: HTMLElement,
-	visit: (element: Element, attribute: Attr) => void,
-): boolean {
-	let foundHydrationMarker = false;
-	const walk = (element: Element): void => {
-		const attributes = Array.from(element.attributes).filter((attribute) =>
-			attribute.name.startsWith(ATTRIBUTE_BINDING_PREFIX),
-		);
-
-		for (let index = attributes.length - 1; index >= 0; index -= 1) {
-			const attribute = attributes[index];
-
-			if (!attribute) {
-				continue;
-			}
-
-			foundHydrationMarker = true;
-			visit(element, attribute);
-		}
-
-		if (element !== target && shouldSkipHydrationSubtree(element)) {
-			return;
-		}
-
-		const children = element.children;
-
-		for (let index = 0; index < children.length; index += 1) {
-			const child = children.item(index);
-
-			if (child) {
-				walk(child);
-			}
-		}
-	};
-
-	walk(target);
-
-	return foundHydrationMarker;
 }
 
 /**

--- a/packages/jsx/src/dom-render/hydration-iterable.ts
+++ b/packages/jsx/src/dom-render/hydration-iterable.ts
@@ -1,50 +1,40 @@
-import { needsHydrationMarker } from '../hydration-marker-policy.ts';
-import { getTemplateInterpolationParts } from '../template-shape.ts';
-import type { TemplateResultLike } from '../jsx-runtime.ts';
+import {
+	collectTemplateAttributeMarkerIndices,
+	visitHydrationBindingMarkers,
+} from '../hydration-bindings.ts';
 import { isIterableRenderable, isTemplateResultLike } from '../renderable-guards.ts';
 import { countHydratedRangeNodes } from './hydration-planning.ts';
 import { hydrateTemplateInstance, type HydrateTemplateInstanceOptions } from './hydration.ts';
 import { unwrapKeyedValue } from './runtime-helpers.ts';
-import type { BindingKind } from '../hydration-bindings.ts';
-import type { DeferredPropertyBinding, TemplateInstance } from './types.ts';
+import type { DeferredPropertyBinding } from './types.ts';
 
 function getHydratableChildNodes(target: HTMLElement): readonly ChildNode[] {
 	return Array.from(target.childNodes).filter((node) => !(node instanceof HTMLScriptElement));
 }
 
-function collectTemplateAttributeBindingIndices(
-	template: TemplateResultLike,
-	startIndex: number,
-): { indices: Map<number, number>; nextIndex: number } {
-	const indices = new Map<number, number>();
-	const interpolationParts = getTemplateInterpolationParts(template.strings);
-	let nextIndex = startIndex;
-
-	for (let index = 0; index < template.values.length; index += 1) {
-		const interpolationPart = interpolationParts[index];
-
-		if (interpolationPart?.type === 'attribute' && needsHydrationMarker(interpolationPart.kind as BindingKind)) {
-			indices.set(index, nextIndex);
-			nextIndex += 1;
-		}
-	}
-
-	return { indices, nextIndex };
-}
-
 /**
- * Reconnects every template child inside an iterable JSX root (for example a
- * fragment) against the matching SSR DOM slice on `target`.
+ * Reconnects iterable JSX roots (for example fragments) against existing SSR DOM.
+ *
+ * Supported shapes:
+ * - a flat list of intrinsic template children (`<>...</>` with elements such as
+ *   `<button>`, `<span>`, and other single-root templates)
+ * - static primitive or markup children mixed between templates
+ *
+ * Unsupported shapes fall back to a full client render:
+ * - nested iterable children (fragments inside fragments)
+ * - bare reactive child sources at the fragment root without a wrapping template
+ * - DOM/script child counts that no longer match the JSX child list
+ *
+ * Success requires every expected hydration marker to be removed from `target`.
  */
 export function hydrateIterableRoot(
 	value: Iterable<unknown>,
 	target: HTMLElement,
 	deferredProperties: DeferredPropertyBinding[],
 	options: HydrateTemplateInstanceOptions = {},
-): readonly TemplateInstance[] | undefined {
+): boolean {
 	const jsxChildren = Array.from(value, (child) => unwrapKeyedValue(child));
 	const domChildren = getHydratableChildNodes(target);
-	const instances: TemplateInstance[] = [];
 	let domOffset = 0;
 	let nextBindingIndex = 0;
 
@@ -53,11 +43,11 @@ export function hydrateIterableRoot(
 		const slice = domChildren.slice(domOffset, domOffset + nodeCount);
 
 		if (slice.length !== nodeCount) {
-			return undefined;
+			return false;
 		}
 
 		if (isTemplateResultLike(child)) {
-			const attributeBindingIndices = collectTemplateAttributeBindingIndices(child, nextBindingIndex);
+			const attributeBindingIndices = collectTemplateAttributeMarkerIndices(child, nextBindingIndex);
 			nextBindingIndex = attributeBindingIndices.nextIndex;
 			const instance = hydrateTemplateInstance(child, target, deferredProperties, {
 				...options,
@@ -67,20 +57,18 @@ export function hydrateIterableRoot(
 			});
 
 			if (!instance) {
-				return undefined;
+				return false;
 			}
-
-			instances.push(instance);
 		} else if (isIterableRenderable(child)) {
-			return undefined;
+			return false;
 		}
 
 		domOffset += nodeCount;
 	}
 
 	if (domOffset !== domChildren.length) {
-		return undefined;
+		return false;
 	}
 
-	return instances;
+	return !visitHydrationBindingMarkers(target, () => undefined);
 }

--- a/packages/jsx/src/dom-render/hydration-iterable.ts
+++ b/packages/jsx/src/dom-render/hydration-iterable.ts
@@ -1,7 +1,4 @@
-import {
-	collectTemplateAttributeMarkerIndices,
-	visitHydrationBindingMarkers,
-} from '../hydration-bindings.ts';
+import { collectTemplateAttributeMarkerIndices, visitHydrationBindingMarkers } from '../hydration-bindings.ts';
 import { isIterableRenderable, isTemplateResultLike } from '../renderable-guards.ts';
 import { countHydratedRangeNodes } from './hydration-planning.ts';
 import { hydrateTemplateInstance, type HydrateTemplateInstanceOptions } from './hydration.ts';

--- a/packages/jsx/src/dom-render/hydration.ts
+++ b/packages/jsx/src/dom-render/hydration.ts
@@ -81,6 +81,13 @@ export function hydrateTemplateInstance(
 	return instance;
 }
 
+/**
+ * Maps blueprint-relative paths onto a host slice when hydrating one
+ * single-root template child inside an iterable root.
+ *
+ * Assumes each iterable child template owns one root node at blueprint path
+ * `[0]`; multi-root template children are not supported in iterable hydration.
+ */
 function mapBlueprintPathToHostPath(path: readonly number[], pathRootOffset: number): readonly number[] {
 	if (path.length === 0) {
 		return [pathRootOffset];

--- a/packages/jsx/src/dom-render/hydration.ts
+++ b/packages/jsx/src/dom-render/hydration.ts
@@ -1,5 +1,5 @@
 import type { TemplateResultLike } from '../jsx-runtime.ts';
-import { ATTRIBUTE_BINDING_PREFIX } from '../hydration-bindings.ts';
+import { resolveHydrationMarkerAttributeName } from '../hydration-bindings.ts';
 import { createBoundaryMarker } from './dom-operations.ts';
 import { hydrateMountedRangeContent } from './hydration-mounted-range.ts';
 import { collectHydratedChildRanges, isolateHydratedTextRange, type HydratedChildRange } from './hydration-planning.ts';
@@ -131,10 +131,9 @@ function createHydratedLiveTemplateParts(
 				continue;
 			}
 
-			const markerName =
-				attributeBindingIndices?.get(part.index) === undefined
-					? part.markerName
-					: `${ATTRIBUTE_BINDING_PREFIX}${attributeBindingIndices.get(part.index)}`;
+			const markerName = attributeBindingIndices?.has(part.index)
+				? resolveHydrationMarkerAttributeName(attributeBindingIndices.get(part.index)!)
+				: part.markerName;
 
 			targetNode.removeAttribute(markerName);
 			liveParts.set(partIndex, {

--- a/packages/jsx/src/hydration-bindings.ts
+++ b/packages/jsx/src/hydration-bindings.ts
@@ -65,23 +65,32 @@ export function collectTemplateAttributeMarkerIndices(
 ): TemplateAttributeMarkerIndices {
 	const indices = new Map<number, number>();
 	const interpolationParts = getTemplateInterpolationParts(template.strings);
-	let nextIndex = startIndex;
+	const state = { nextBindingIndex: startIndex };
 
 	for (let index = 0; index < template.values.length; index += 1) {
 		const interpolationPart = interpolationParts[index];
 
 		if (interpolationPart?.type === 'attribute') {
-			indices.set(index, nextIndex);
-			nextIndex += 1;
+			indices.set(index, takeNextHydrationMarkerIndex(state));
 		}
 	}
 
-	return { indices, nextIndex };
+	return { indices, nextIndex: state.nextBindingIndex };
 }
 
 /** Resolves the DOM attribute name for a global SSR hydration marker index. */
 export function resolveHydrationMarkerAttributeName(globalIndex: number): string {
 	return `${ATTRIBUTE_BINDING_PREFIX}${globalIndex}`;
+}
+
+/**
+ * Reserves the next global SSR marker index for one template attribute
+ * interpolation during depth-first serialization.
+ */
+export function takeNextHydrationMarkerIndex(state: { nextBindingIndex: number }): number {
+	const index = state.nextBindingIndex;
+	state.nextBindingIndex += 1;
+	return index;
 }
 
 /**

--- a/packages/jsx/src/hydration-bindings.ts
+++ b/packages/jsx/src/hydration-bindings.ts
@@ -18,6 +18,12 @@ export type HydrationBinding = {
 	value: unknown;
 };
 
+/** Maps template value indexes to global SSR hydration marker indexes. */
+export type TemplateAttributeMarkerIndices = {
+	indices: ReadonlyMap<number, number>;
+	nextIndex: number;
+};
+
 type CollectHydrationBindingsOptions = {
 	skipNestedCustomElementRoots?: boolean;
 };
@@ -43,6 +49,39 @@ export function collectHydrationBindings(
 	collectValueBindings(value, bindings, state, options);
 
 	return bindings;
+}
+
+/**
+ * Records the global SSR marker indexes for every attribute interpolation in
+ * `template`, starting at `startIndex`.
+ *
+ * This mirrors the index advancement performed by `serializeRenderable(...,
+ * { mode: 'hydrate' })` and by {@link collectHydrationBindings}, so iterable
+ * fragment hydration can resolve per-child markers against the same namespace.
+ */
+export function collectTemplateAttributeMarkerIndices(
+	template: TemplateResultLike,
+	startIndex: number,
+): TemplateAttributeMarkerIndices {
+	const indices = new Map<number, number>();
+	const interpolationParts = getTemplateInterpolationParts(template.strings);
+	let nextIndex = startIndex;
+
+	for (let index = 0; index < template.values.length; index += 1) {
+		const interpolationPart = interpolationParts[index];
+
+		if (interpolationPart?.type === 'attribute') {
+			indices.set(index, nextIndex);
+			nextIndex += 1;
+		}
+	}
+
+	return { indices, nextIndex };
+}
+
+/** Resolves the DOM attribute name for a global SSR hydration marker index. */
+export function resolveHydrationMarkerAttributeName(globalIndex: number): string {
+	return `${ATTRIBUTE_BINDING_PREFIX}${globalIndex}`;
 }
 
 /**
@@ -80,6 +119,54 @@ export function serializeBindingDescriptor(kind: BindingKind, name: string): str
 	return `${kind}:${name}`;
 }
 
+/**
+ * Walks the subtree rooted at `target` and invokes `visit` for every attribute
+ * whose name starts with {@link ATTRIBUTE_BINDING_PREFIX}.
+ *
+ * Attributes are iterated in reverse index order so that callers may safely call
+ * `removeAttribute` inside `visit` without corrupting the live `NamedNodeMap`.
+ */
+export function visitHydrationBindingMarkers(
+	target: HTMLElement,
+	visit: (element: Element, attribute: Attr) => void,
+): boolean {
+	let foundHydrationMarker = false;
+	const walk = (element: Element): void => {
+		const attributes = Array.from(element.attributes).filter((attribute) =>
+			attribute.name.startsWith(ATTRIBUTE_BINDING_PREFIX),
+		);
+
+		for (let index = attributes.length - 1; index >= 0; index -= 1) {
+			const attribute = attributes[index];
+
+			if (!attribute) {
+				continue;
+			}
+
+			foundHydrationMarker = true;
+			visit(element, attribute);
+		}
+
+		if (element !== target && shouldSkipHydrationSubtree(element)) {
+			return;
+		}
+
+		const children = element.children;
+
+		for (let index = 0; index < children.length; index += 1) {
+			const child = children.item(index);
+
+			if (child) {
+				walk(child);
+			}
+		}
+	};
+
+	walk(target);
+
+	return foundHydrationMarker;
+}
+
 function collectValueBindings(
 	value: JsxRenderable,
 	bindings: Map<number, HydrationBinding>,
@@ -113,23 +200,25 @@ function collectTemplateBindings(
 	}
 
 	const interpolationParts = getTemplateInterpolationParts(template.strings);
+	const markerIndices = collectTemplateAttributeMarkerIndices(template, state.nextIndex);
+	state.nextIndex = markerIndices.nextIndex;
 
-	for (let index = 0; index < template.values.length; index += 1) {
-		const interpolationPart = interpolationParts[index];
+	for (const [valueIndex, globalIndex] of markerIndices.indices) {
+		const interpolationPart = interpolationParts[valueIndex];
 
 		if (interpolationPart?.type === 'attribute') {
-			const bindingValue = template.values[index];
-
-			bindings.set(state.nextIndex, {
+			bindings.set(globalIndex, {
 				kind: interpolationPart.kind,
 				name: interpolationPart.name,
-				value: bindingValue,
+				value: template.values[valueIndex],
 			});
-			state.nextIndex += 1;
-			continue;
 		}
+	}
 
-		collectValueBindings(template.values[index] as JsxRenderable, bindings, state, options);
+	for (let index = 0; index < template.values.length; index += 1) {
+		if (interpolationParts[index]?.type !== 'attribute') {
+			collectValueBindings(template.values[index] as JsxRenderable, bindings, state, options);
+		}
 	}
 }
 

--- a/packages/jsx/src/hydration-bindings.ts
+++ b/packages/jsx/src/hydration-bindings.ts
@@ -1,3 +1,16 @@
+/**
+ * Hydration binding contract shared by SSR serialization and client recovery.
+ *
+ * Lifecycle overview:
+ * 1. `serializeRenderable(..., { mode: 'hydrate' })` writes `data-radiant-jsx-bind-N`
+ *    attributes through {@link takeNextHydrationMarkerIndex} and
+ *    {@link resolveHydrationMarkerAttributeName}.
+ * 2. {@link collectHydrationBindings} and {@link collectTemplateAttributeMarkerIndices}
+ *    resolve the same global namespace for iterable fragment children.
+ * 3. `hydrate(...)` walks markers back to live bindings via template, iterable, or flat paths.
+ *
+ * See `packages/jsx/README.md` → "SSR Marker Lifecycle" for the full walkthrough.
+ */
 import type { JsxRenderable, TemplateResultLike } from './jsx-runtime.ts';
 import { isIterableRenderable, isTemplateResultLike } from './renderable-guards.ts';
 import { shouldSkipHydrationSubtree } from './hydration-subtree-policy.ts';

--- a/packages/jsx/src/serialize-renderable.ts
+++ b/packages/jsx/src/serialize-renderable.ts
@@ -11,9 +11,10 @@ import {
 	toTemplateResultLike,
 } from './renderable-guards.ts';
 import {
-	ATTRIBUTE_BINDING_PREFIX,
 	getTemplateInterpolationParts,
+	resolveHydrationMarkerAttributeName,
 	serializeBindingDescriptor,
+	takeNextHydrationMarkerIndex,
 } from './hydration-bindings.ts';
 import { isClientOnlyBinding, needsHydrationMarker } from './hydration-marker-policy.ts';
 import { escapeAttribute, escapeHtml } from './html-escape.ts';
@@ -99,6 +100,7 @@ function serializeTemplateResult(template: TemplateResultLike, options: Serializ
 	}
 
 	const interpolationParts = getTemplateInterpolationParts(template.strings);
+	const hydrationState = options.hydrationBindingState;
 	let html = '';
 
 	for (let index = 0; index < template.values.length; index += 1) {
@@ -115,15 +117,11 @@ function serializeTemplateResult(template: TemplateResultLike, options: Serializ
 		}
 
 		const bindingKind = interpolationPart.kind;
-		const bindingIndex = options.hydrationBindingState?.nextBindingIndex ?? 0;
+		const bindingIndex = hydrationState ? takeNextHydrationMarkerIndex(hydrationState) : 0;
 		html += interpolationPart.leading;
 
-		if (options.mode === 'hydrate' && options.hydrationBindingState && needsHydrationMarker(bindingKind)) {
-			html += `${interpolationPart.whitespace}${ATTRIBUTE_BINDING_PREFIX}${bindingIndex}="${serializeBindingDescriptor(bindingKind, interpolationPart.name)}"`;
-		}
-
-		if (options.hydrationBindingState) {
-			options.hydrationBindingState.nextBindingIndex += 1;
+		if (options.mode === 'hydrate' && hydrationState && needsHydrationMarker(bindingKind)) {
+			html += `${interpolationPart.whitespace}${resolveHydrationMarkerAttributeName(bindingIndex)}="${serializeBindingDescriptor(bindingKind, interpolationPart.name)}"`;
 		}
 
 		if (isClientOnlyBinding(bindingKind)) {

--- a/packages/jsx/test/hydration-marker-policy.test.tsx
+++ b/packages/jsx/test/hydration-marker-policy.test.tsx
@@ -134,3 +134,37 @@ describe('hydration marker policy integration with SSR output', () => {
 		expect(htmlWithoutMarkers).not.toContain('disabled');
 	});
 });
+
+describe('template attribute marker index collection', () => {
+	test('collectTemplateAttributeMarkerIndices matches collectHydrationBindings for iterable roots', async () => {
+		const [{ jsx, jsxs, Fragment }, { collectHydrationBindings, collectTemplateAttributeMarkerIndices }] =
+			await Promise.all([loadJsxRuntime(), loadHydrationBindings()]);
+
+		const renderFragment = () =>
+			jsxs(Fragment, {
+				children: [
+					jsx('button', { class: 'alpha', 'on:click': () => undefined, children: 'Alpha' }),
+					jsx('span', { id: 'metric', children: '2' }),
+				],
+			});
+
+		const fragment = renderFragment();
+		const bindings = collectHydrationBindings(fragment);
+		const firstButton = (fragment as unknown[])[0] as ReturnType<typeof jsx>;
+		const span = (fragment as unknown[])[1] as ReturnType<typeof jsx>;
+
+		const firstButtonIndices = collectTemplateAttributeMarkerIndices(firstButton, 0);
+		expect(firstButtonIndices.nextIndex).toBe(2);
+		expect(firstButtonIndices.indices.get(0)).toBe(0);
+		expect(firstButtonIndices.indices.get(1)).toBe(1);
+
+		const spanIndices = collectTemplateAttributeMarkerIndices(span, firstButtonIndices.nextIndex);
+		expect(spanIndices.nextIndex).toBe(3);
+		expect(spanIndices.indices.get(0)).toBe(2);
+
+		expect(bindings.size).toBe(3);
+		expect(bindings.get(0)?.kind).toBe('attr');
+		expect(bindings.get(1)?.kind).toBe('event');
+		expect(bindings.get(2)?.name).toBe('id');
+	});
+});

--- a/packages/jsx/test/hydration-marker-policy.test.tsx
+++ b/packages/jsx/test/hydration-marker-policy.test.tsx
@@ -167,4 +167,84 @@ describe('template attribute marker index collection', () => {
 		expect(bindings.get(1)?.kind).toBe('event');
 		expect(bindings.get(2)?.name).toBe('id');
 	});
+
+	test('renderToString hydrate markers match collectHydrationBindings for iterable roots', async () => {
+		const [
+			{ jsx, jsxs, Fragment },
+			{ collectHydrationBindings, resolveHydrationMarkerAttributeName, serializeBindingDescriptor },
+			{ renderToString },
+		] = await Promise.all([loadJsxRuntime(), loadHydrationBindings(), loadServerRender()]);
+
+		const fragment = jsxs(Fragment, {
+			children: [
+				jsx('button', { id: 'dec', 'on:click': () => undefined, children: '-' }),
+				jsx('span', { id: 'metric', children: '2' }),
+				jsx('button', { id: 'inc', children: '+' }),
+			],
+		});
+
+		const html = renderToString(fragment, { mode: 'hydrate' });
+		const bindings = collectHydrationBindings(fragment);
+
+		expect(bindings.size).toBe(4);
+
+		for (const [index, binding] of bindings) {
+			const markerName = resolveHydrationMarkerAttributeName(index);
+			const descriptor = serializeBindingDescriptor(binding.kind, binding.name);
+			expect(html).toContain(`${markerName}="${descriptor}"`);
+		}
+	});
+
+	test('renderToString hydrate markers match counter-shaped fragments with subscribable children', async () => {
+		const [
+			{ createSubscribableJsxValue, jsx, jsxs, Fragment },
+			{
+				collectHydrationBindings,
+				collectTemplateAttributeMarkerIndices,
+				resolveHydrationMarkerAttributeName,
+				serializeBindingDescriptor,
+			},
+			{ renderToString },
+		] = await Promise.all([loadJsxRuntime(), loadHydrationBindings(), loadServerRender()]);
+
+		const boundCount = createSubscribableJsxValue({
+			getValue: () => 2,
+			subscribe: () => () => undefined,
+		});
+		const fragment = jsxs(Fragment, {
+			children: [
+				jsx('button', { id: 'dec', children: '-' }),
+				jsx('span', { id: 'metric', children: boundCount }),
+				jsx('button', { id: 'inc', children: '+' }),
+			],
+		});
+		const [decButton, metricSpan, incButton] = fragment as unknown as [
+			ReturnType<typeof jsx>,
+			ReturnType<typeof jsx>,
+			ReturnType<typeof jsx>,
+		];
+
+		const html = renderToString(fragment, { mode: 'hydrate' });
+		const bindings = collectHydrationBindings(fragment);
+
+		expect(bindings.size).toBe(3);
+		expect(bindings.get(0)?.name).toBe('id');
+		expect(bindings.get(1)?.name).toBe('id');
+		expect(bindings.get(2)?.name).toBe('id');
+
+		for (const [index, binding] of bindings) {
+			const markerName = resolveHydrationMarkerAttributeName(index);
+			const descriptor = serializeBindingDescriptor(binding.kind, binding.name);
+			expect(html).toContain(`${markerName}="${descriptor}"`);
+		}
+
+		const decIndices = collectTemplateAttributeMarkerIndices(decButton, 0);
+		const spanIndices = collectTemplateAttributeMarkerIndices(metricSpan, decIndices.nextIndex);
+		const incIndices = collectTemplateAttributeMarkerIndices(incButton, spanIndices.nextIndex);
+
+		expect(decIndices.nextIndex).toBe(1);
+		expect(spanIndices.nextIndex).toBe(2);
+		expect(incIndices.nextIndex).toBe(3);
+		expect(incIndices.nextIndex).toBe(bindings.size);
+	});
 });

--- a/packages/radiant/test/core/counter-binding-repro.test.tsx
+++ b/packages/radiant/test/core/counter-binding-repro.test.tsx
@@ -71,7 +71,7 @@ describe('counter binding repro', () => {
 
 	test('this.value plain updates on click', async () => {
 		document.body.innerHTML = '<repro-counter-plain></repro-counter-plain>';
-		const el = document.querySelector('repro-counter-plain') as RadiantElement;
+		const el = document.querySelector('repro-counter-plain') as ReproCounterPlain;
 		await waitFor(() => expect(el.querySelector('[data-testid="plain"]')?.textContent).toBe('0'));
 		(el.querySelector('[data-testid="inc-plain"]') as HTMLButtonElement).click();
 		await waitFor(() => expect(el.querySelector('[data-testid="plain"]')?.textContent).toBe('1'));


### PR DESCRIPTION
## Summary
- Moves template attribute marker indexing and DOM marker scanning into `hydration-bindings.ts` as the single contract shared by SSR collection, flat hydration, and iterable fragment hydration.
- Simplifies `hydrateIterableRoot` to return a boolean and validates marker removal inside the iterable hydrator.
- Documents supported fragment hydration shapes in `hydration-iterable.ts` and the jsx README.

## Test plan
- [x] `packages/jsx` test suite (158 tests)
- [x] `counter-binding-repro` radiant tests
- [x] New marker index alignment test for iterable fragments