### PR TITLE
refactor(radiant-ui): drop floating-ui for shared positioner

### DIFF
--- a/.changeset/drop-floating-ui-native-positioning.md
+++ b/.changeset/drop-floating-ui-native-positioning.md
@@ -1,0 +1,11 @@
+---
+'@ecopages/radiant-ui': minor
+---
+
+Remove `@floating-ui/dom` and position tooltips and menu buttons with an in-package floating helper.
+
+**@ecopages/radiant-ui**
+
+- Drop the `@floating-ui/dom` dependency.
+- `rui-tooltip` and `rui-menu-button` use `computeFloatingCoords` / `attachFloating` for fixed placement, primary-axis flip by free space, and cross-axis viewport clamping.
+- Close open menubar menus when activating a top-level item without a submenu.

--- a/packages/radiant-ui/scripts/build.ts
+++ b/packages/radiant-ui/scripts/build.ts
@@ -2,7 +2,7 @@
  * Builds the radiant-ui library into `dist/`.
  *
  * Bundles every `src/components/ui/<name>/index.ts` (plus the root barrel)
- * as browser-targeted ESM with `@ecopages/*` and `@floating-ui/dom` external.
+ * as browser-targeted ESM with `@ecopages/*` external.
  *
  * Run with: pnpm run build:files
  */
@@ -22,7 +22,6 @@ const externalPackages = [
 	'@ecopages/radiant/*',
 	'@ecopages/signals',
 	'@ecopages/signals/*',
-	'@floating-ui/dom',
 	'*.css',
 ];
 

--- a/packages/radiant-ui/src/components/ui/menu-button/menu-button.css
+++ b/packages/radiant-ui/src/components/ui/menu-button/menu-button.css
@@ -1,4 +1,5 @@
 @reference '../../../styles/radiant-ui.css';
+@import '../shared/floating.css';
 
 rui-menu-button {
 	@apply inline-flex;
@@ -20,7 +21,7 @@ rui-menu-button {
 	}
 
 	.rui-menu-button__menu {
-		@apply absolute z-popover min-w-40 rounded-container border border-border bg-background p-1 shadow-md;
+		@apply z-popover min-w-40 rounded-container border border-border bg-background p-1 shadow-md;
 	}
 
 	.rui-menu-button__menu[hidden] {

--- a/packages/radiant-ui/src/components/ui/menu-button/menu-button.script.tsx
+++ b/packages/radiant-ui/src/components/ui/menu-button/menu-button.script.tsx
@@ -1,17 +1,20 @@
 import { RadiantElement, bound, customElement, event, onEvent, onUpdated, prop, query } from '@ecopages/radiant';
 import type { EventEmitter } from '@ecopages/radiant/tools/event-emitter';
-import { type Placement, autoUpdate, computePosition, flip, offset, shift } from '@floating-ui/dom';
+import { attachFloating } from '../shared/floating-position';
+import type { RuiPlacement } from '../shared/placement';
 
 export type RuiMenuButtonProps = {
 	/** Whether the menu starts open. Default: `false`. */
 	open?: boolean;
-	/** Floating-ui placement for the menu. Default: `bottom-start`. */
-	placement?: Placement;
+	/** Placement of the menu surface relative to its trigger. Default: `bottom-start`. */
+	placement?: RuiPlacement;
 };
 
 export type RuiMenuButtonSelectDetail = {
 	value: string;
 };
+
+const MENU_GAP = 6;
 
 /**
  * `<rui-menu-button>` — a button that opens a menu of actions.
@@ -43,7 +46,7 @@ export type RuiMenuButtonSelectDetail = {
 @customElement('rui-menu-button')
 export class RuiMenuButton extends RadiantElement {
 	@prop({ type: Boolean, reflect: true, defaultValue: false }) open: boolean;
-	@prop({ type: String, defaultValue: 'bottom-start' }) placement: Placement;
+	@prop({ type: String, defaultValue: 'bottom-start' }) placement: RuiPlacement;
 
 	@query({ ref: 'trigger' }) triggerTarget: HTMLButtonElement;
 	@query({ ref: 'menu' }) menuTarget: HTMLElement;
@@ -54,8 +57,9 @@ export class RuiMenuButton extends RadiantElement {
 	@event({ name: 'rui-close', bubbles: true, composed: true })
 	closeEvent: EventEmitter<void>;
 
-	private cleanup: ReturnType<typeof autoUpdate> | null = null;
 	private menuId = `rui-menu-${Math.random().toString(36).slice(2, 9)}`;
+	private cleanupFloating: (() => void) | null = null;
+	private pendingFocus: 'first' | 'last' | 'trigger' | null = null;
 
 	override connectedCallback(): void {
 		super.connectedCallback();
@@ -74,25 +78,20 @@ export class RuiMenuButton extends RadiantElement {
 	}
 
 	private teardownFloating(): void {
-		this.cleanup?.();
-		this.cleanup = null;
+		this.cleanupFloating?.();
+		this.cleanupFloating = null;
 	}
 
-	@bound
-	updatePosition(): void {
-		if (!this.triggerTarget || !this.menuTarget || !this.open) return;
-		computePosition(this.triggerTarget, this.menuTarget, {
-			placement: this.placement,
-			middleware: [offset(6), flip(), shift({ padding: 8 })],
-		}).then(({ x, y }) => {
-			Object.assign(this.menuTarget.style, {
-				left: `${x}px`,
-				top: `${y}px`,
-			});
+	private attachFloating(): void {
+		if (!this.triggerTarget || !this.menuTarget) return;
+		this.teardownFloating();
+		this.cleanupFloating = attachFloating({
+			anchor: this.triggerTarget,
+			floating: this.menuTarget,
+			getPlacement: () => this.placement,
+			gap: MENU_GAP,
 		});
 	}
-
-	private pendingFocus: 'first' | 'last' | 'trigger' | null = null;
 
 	@bound
 	@onUpdated(['open', 'placement'])
@@ -105,13 +104,8 @@ export class RuiMenuButton extends RadiantElement {
 		this.triggerTarget.setAttribute('aria-expanded', String(this.open));
 		this.menuTarget.hidden = !this.open;
 
-		if (this.open) {
-			this.teardownFloating();
-			this.cleanup = autoUpdate(this.triggerTarget, this.menuTarget, this.updatePosition);
-			this.updatePosition();
-		} else {
-			this.teardownFloating();
-		}
+		if (this.open) this.attachFloating();
+		else this.teardownFloating();
 
 		const focus = this.pendingFocus;
 		this.pendingFocus = null;
@@ -236,7 +230,7 @@ export class RuiMenuButton extends RadiantElement {
 					<slot name="trigger"></slot>
 					<span class="rui-menu-button__chevron" aria-hidden="true"></span>
 				</button>
-				<div data-ref="menu" class="rui-menu-button__menu" role="menu" hidden>
+				<div data-ref="menu" class="rui-menu-button__menu rui-floating" role="menu" hidden>
 					<slot></slot>
 				</div>
 			</div>

--- a/packages/radiant-ui/src/components/ui/menubar/menubar.css
+++ b/packages/radiant-ui/src/components/ui/menubar/menubar.css
@@ -29,7 +29,7 @@ rui-menubar {
 		@apply bg-background outline-none ring-2 ring-focus-ring;
 	}
 	.rui-menubar__menu {
-		@apply absolute left-0 top-full z-dropdown mt-1 min-w-40 rounded-container border border-border bg-surface p-1 shadow-md;
+		@apply absolute left-0 top-full z-dropdown mt-2.5 min-w-40 rounded-container border border-border bg-surface p-1 shadow-md;
 	}
 	.rui-menubar__menu-item {
 		@apply block w-full cursor-pointer rounded-control border-0 bg-transparent px-3 py-1.5 text-left text-sm text-on-surface;

--- a/packages/radiant-ui/src/components/ui/menubar/menubar.script.tsx
+++ b/packages/radiant-ui/src/components/ui/menubar/menubar.script.tsx
@@ -140,7 +140,11 @@ export class RuiMenubar extends RadiantElement<RuiMenubarBindings> {
 	onTopClick(event: Event): void {
 		const current = (event.target as HTMLElement).closest('[role="menuitem"]') as HTMLElement | null;
 		if (!current || !this.getTopItems().includes(current)) return;
-		if (!this.getMenuFor(current)) return;
+
+		if (!this.getMenuFor(current)) {
+			this.closeOpenMenu();
+			return;
+		}
 
 		const expanded = current.getAttribute('aria-expanded') === 'true';
 		if (expanded) this.closeOpenMenu();

--- a/packages/radiant-ui/src/components/ui/menubar/menubar.stories.tsx
+++ b/packages/radiant-ui/src/components/ui/menubar/menubar.stories.tsx
@@ -55,5 +55,11 @@ export const Default: Story = {
 		await step('open menu top item shows aria-expanded styling', async () => {
 			await expect(tops[0]).toHaveAttribute('aria-expanded', 'true');
 		});
+
+		await step('clicking a top item without a menu closes the open menu', async () => {
+			await userEvent.click(tops[2]);
+			await expect(tops[0]).toHaveAttribute('aria-expanded', 'false');
+			await expect(canvasElement.querySelector('[role="menu"]:not([hidden])')).toBeNull();
+		});
 	},
 };

--- a/packages/radiant-ui/src/components/ui/shared/floating-position.test.ts
+++ b/packages/radiant-ui/src/components/ui/shared/floating-position.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { computeFloatingCoords } from './floating-position';
+import type { RuiPlacement } from './placement';
+
+function rect(left: number, top: number, width: number, height: number): DOMRect {
+	return {
+		left,
+		top,
+		right: left + width,
+		bottom: top + height,
+		width,
+		height,
+		x: left,
+		y: top,
+		toJSON: () => ({}),
+	};
+}
+
+const viewport = { width: 800, height: 600, padding: 8 };
+const size = { width: 120, height: 28 };
+const gap = 8;
+
+describe('computeFloatingCoords', () => {
+	it('places top centered above the anchor', () => {
+		const coords = computeFloatingCoords(rect(200, 200, 80, 32), size, 'top', gap, viewport);
+		expect(coords.y).toBe(200 - size.height - gap);
+		expect(coords.x).toBe(200 + 40 - size.width / 2);
+	});
+
+	it('flips top to bottom near the top edge', () => {
+		const coords = computeFloatingCoords(rect(200, 20, 80, 32), size, 'top', gap, viewport);
+		expect(coords.y).toBe(20 + 32 + gap);
+		expect(coords.y).toBeGreaterThan(20);
+	});
+
+	it('shifts a top tooltip right when centered would clip the left edge', () => {
+		const coords = computeFloatingCoords(rect(12, 200, 80, 32), size, 'top', gap, viewport);
+		expect(coords.x).toBe(8);
+		expect(coords.y).toBe(200 - size.height - gap);
+	});
+
+	it('keeps bottom-start left-aligned under the anchor', () => {
+		const coords = computeFloatingCoords(rect(100, 100, 80, 32), size, 'bottom-start', gap, viewport);
+		expect(coords.x).toBe(100);
+		expect(coords.y).toBe(100 + 32 + gap);
+	});
+
+	it('flips bottom-start above near the bottom edge', () => {
+		const coords = computeFloatingCoords(rect(100, 560, 80, 32), size, 'bottom-start' satisfies RuiPlacement, gap, viewport);
+		expect(coords.y).toBe(560 - size.height - gap);
+		expect(coords.x).toBe(100);
+	});
+
+	it('does not clamp the primary axis onto the anchor after a top flip', () => {
+		const coords = computeFloatingCoords(rect(200, 16, 80, 32), size, 'top', gap, viewport);
+		expect(coords.y).toBeGreaterThanOrEqual(16 + 32);
+	});
+});

--- a/packages/radiant-ui/src/components/ui/shared/floating-position.test.ts
+++ b/packages/radiant-ui/src/components/ui/shared/floating-position.test.ts
@@ -46,7 +46,13 @@ describe('computeFloatingCoords', () => {
 	});
 
 	it('flips bottom-start above near the bottom edge', () => {
-		const coords = computeFloatingCoords(rect(100, 560, 80, 32), size, 'bottom-start' satisfies RuiPlacement, gap, viewport);
+		const coords = computeFloatingCoords(
+			rect(100, 560, 80, 32),
+			size,
+			'bottom-start' satisfies RuiPlacement,
+			gap,
+			viewport,
+		);
 		expect(coords.y).toBe(560 - size.height - gap);
 		expect(coords.x).toBe(100);
 	});

--- a/packages/radiant-ui/src/components/ui/shared/floating-position.ts
+++ b/packages/radiant-ui/src/components/ui/shared/floating-position.ts
@@ -1,0 +1,201 @@
+import type { RuiPlacement } from './placement';
+
+type Side = 'top' | 'right' | 'bottom' | 'left';
+type Align = 'start' | 'center' | 'end';
+
+export type FloatingSize = { width: number; height: number };
+export type FloatingCoords = { x: number; y: number };
+export type FloatingViewport = { width: number; height: number; padding: number };
+
+const OPPOSITE: Record<Side, Side> = {
+	top: 'bottom',
+	bottom: 'top',
+	left: 'right',
+	right: 'left',
+};
+
+const DEFAULT_VIEWPORT_PADDING = 8;
+
+function parsePlacement(placement: RuiPlacement): { side: Side; align: Align } {
+	const dash = placement.indexOf('-');
+	if (dash === -1) return { side: placement as Side, align: 'center' };
+	const side = placement.slice(0, dash) as Side;
+	const align = placement.slice(dash + 1);
+	return { side, align: align === 'start' || align === 'end' ? align : 'center' };
+}
+
+function primaryAxis(side: Side): 'x' | 'y' {
+	return side === 'top' || side === 'bottom' ? 'y' : 'x';
+}
+
+function coordsFor(
+	anchor: DOMRect,
+	size: FloatingSize,
+	side: Side,
+	align: Align,
+	gap: number,
+): FloatingCoords {
+	const { width, height } = size;
+	let x = 0;
+	let y = 0;
+
+	switch (side) {
+		case 'top':
+			y = anchor.top - height - gap;
+			break;
+		case 'bottom':
+			y = anchor.bottom + gap;
+			break;
+		case 'left':
+			x = anchor.left - width - gap;
+			break;
+		case 'right':
+			x = anchor.right + gap;
+			break;
+	}
+
+	if (primaryAxis(side) === 'y') {
+		if (align === 'start') x = anchor.left;
+		else if (align === 'end') x = anchor.right - width;
+		else x = anchor.left + (anchor.width - width) / 2;
+	} else {
+		if (align === 'start') y = anchor.top;
+		else if (align === 'end') y = anchor.bottom - height;
+		else y = anchor.top + (anchor.height - height) / 2;
+	}
+
+	return { x, y };
+}
+
+function overflowOnPrimary(
+	coords: FloatingCoords,
+	size: FloatingSize,
+	side: Side,
+	viewport: FloatingViewport,
+): number {
+	const { padding, width: vw, height: vh } = viewport;
+	if (side === 'top') return Math.max(0, padding - coords.y);
+	if (side === 'bottom') return Math.max(0, coords.y + size.height - (vh - padding));
+	if (side === 'left') return Math.max(0, padding - coords.x);
+	return Math.max(0, coords.x + size.width - (vw - padding));
+}
+
+function freeSpaceOnSide(anchor: DOMRect, size: FloatingSize, side: Side, viewport: FloatingViewport): number {
+	const { padding, width: vw, height: vh } = viewport;
+	if (side === 'top') return anchor.top - padding - size.height;
+	if (side === 'bottom') return vh - padding - size.height - anchor.bottom;
+	if (side === 'left') return anchor.left - padding - size.width;
+	return vw - padding - size.width - anchor.right;
+}
+
+function clampCrossAxis(
+	coords: FloatingCoords,
+	size: FloatingSize,
+	side: Side,
+	viewport: FloatingViewport,
+): FloatingCoords {
+	const { padding, width: vw, height: vh } = viewport;
+	if (primaryAxis(side) === 'y') {
+		const maxX = Math.max(padding, vw - padding - size.width);
+		return { x: Math.min(Math.max(coords.x, padding), maxX), y: coords.y };
+	}
+	const maxY = Math.max(padding, vh - padding - size.height);
+	return { x: coords.x, y: Math.min(Math.max(coords.y, padding), maxY) };
+}
+
+/**
+ * Computes fixed-position coords for a floating surface.
+ *
+ * @remarks
+ * Prefers `placement`, then flips on the primary axis when the opposite side
+ * has more free space. Clamps only the cross-axis so the floating surface
+ * never slides onto its anchor.
+ */
+export function computeFloatingCoords(
+	anchor: DOMRect,
+	size: FloatingSize,
+	placement: RuiPlacement,
+	gap: number,
+	viewport: FloatingViewport = {
+		width: typeof window === 'undefined' ? 0 : window.innerWidth,
+		height: typeof window === 'undefined' ? 0 : window.innerHeight,
+		padding: DEFAULT_VIEWPORT_PADDING,
+	},
+): FloatingCoords {
+	const { side: preferred, align } = parsePlacement(placement);
+	const preferredCoords = coordsFor(anchor, size, preferred, align, gap);
+	const preferredOverflow = overflowOnPrimary(preferredCoords, size, preferred, viewport);
+
+	let side = preferred;
+	let coords = preferredCoords;
+
+	if (preferredOverflow > 0) {
+		const flipped = OPPOSITE[preferred];
+		const flippedCoords = coordsFor(anchor, size, flipped, align, gap);
+		const preferredFree = freeSpaceOnSide(anchor, size, preferred, viewport);
+		const flippedFree = freeSpaceOnSide(anchor, size, flipped, viewport);
+		if (flippedFree > preferredFree) {
+			side = flipped;
+			coords = flippedCoords;
+		}
+	}
+
+	return clampCrossAxis(coords, size, side, viewport);
+}
+
+/** Applies fixed coords to a floating element. */
+export function applyFloatingPosition(
+	anchor: HTMLElement,
+	floating: HTMLElement,
+	placement: RuiPlacement,
+	gap: number,
+): void {
+	const coords = computeFloatingCoords(
+		anchor.getBoundingClientRect(),
+		{ width: floating.offsetWidth, height: floating.offsetHeight },
+		placement,
+		gap,
+	);
+	Object.assign(floating.style, {
+		position: 'fixed',
+		left: `${coords.x}px`,
+		top: `${coords.y}px`,
+		right: 'auto',
+		bottom: 'auto',
+		visibility: 'visible',
+	});
+}
+
+export type AttachFloatingOptions = {
+	anchor: HTMLElement;
+	floating: HTMLElement;
+	getPlacement: () => RuiPlacement;
+	gap: number;
+};
+
+/**
+ * Positions on attach and keeps the floating element updated on scroll/resize.
+ *
+ * @returns Cleanup that removes listeners and observers.
+ */
+export function attachFloating({ anchor, floating, getPlacement, gap }: AttachFloatingOptions): () => void {
+	const update = (): void => {
+		if (floating.hidden) return;
+		applyFloatingPosition(anchor, floating, getPlacement(), gap);
+	};
+
+	update();
+
+	window.addEventListener('resize', update);
+	window.addEventListener('scroll', update, true);
+
+	const observer = new ResizeObserver(update);
+	observer.observe(anchor);
+	observer.observe(floating);
+
+	return () => {
+		window.removeEventListener('resize', update);
+		window.removeEventListener('scroll', update, true);
+		observer.disconnect();
+	};
+}

--- a/packages/radiant-ui/src/components/ui/shared/floating-position.ts
+++ b/packages/radiant-ui/src/components/ui/shared/floating-position.ts
@@ -28,13 +28,7 @@ function primaryAxis(side: Side): 'x' | 'y' {
 	return side === 'top' || side === 'bottom' ? 'y' : 'x';
 }
 
-function coordsFor(
-	anchor: DOMRect,
-	size: FloatingSize,
-	side: Side,
-	align: Align,
-	gap: number,
-): FloatingCoords {
+function coordsFor(anchor: DOMRect, size: FloatingSize, side: Side, align: Align, gap: number): FloatingCoords {
 	const { width, height } = size;
 	let x = 0;
 	let y = 0;
@@ -67,12 +61,7 @@ function coordsFor(
 	return { x, y };
 }
 
-function overflowOnPrimary(
-	coords: FloatingCoords,
-	size: FloatingSize,
-	side: Side,
-	viewport: FloatingViewport,
-): number {
+function overflowOnPrimary(coords: FloatingCoords, size: FloatingSize, side: Side, viewport: FloatingViewport): number {
 	const { padding, width: vw, height: vh } = viewport;
 	if (side === 'top') return Math.max(0, padding - coords.y);
 	if (side === 'bottom') return Math.max(0, coords.y + size.height - (vh - padding));

--- a/packages/radiant-ui/src/components/ui/shared/floating.css
+++ b/packages/radiant-ui/src/components/ui/shared/floating.css
@@ -1,0 +1,6 @@
+@layer components {
+	.rui-floating {
+		position: fixed;
+		visibility: hidden;
+	}
+}

--- a/packages/radiant-ui/src/components/ui/shared/placement.ts
+++ b/packages/radiant-ui/src/components/ui/shared/placement.ts
@@ -1,0 +1,14 @@
+/** Placement of a floating surface relative to its anchor. */
+export type RuiPlacement =
+	| 'top'
+	| 'top-start'
+	| 'top-end'
+	| 'right'
+	| 'right-start'
+	| 'right-end'
+	| 'bottom'
+	| 'bottom-start'
+	| 'bottom-end'
+	| 'left'
+	| 'left-start'
+	| 'left-end';

--- a/packages/radiant-ui/src/components/ui/tooltip/tooltip.css
+++ b/packages/radiant-ui/src/components/ui/tooltip/tooltip.css
@@ -1,4 +1,5 @@
 @reference '../../../styles/radiant-ui.css';
+@import '../shared/floating.css';
 
 rui-tooltip {
 	@apply inline-flex;
@@ -14,7 +15,7 @@ rui-tooltip {
 	}
 
 	.rui-tooltip__content {
-		@apply absolute z-overlay max-w-xs rounded-container bg-on-background px-2 py-1 text-xs text-background shadow-md;
+		@apply z-overlay max-w-xs rounded-container bg-on-background px-2 py-1 text-xs text-background shadow-md;
 		width: max-content;
 		pointer-events: none;
 	}

--- a/packages/radiant-ui/src/components/ui/tooltip/tooltip.script.tsx
+++ b/packages/radiant-ui/src/components/ui/tooltip/tooltip.script.tsx
@@ -1,11 +1,12 @@
 import { RadiantElement, bound, customElement, onEvent, onUpdated, prop, query } from '@ecopages/radiant';
-import { type Placement, autoUpdate, computePosition, flip, offset, shift } from '@floating-ui/dom';
+import { applyFloatingPosition, attachFloating } from '../shared/floating-position';
+import type { RuiPlacement } from '../shared/placement';
 
 export type RuiTooltipProps = {
 	/** Accessible description shown in the tooltip. */
 	content?: string;
-	/** Floating-ui placement. Default: `top`. */
-	placement?: Placement;
+	/** Placement of the tooltip surface relative to its anchor. Default: `top`. */
+	placement?: RuiPlacement;
 	/** Delay in ms before showing on hover/focus. Default: `200`. */
 	delay?: number;
 };
@@ -13,6 +14,8 @@ export type RuiTooltipProps = {
 type RuiTooltipBindings = {
 	content: string;
 };
+
+const TOOLTIP_GAP = 8;
 
 /**
  * `<rui-tooltip>` — a popup that describes a trigger on hover or focus.
@@ -34,7 +37,7 @@ type RuiTooltipBindings = {
 @customElement('rui-tooltip')
 export class RuiTooltip extends RadiantElement<RuiTooltipBindings> {
 	@prop({ type: String, defaultValue: '' }) content: string;
-	@prop({ type: String, defaultValue: 'top' }) placement: Placement;
+	@prop({ type: String, defaultValue: 'top' }) placement: RuiPlacement;
 	@prop({ type: Number, defaultValue: 200 }) delay: number;
 
 	@query({ ref: 'tooltip' }) tooltipTarget: HTMLElement;
@@ -49,9 +52,9 @@ export class RuiTooltip extends RadiantElement<RuiTooltipBindings> {
 
 	private showTimer: ReturnType<typeof setTimeout> | null = null;
 	private hideTimer: ReturnType<typeof setTimeout> | null = null;
-	private cleanup: ReturnType<typeof autoUpdate> | null = null;
 	private tooltipId = `rui-tooltip-${Math.random().toString(36).slice(2, 9)}`;
 	private describedEl: HTMLElement | null = null;
+	private cleanupFloating: (() => void) | null = null;
 
 	/**
 	 * Pointer enter/leave must be host listeners: those events do not bubble, and
@@ -81,8 +84,8 @@ export class RuiTooltip extends RadiantElement<RuiTooltipBindings> {
 	}
 
 	private teardownFloating(): void {
-		this.cleanup?.();
-		this.cleanup = null;
+		this.cleanupFloating?.();
+		this.cleanupFloating = null;
 	}
 
 	private getAnchor(): HTMLElement {
@@ -99,25 +102,23 @@ export class RuiTooltip extends RadiantElement<RuiTooltipBindings> {
 		this.describedEl.setAttribute('aria-describedby', this.tooltipId);
 	}
 
-	@bound
-	updatePosition(): void {
-		if (!this.tooltipTarget || !this.open) return;
-		const anchor = this.getAnchor();
-		computePosition(anchor, this.tooltipTarget, {
-			placement: this.placement,
-			middleware: [offset(8), flip(), shift({ padding: 8 })],
-		}).then(({ x, y }) => {
-			Object.assign(this.tooltipTarget.style, {
-				left: `${x}px`,
-				top: `${y}px`,
-			});
+	private attachFloating(): void {
+		if (!this.tooltipTarget) return;
+		this.teardownFloating();
+		this.cleanupFloating = attachFloating({
+			anchor: this.getAnchor(),
+			floating: this.tooltipTarget,
+			getPlacement: () => this.placement,
+			gap: TOOLTIP_GAP,
 		});
 	}
 
 	@onUpdated(['content', 'placement'])
 	onDescribedPropsUpdated(): void {
 		this.wireTrigger();
-		if (this.open) this.updatePosition();
+		if (this.open && this.tooltipTarget) {
+			applyFloatingPosition(this.getAnchor(), this.tooltipTarget, this.placement, TOOLTIP_GAP);
+		}
 	}
 
 	private setOpen(next: boolean): void {
@@ -126,14 +127,8 @@ export class RuiTooltip extends RadiantElement<RuiTooltipBindings> {
 		if (!this.tooltipTarget) return;
 		this.tooltipTarget.hidden = !next;
 
-		if (next) {
-			this.teardownFloating();
-			const anchor = this.getAnchor();
-			this.cleanup = autoUpdate(anchor, this.tooltipTarget, this.updatePosition);
-			this.updatePosition();
-		} else {
-			this.teardownFloating();
-		}
+		if (next) this.attachFloating();
+		else this.teardownFloating();
 	}
 
 	private scheduleShow(): void {
@@ -184,7 +179,13 @@ export class RuiTooltip extends RadiantElement<RuiTooltipBindings> {
 				<span class="rui-tooltip__trigger">
 					<slot></slot>
 				</span>
-				<span data-ref="tooltip" id={this.tooltipId} class="rui-tooltip__content" role="tooltip" hidden>
+				<span
+					data-ref="tooltip"
+					id={this.tooltipId}
+					class="rui-tooltip__content rui-floating"
+					role="tooltip"
+					hidden
+				>
 					{this.$.content}
 				</span>
 			</span>

--- a/playground/vite/package.json
+++ b/playground/vite/package.json
@@ -13,8 +13,7 @@
 		"@ecopages/jsx": "workspace:*",
 		"@ecopages/radiant": "workspace:*",
 		"@ecopages/radiant-ui": "workspace:*",
-		"@ecopages/signals": "workspace:*",
-		"@floating-ui/dom": "^1.6.11"
+		"@ecopages/signals": "workspace:*"
 	},
 	"devDependencies": {
 		"@ecopages/vite-plugin-radiant": "workspace:*",

--- a/playground/vite/src/components/accordion/accordion.script.ts
+++ b/playground/vite/src/components/accordion/accordion.script.ts
@@ -28,9 +28,12 @@ export class RadiantAccordion extends RadiantElement {
 	private animations: DetailsAnimation[] = [];
 
 	connectedCallback(): void {
-		for (const _details of this.detailsTargets) {
-			this.animations.push({ reference: null, isClosing: false, isExpanding: false });
-		}
+		super.connectedCallback();
+		queueMicrotask(() => {
+			for (const _details of this.detailsTargets ?? []) {
+				this.animations.push({ reference: null, isClosing: false, isExpanding: false });
+			}
+		});
 	}
 
 	@onEvent({ selector: 'summary', type: 'click' })

--- a/playground/vite/src/components/dropdown/dropdown.css
+++ b/playground/vite/src/components/dropdown/dropdown.css
@@ -1,25 +1,61 @@
 @reference '../../styles/tailwind.css';
 
 radiant-dropdown {
-	@apply block;
-	[data-ref='content'] {
-		@apply hidden;
-		@apply w-max absolute top-0 left-0;
-		@apply bg-surface p-3 md:p-4 border border-border rounded-md;
+	@apply relative inline-block;
+}
+
+@layer components {
+	radiant-dropdown [data-ref='content'] {
+		@apply absolute left-0 top-full z-10 mt-1.5 w-max rounded-md border border-border bg-surface p-3 md:p-4;
 	}
-	[data-ref='arrow'] {
-		@apply absolute w-2 h-2 bg-surface transform rotate-45 border-t border-l border-t-border border-l-border;
-		&[data-placement^='top'] {
-			@apply -rotate-135;
-		}
-		&[data-placement^='right'] {
-			@apply -rotate-45;
-		}
-		&[data-placement^='bottom'] {
-			@apply rotate-45;
-		}
-		&[data-placement^='left'] {
-			@apply rotate-135;
-		}
+
+	radiant-dropdown [data-ref='content'][hidden] {
+		@apply hidden;
+	}
+
+	radiant-dropdown[placement^='top'] [data-ref='content'] {
+		@apply bottom-full top-auto mb-1.5 mt-0;
+	}
+
+	radiant-dropdown[placement^='bottom'] [data-ref='content'] {
+		@apply top-full;
+	}
+
+	radiant-dropdown[placement^='left'] [data-ref='content'] {
+		@apply right-full top-0 mr-1.5 mt-0;
+	}
+
+	radiant-dropdown[placement^='right'] [data-ref='content'] {
+		@apply left-full top-0 ml-1.5 mt-0;
+	}
+
+	radiant-dropdown[placement$='-end'][placement^='top'] [data-ref='content'],
+	radiant-dropdown[placement$='-end'][placement^='bottom'] [data-ref='content'] {
+		@apply right-0 left-auto;
+	}
+
+	radiant-dropdown[placement$='-start'][placement^='top'] [data-ref='content'],
+	radiant-dropdown[placement$='-start'][placement^='bottom'] [data-ref='content'] {
+		@apply left-0;
+	}
+
+	radiant-dropdown [data-ref='arrow'] {
+		@apply absolute h-2 w-2 rotate-45 border-t border-l border-t-border border-l-border bg-surface;
+	}
+
+	radiant-dropdown [data-ref='arrow'][data-placement^='top'] {
+		@apply -bottom-1 left-1/2 -translate-x-1/2 -rotate-135;
+	}
+
+	radiant-dropdown [data-ref='arrow'][data-placement^='right'] {
+		@apply -left-1 top-1/2 -translate-y-1/2 -rotate-45;
+	}
+
+	radiant-dropdown [data-ref='arrow'][data-placement^='bottom'] {
+		@apply -top-1 left-1/2 -translate-x-1/2 rotate-45;
+	}
+
+	radiant-dropdown [data-ref='arrow'][data-placement^='left'] {
+		@apply -right-1 top-1/2 -translate-y-1/2 rotate-135;
 	}
 }

--- a/playground/vite/src/components/dropdown/dropdown.script.ts
+++ b/playground/vite/src/components/dropdown/dropdown.script.ts
@@ -6,26 +6,31 @@ import { customElement } from '@ecopages/radiant/decorators/custom-element';
 import { onEvent } from '@ecopages/radiant/decorators/on-event';
 import { query } from '@ecopages/radiant/decorators/query';
 import { prop } from '@ecopages/radiant/decorators/prop';
-import { type Coords, type Placement, arrow, autoUpdate, computePosition, flip, offset } from '@floating-ui/dom';
+
+export type RadiantDropdownPlacement =
+	| 'top'
+	| 'top-start'
+	| 'top-end'
+	| 'right'
+	| 'right-start'
+	| 'right-end'
+	| 'bottom'
+	| 'bottom-start'
+	| 'bottom-end'
+	| 'left'
+	| 'left-start'
+	| 'left-end';
 
 export type RadiantDropdownProps = {
 	defaultOpen?: boolean;
-	placement?: Placement;
+	placement?: RadiantDropdownPlacement;
 	offset?: number;
 	arrow?: boolean;
 };
 
 /**
  * @element radiant-dropdown
- * @description A dropdown component that can be toggled by a trigger element
- *
- * @ref trigger - The trigger element
- * @ref content - The content container
- * @ref arrow - The arrow element
- * @prop {boolean} defaultOpen - Whether the dropdown should be open by default
- * @prop {Placement} placement - The placement of the dropdown
- * @prop {number} offset - The offset of the dropdown
- * @prop {ShiftOptions} shiftOptions - The shift options of the dropdown {@link ShiftOptions}
+ * @description A CSS-positioned dropdown demo for the Vite playground
  */
 @customElement('radiant-dropdown')
 export class RadiantDropdown extends RadiantElement {
@@ -34,52 +39,25 @@ export class RadiantDropdown extends RadiantElement {
 	@query({ ref: 'arrow' }) arrowTarget!: HTMLElement;
 
 	@prop({ type: Boolean, reflect: true, defaultValue: false }) defaultOpen!: boolean;
-	@prop({ type: String, defaultValue: 'left' }) placement!: Placement;
-	@prop({ type: Number, defaultValue: 6 }) offset!: number;
+	@prop({ type: String, defaultValue: 'bottom-start', reflect: true }) placement!: RadiantDropdownPlacement;
 	@prop({ type: Boolean, defaultValue: true }) focusOnOpen!: boolean;
-
-	cleanup: ReturnType<typeof autoUpdate> | null = null;
 
 	connectedCallback(): void {
 		super.connectedCallback();
-		this.updateFloatingUI();
-		if (this.defaultOpen) this.toggleContent();
+		queueMicrotask(() => {
+			if (this.defaultOpen) this.toggleContent();
+		});
+	}
+
+	disconnectedCallback(): void {
+		document.removeEventListener('click', this.closeContent);
+		super.disconnectedCallback();
 	}
 
 	@bound
-	@onUpdated(['offset', 'placement'])
-	updateFloatingUI(): void {
-		if (!this.triggerTarget || !this.contentTarget) return;
-		computePosition(this.triggerTarget, this.contentTarget, {
-			placement: this.placement,
-			middleware: [offset(this.offset), flip(), arrow({ element: this.arrowTarget })],
-		}).then(({ x, y, placement, middlewareData }) => {
-			Object.assign(this.contentTarget.style, {
-				left: `${x}px`,
-				top: `${y}px`,
-			});
-
-			if (!this.arrowTarget) return;
-
-			const { x: arrowX, y: arrowY } = middlewareData.arrow as Coords;
-
-			const staticSide = {
-				top: 'bottom',
-				right: 'left',
-				bottom: 'top',
-				left: 'right',
-			}[placement.split('-')[0]] as string;
-
-			Object.assign(this.arrowTarget.style, {
-				left: arrowX != null ? `${arrowX}px` : '',
-				top: arrowY != null ? `${arrowY}px` : '',
-				right: '',
-				bottom: '',
-				[staticSide]: '-4px',
-			});
-
-			this.arrowTarget.dataset.placement = placement;
-		});
+	@onUpdated(['placement'])
+	syncPlacement(): void {
+		if (this.arrowTarget) this.arrowTarget.dataset.placement = this.placement;
 	}
 
 	@onEvent({ ref: 'trigger', type: 'click' })
@@ -87,14 +65,14 @@ export class RadiantDropdown extends RadiantElement {
 		if (typeof this.triggerTarget.ariaExpanded === 'undefined') this.triggerTarget.ariaExpanded = 'false';
 		this.triggerTarget.setAttribute('aria-expanded', String(this.triggerTarget.ariaExpanded !== 'true'));
 		const isOpen = this.triggerTarget.ariaExpanded === 'true';
-		this.contentTarget.style.display = isOpen ? 'block' : 'none';
+		this.contentTarget.hidden = !isOpen;
+		this.syncPlacement();
 
 		if (isOpen) {
-			this.cleanup = autoUpdate(this.triggerTarget, this.contentTarget, this.updateFloatingUI);
 			document.addEventListener('click', this.closeContent);
 			this.focusOnOpenChanged();
 		} else {
-			this.cleanup?.();
+			document.removeEventListener('click', this.closeContent);
 		}
 	}
 
@@ -114,14 +92,8 @@ export class RadiantDropdown extends RadiantElement {
 	closeContent(event: MouseEvent) {
 		if (!this.triggerTarget.contains(event.target as Node) && !this.contentTarget.contains(event.target as Node)) {
 			this.triggerTarget.setAttribute('aria-expanded', 'false');
-			this.contentTarget.style.display = 'none';
+			this.contentTarget.hidden = true;
 			document.removeEventListener('click', this.closeContent);
-			this.cleanup?.();
 		}
-	}
-
-	disconnectedCallback(): void {
-		super.disconnectedCallback();
-		this.cleanup?.();
 	}
 }

--- a/playground/vite/src/components/dropdown/dropdown.tsx
+++ b/playground/vite/src/components/dropdown/dropdown.tsx
@@ -9,7 +9,7 @@ export const RadiantDropdown = ({ defaultOpen, placement, arrow, children }: Wit
 			<button type="button" data-ref="trigger" class="rui-button rui-button--primary rui-button--md">
 				Open
 			</button>
-			<div data-ref="content">
+			<div data-ref="content" hidden>
 				{children}
 				{arrow ? <div data-ref="arrow"></div> : null}
 			</div>

--- a/playground/vite/src/main.tsx
+++ b/playground/vite/src/main.tsx
@@ -1,8 +1,8 @@
-import type { Placement } from '@floating-ui/dom';
 import { createRoot } from '@ecopages/jsx';
 import { PlaygroundSection } from './components/playground-section/playground-section';
 import { RadiantAccordion } from './components/accordion/accordion';
 import { RadiantDropdown } from './components/dropdown/dropdown';
+import type { RadiantDropdownPlacement } from './components/dropdown/dropdown.script';
 import { RadiantCounter } from './components/radiant-counter/radiant-counter';
 import { RadiantEvent } from './components/radiant-event/radiant-event';
 import { RadiantRefs } from './components/radiant-refs/radiant-refs.view';
@@ -14,14 +14,14 @@ import './styles/tailwind.css';
 const appRoot = document.querySelector<HTMLDivElement>('#app');
 const root = appRoot ? createRoot(appRoot) : null;
 
-const changePlacement = (newPlacement: Placement) => {
+const changePlacement = (newPlacement: RadiantDropdownPlacement) => {
 	document.querySelector('radiant-dropdown')?.setAttribute('placement', newPlacement);
 };
 
 const attachPlacementListener = () => {
 	document.querySelector('#placement')?.addEventListener('change', (e: Event) => {
 		const target = e.target as HTMLSelectElement;
-		changePlacement(target.value as Placement);
+		changePlacement(target.value as RadiantDropdownPlacement);
 	});
 };
 
@@ -48,7 +48,7 @@ const App = () => {
 						]}
 					/>
 					<div class="flex flex-wrap items-center gap-4">
-						<RadiantDropdown placement="left-end" arrow>
+						<RadiantDropdown placement="bottom-start" arrow>
 							<ul class="flex flex-col gap-2 m-0 p-0" style="list-style: none;">
 								<li>
 									<a href="/" class="text-[#2563eb] hover:underline">


### PR DESCRIPTION
## Summary
- Replace `@floating-ui/dom` with an in-package floating helper (`computeFloatingCoords` / `attachFloating`) for tooltip and menu-button placement (fixed coords, primary-axis flip, cross-axis clamp).
- Fix menubar so activating a top-level item without a submenu closes any open menu; align menubar menu gap with menu-button.
- Drop floating-ui from the Vite playground dropdown (CSS positioning) and fix accordion connect race that broke playground e2e.

## Test plan
- [x] Tooltip and menu-button open with correct placement and flip near viewport edges
- [x] Menubar: open File menu, click Edit (no submenu) — menu closes
- [x] Menubar menu gap matches menu-button visually
- [x] `pnpm --filter playground-vite test:e2e` (dropdown + accordion)
- [x] Radiant-ui unit tests for `floating-position` pass