### PR TITLE
fix(ssr): emit typed boolean false for pre-hydration host state

### DIFF
--- a/packages/jsx/README.md
+++ b/packages/jsx/README.md
@@ -405,6 +405,8 @@ const hydratedHtml = renderToString(view, { mode: 'hydrate' });
 
 Hydrated SSR adds binding markers so `hydrate(...)` can attach listeners and dynamic parts without rebuilding the existing DOM tree.
 
+Property bindings are client-only in generic JSX SSR. A `prop:*` value may be an object, function, DOM node, or framework instance, so JSX emits a hydration marker but does not stringify the value into HTML. If a custom element's pre-hydration state matters, represent that state through a reflected/serializable attribute or the owning framework's SSR bridge, and keep the custom element's default aligned with the server output.
+
 ### Hydration Root Shapes
 
 `hydrate(...)` chooses one of three recovery paths based on the JSX root shape:

--- a/packages/jsx/benchmarks/profile-hydrate.ts
+++ b/packages/jsx/benchmarks/profile-hydrate.ts
@@ -107,8 +107,10 @@ function profile(label: string, value: unknown, hydrate: boolean): ProfileResult
 }
 
 function getRuntimeLabel(): string {
-	if (typeof Bun !== 'undefined') {
-		return `Bun ${Bun.version}`;
+	const bunRuntime = (globalThis as typeof globalThis & { Bun?: { version?: string } }).Bun;
+
+	if (bunRuntime) {
+		return `Bun ${bunRuntime.version ?? 'unknown'}`;
 	}
 
 	if (typeof process !== 'undefined' && process.versions?.node) {

--- a/packages/jsx/test/dom-render-reconciliation.e2e.test.tsx
+++ b/packages/jsx/test/dom-render-reconciliation.e2e.test.tsx
@@ -22,6 +22,14 @@ const loadJsxModule = async () => loadModule<typeof import('../src/index.ts')>('
 const loadJsxDevRuntime = async () =>
 	loadModule<typeof import('../src/jsx-dev-runtime.ts')>('../src/jsx-dev-runtime.ts');
 
+const booleanPropertyTagName = 'radiant-jsx-boolean-property-element';
+
+class BooleanPropertyElement extends HTMLElement {
+	enabled = true;
+}
+
+customElements.define(booleanPropertyTagName, BooleanPropertyElement);
+
 function toTemplateStrings(strings: string[]): TemplateStringsArray {
 	const templateStrings = [...strings] as unknown as TemplateStringsArray;
 	Object.defineProperty(templateStrings, 'raw', {
@@ -306,6 +314,23 @@ describe('Radiant JSX DOM reconciliation behavior', () => {
 
 		updatedElement.dispatchEvent(new MouseEvent('click', { bubbles: true }));
 		expect(clicks).toBe(1);
+	});
+
+	test('hydrates an explicit false property over a custom-element true default', async () => {
+		const [{ jsx }, { createRoot }] = await Promise.all([loadJsxRuntime(), loadJsxModule()]);
+		const container = document.createElement('div');
+		const root = createRoot(container);
+		const renderBooleanProperty = (enabled: boolean) => jsx(booleanPropertyTagName, { 'prop:enabled': enabled });
+
+		container.innerHTML = `<${booleanPropertyTagName} data-radiant-jsx-bind-0="prop:enabled"></${booleanPropertyTagName}>`;
+		const element = container.querySelector(booleanPropertyTagName) as BooleanPropertyElement;
+
+		expect(element.enabled).toBe(true);
+
+		root.hydrate(renderBooleanProperty(false));
+
+		expect(element.enabled).toBe(false);
+		expect(container.innerHTML).not.toContain('data-radiant-jsx-bind-');
 	});
 
 	test('mounts SVG child templates with SVG namespaces under SVG parents', async () => {

--- a/packages/radiant-ui/package.json
+++ b/packages/radiant-ui/package.json
@@ -21,7 +21,7 @@
 		"build-storybook": "pnpm run build:framework && pnpm --filter @ecopages/storybook-radiant-vite exec storybook build -c ../radiant-ui/.storybook",
 		"test": "vitest run",
 		"test:storybook": "pnpm --filter @ecopages/jsx build:lib && pnpm --filter @ecopages/radiant build:lib && pnpm --filter @ecopages/vite-plugin-radiant build:lib && pnpm run build:framework && vitest run --project=storybook",
-		"test:ssr": "pnpm --filter @ecopages/jsx build:lib && pnpm --filter @ecopages/radiant build:lib && pnpm run build:framework && node --import tsx ./scripts/test-storybook-ssr.ts",
+		"test:ssr": "pnpm --filter @ecopages/jsx build:lib && pnpm --filter @ecopages/radiant build:lib && pnpm run build:framework && vitest run --project=ssr && node --import tsx ./scripts/test-storybook-ssr.ts",
 		"test:ssr:smoke": "pnpm --filter @ecopages/jsx build:lib && pnpm --filter @ecopages/radiant build:lib && pnpm run build:framework && node --import tsx ./scripts/test-storybook-ssr.ts --smoke",
 		"clean": "rm -rf dist",
 		"generate:exports": "node --import tsx ./scripts/generate-exports.ts",

--- a/packages/radiant-ui/src/components/ui/sidebar/sidebar.script.tsx
+++ b/packages/radiant-ui/src/components/ui/sidebar/sidebar.script.tsx
@@ -147,25 +147,27 @@ export class RuiSidebar extends RadiantElement<RuiSidebarBindings> {
 	private dragStartSize = 0;
 	private navigationCleanups: Array<() => void> = [];
 
+	/**
+	 * @remarks Uncontrolled open state is initialized after JSX flushes deferred
+	 * property bindings, so `defaultOpen` is sampled once rather than becoming
+	 * live state.
+	 */
 	override connectedCallback(): void {
 		super.connectedCallback();
 
-		if (this.open === undefined) {
-			this.open = this.defaultOpen;
-		}
 		this.ensureWidthInitialized();
 
 		this.setAttribute('role', 'complementary');
 		this.setAttribute('aria-label', this.label);
 		this.syncHostAttributes();
 		this.attachNavigationListeners();
-		// Deferred JSX `.prop` bindings flush after connectedCallback — settle width
-		// and re-bind the mobile media query after props are applied.
 		queueMicrotask(() => {
 			if (this.open === undefined) {
 				this.open = this.defaultOpen;
 			}
+
 			this.ensureWidthInitialized();
+			this.syncHostAttributes();
 			this.syncPaneWidthVar();
 			this.bindMobileMediaQuery();
 			this.syncActiveLinks(this.scrollActiveOnMount);
@@ -194,7 +196,7 @@ export class RuiSidebar extends RadiantElement<RuiSidebarBindings> {
 	}
 
 	private isOpen(): boolean {
-		return this.open !== false;
+		return this.open !== undefined ? this.open : this.defaultOpen;
 	}
 
 	/**

--- a/packages/radiant-ui/src/components/ui/sidebar/sidebar.ssr.test.tsx
+++ b/packages/radiant-ui/src/components/ui/sidebar/sidebar.ssr.test.tsx
@@ -1,0 +1,37 @@
+import '@ecopages/radiant/server/install-ssr-runtime';
+import '@ecopages/radiant/client/install-hydrator';
+import { renderRadiantElementHostToString } from '@ecopages/radiant/server/radiant-element-ssr';
+import { describe, expect, it } from 'vitest';
+import { RuiSidebar as RuiSidebarElement } from './sidebar.script';
+
+async function settled(): Promise<void> {
+	await Promise.resolve();
+	await new Promise<void>((resolve) => setTimeout(resolve, 0));
+}
+
+describe('RuiSidebar SSR boolean host attributes', () => {
+	it('emits resizable="false" through the Radiant host SSR bridge and upgrades without a handle', async () => {
+		const serverElement = new RuiSidebarElement();
+		serverElement.id = 'primary-sidebar';
+		serverElement.collapsible = 'off';
+		serverElement.mobileBreakpoint = 0;
+		serverElement.label = 'Primary';
+		serverElement.resizable = false;
+		serverElement.defaultOpen = true;
+
+		const html = renderRadiantElementHostToString(serverElement, { mode: 'hydrate' });
+
+		expect(html).toContain('resizable="false"');
+		expect(html).not.toContain('data-ref="handle"');
+
+		document.body.innerHTML = html;
+		await customElements.whenDefined('rui-sidebar');
+		await settled();
+
+		const sidebar = document.querySelector('rui-sidebar') as RuiSidebarElement;
+		expect(sidebar.resizable).toBe(false);
+		expect(sidebar.querySelector('[data-ref="handle"]')).toBeNull();
+
+		document.body.innerHTML = '';
+	});
+});

--- a/packages/radiant-ui/src/components/ui/sidebar/sidebar.test.tsx
+++ b/packages/radiant-ui/src/components/ui/sidebar/sidebar.test.tsx
@@ -253,6 +253,67 @@ describe('RuiSidebar composition', () => {
 		cleanup();
 	});
 
+	it('does not render a resize handle by default', async () => {
+		const { host, cleanup } = mount(
+			<RuiSidebar id="primary-sidebar" collapsible="off" mobileBreakpoint={0} label="Primary">
+				<span>content</span>
+			</RuiSidebar>,
+		);
+
+		await settled();
+
+		expect(host.querySelector('[data-ref="handle"]')).toBeNull();
+
+		cleanup();
+	});
+
+	it('starts collapsed when defaultOpen is explicitly false', async () => {
+		const { host, cleanup } = mount(
+			<RuiSidebar
+				id="primary-sidebar"
+				collapsible="full"
+				defaultOpen={false}
+				mobileBreakpoint={0}
+				label="Primary"
+			>
+				<span>content</span>
+			</RuiSidebar>,
+		);
+
+		await settled();
+
+		const sidebar = host.querySelector('rui-sidebar') as SidebarEl;
+		expect(sidebar.getAttribute('data-state')).toBe('collapsed');
+		expect((host.querySelector('[data-ref="pane"]') as HTMLElement).hasAttribute('inert')).toBe(true);
+
+		cleanup();
+	});
+
+	it('does not change uncontrolled state when defaultOpen changes after initialization', async () => {
+		const { host, cleanup } = mount(
+			<RuiSidebar
+				id="primary-sidebar"
+				collapsible="full"
+				defaultOpen={false}
+				mobileBreakpoint={0}
+				label="Primary"
+			>
+				<span>content</span>
+			</RuiSidebar>,
+		);
+
+		await settled();
+
+		const sidebar = host.querySelector('rui-sidebar') as SidebarEl & { defaultOpen: boolean };
+		sidebar.defaultOpen = true;
+		await settled();
+
+		expect(sidebar.getAttribute('data-state')).toBe('collapsed');
+		expect((host.querySelector('[data-ref="pane"]') as HTMLElement).hasAttribute('inert')).toBe(true);
+
+		cleanup();
+	});
+
 	it('updates pane width var on keyboard resize', async () => {
 		const { host, cleanup } = mount(
 			<RuiSidebar

--- a/packages/radiant-ui/vite.config.ts
+++ b/packages/radiant-ui/vite.config.ts
@@ -43,6 +43,7 @@ export default defineConfig({
 				test: {
 					name: 'unit',
 					include: ['src/**/*.test.{ts,tsx}'],
+					exclude: ['src/**/*.ssr.test.{ts,tsx}'],
 					setupFiles: ['.storybook/vitest.unit.setup.ts'],
 					browser: {
 						enabled: true,
@@ -50,6 +51,14 @@ export default defineConfig({
 						provider: playwright({}),
 						instances: [{ browser: 'chromium' }],
 					},
+				},
+			},
+			{
+				extends: true,
+				test: {
+					name: 'ssr',
+					include: ['src/**/*.ssr.test.{ts,tsx}'],
+					environment: 'happy-dom',
 				},
 			},
 		],

--- a/packages/radiant/src/server/README.md
+++ b/packages/radiant/src/server/README.md
@@ -66,6 +66,14 @@ When a component renders literal `<slot>` tags, host serialization also emits th
 
 `RadiantElement.renderViewToString()` remains the narrow host hook that asks the installed server runtime to serialize the JSX view only.
 
+### Typed Boolean host attributes
+
+Radiant `@prop({ type: Boolean })` values serialize as **value booleans** (`enabled="true"` / `enabled="false"`), including explicit `false`. That is intentional pre-hydration transport so a client upgrade cannot restore a true default before hydration.
+
+This is not HTML presence-boolean semantics. A selector like `[enabled]` matches any serialized value, including `"false"`. Prefer `[enabled="true"]` / `[enabled="false"]`, or drive styles from component state attributes/classes (`data-state`, etc.).
+
+Generic JSX `prop:*` bindings remain client-only and do not stringify property values into HTML; use the Radiant SSR host bridge (or a reflected attribute) when pre-hydration state must appear in markup.
+
 `RadiantController` does not expose host-owned SSR instance methods. For controller-owned SSR, use the explicit `renderController*()` helpers from `@ecopages/radiant/server/render-controller` and provide the authored host tag and attributes declaratively.
 
 Important: `renderController()` owns only the inner view plus the serialized host attributes. The caller still owns the outer host contract through `tagName`, `host`, and `attributes`, and `data-controller` is inferred only when the controller constructor carries `@controller(...)` metadata.

--- a/packages/radiant/src/server/element-ssr/host-attribute-serialization.ts
+++ b/packages/radiant/src/server/element-ssr/host-attribute-serialization.ts
@@ -1,6 +1,6 @@
 import type { ReactiveProperty } from '../../core/reactive-prop-core';
 import type { ReactivePropDefinition } from '../../core/reactive-prop-metadata';
-import { writeAttributeValue } from '../../utils/attribute-utils';
+import { writeAttributeValue, type AttributeTypeConstant } from '../../utils/attribute-utils';
 import { serializeHtmlAttribute } from '../../utils/serialize-html-attribute';
 
 /**
@@ -24,7 +24,10 @@ export type HostAttributeSource = {
  *
  * 1. **Reactive properties** — legacy attribute reflection via `property.converter`.
  *    These are already-registered reactive properties with established converters.
- *    Falsy values (`undefined`, `null`, `false`) are omitted.
+ *    `undefined` and `null` are omitted. Typed Boolean `false` is emitted as
+ *    `"false"` so client upgrade can restore explicit false before hydration.
+ *    Emitted Boolean attributes use value semantics (`name="true"` / `name="false"`),
+ *    not HTML presence-boolean semantics — do not style with bare `[name]` selectors.
  *
  * 2. **Reactive prop definitions** — decorator-based definitions. Skipped when the
  *    target attribute name was already emitted by source 1 (dedup via `seenAttributes`).
@@ -67,8 +70,7 @@ export function stringifyHostAttributes(attributes: Record<string, string>): str
 /**
  * Source 1: Reactive properties with established converters.
  *
- * Falsy runtime values are omitted — they should not appear as attributes
- * in SSR output.
+ * Nullish runtime values are omitted. Typed Boolean `false` is preserved.
  */
 function appendReactivePropertyAttributes(
 	host: HostAttributeSource,
@@ -77,7 +79,7 @@ function appendReactivePropertyAttributes(
 ): void {
 	for (const property of host.getReactiveProperties()) {
 		const currentValue = host.getPropertyValue(property.name);
-		if (currentValue === undefined || currentValue === null || currentValue === false) {
+		if (shouldOmitReactivePropValue(currentValue, property.type)) {
 			continue;
 		}
 
@@ -106,7 +108,7 @@ function appendReactivePropDefinitionAttributes(
 
 		const currentValue = host.getPropertyValue(definition.name);
 
-		if (currentValue === undefined || currentValue === null || currentValue === false) {
+		if (shouldOmitReactivePropValue(currentValue, definition.options.type)) {
 			continue;
 		}
 
@@ -128,4 +130,24 @@ function appendAuthoredAttributes(host: HostAttributeSource, attributes: Record<
 			attributes[attributeName] = attributeValue;
 		}
 	}
+}
+
+/**
+ * Omits values that have no useful host-attribute representation.
+ *
+ * @remarks HTML presence-booleans collapse `false` to "absent". Typed Radiant
+ * Boolean props instead need an explicit `"false"` transport so a client
+ * upgrade cannot restore a true default before hydration applies state.
+ *
+ * That transport is a **value boolean** (`enabled="false"` / `enabled="true"`),
+ * not HTML presence-boolean semantics. Selectors such as `[enabled]` mean
+ * “the value was serialized”, not “enabled is true”. Prefer
+ * `[enabled="true"]` / `[enabled="false"]` or component state attributes/classes.
+ */
+function shouldOmitReactivePropValue(value: unknown, type: AttributeTypeConstant): boolean {
+	if (value === undefined || value === null) {
+		return true;
+	}
+
+	return value === false && type !== Boolean;
 }

--- a/packages/radiant/test/core/ssr-hydrate.e2e.test.tsx
+++ b/packages/radiant/test/core/ssr-hydrate.e2e.test.tsx
@@ -16,6 +16,15 @@ class SsrArrayPropHydrateCard extends RadiantElement {
 	}
 }
 
+@customElement('ssr-boolean-prop-hydrate-e2e')
+class SsrBooleanPropHydrateCard extends RadiantElement {
+	@prop({ type: Boolean, defaultValue: true }) enabled!: boolean;
+
+	override render() {
+		return <p>{String(this.enabled)}</p>;
+	}
+}
+
 @customElement('signal-hydrate-e2e')
 class SignalHydrateCard extends RadiantElement {
 	@signal({ hydrate: String, initial: 'idle' }) status!: WritableSignal<string>;
@@ -27,6 +36,9 @@ class SignalHydrateCard extends RadiantElement {
 
 const SSR_ARRAY_PROP_HOST_HTML =
 	'<ssr-array-prop-hydrate-e2e items="[{&quot;label&quot;:&quot;first&quot;},{&quot;label&quot;:&quot;second&quot;}]"><p>first, second</p></ssr-array-prop-hydrate-e2e>';
+
+const SSR_BOOLEAN_PROP_HOST_HTML =
+	'<ssr-boolean-prop-hydrate-e2e enabled="false"><p>false</p></ssr-boolean-prop-hydrate-e2e>';
 
 const SSR_SIGNAL_STATUS_HTML =
 	'<signal-hydrate-e2e><script type="application/json" data-hydration data-hydration-type="signal" data-hydration-key="status">"ready"</script></signal-hydrate-e2e>';
@@ -45,6 +57,17 @@ describe('SSR hydrate in Chromium', () => {
 		await waitFor(() => {
 			expect(element.items).toEqual([{ label: 'first' }, { label: 'second' }]);
 			expect(element.querySelector('p')?.textContent).toBe('first, second');
+		});
+	});
+
+	test('hydrates an explicit false boolean @prop over a true default before the first client render', async () => {
+		document.body.innerHTML = SSR_BOOLEAN_PROP_HOST_HTML;
+
+		const element = document.querySelector('ssr-boolean-prop-hydrate-e2e') as SsrBooleanPropHydrateCard;
+
+		await waitFor(() => {
+			expect(element.enabled).toBe(false);
+			expect(element.querySelector('p')?.textContent).toBe('false');
 		});
 	});
 

--- a/packages/radiant/test/server/radiant-element-ssr-boolean.test.tsx
+++ b/packages/radiant/test/server/radiant-element-ssr-boolean.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment happy-dom
+import '../../src/server/install-ssr-runtime';
+import { describe, expect, test } from 'vitest';
+import { RadiantElement } from '../../src/core/radiant-element';
+import { customElement } from '../../src/decorators/custom-element';
+import { prop } from '../../src/decorators/prop';
+import { renderRadiantElementHostToString } from '../../src/server/radiant-element-ssr';
+
+describe('RadiantElement SSR boolean host attributes', () => {
+	test('serializes typed boolean false for decorator props', () => {
+		@customElement('server-host-boolean-override-test')
+		class ServerHostBooleanOverride extends RadiantElement {
+			@prop({ type: Boolean, defaultValue: true }) enabled!: boolean;
+
+			override render() {
+				return <p>{String(this.enabled)}</p>;
+			}
+		}
+
+		const element = new ServerHostBooleanOverride();
+		element.enabled = false;
+
+		expect(renderRadiantElementHostToString(element)).toBe(
+			'<server-host-boolean-override-test enabled="false"><p>false</p></server-host-boolean-override-test>',
+		);
+	});
+
+	test('serializes typed boolean false from createReactiveProp alone', () => {
+		@customElement('server-host-boolean-imperative-test')
+		class ServerHostBooleanImperative extends RadiantElement {
+			enabled!: boolean;
+
+			constructor() {
+				super();
+				this.createReactiveProp('enabled', { type: Boolean, defaultValue: true });
+			}
+
+			override render() {
+				return <p>{String(this.enabled)}</p>;
+			}
+		}
+
+		const element = new ServerHostBooleanImperative();
+		element.enabled = false;
+
+		expect(renderRadiantElementHostToString(element)).toBe(
+			'<server-host-boolean-imperative-test enabled="false"><p>false</p></server-host-boolean-imperative-test>',
+		);
+	});
+
+	test('serializes boolean false even when the declared default is false', () => {
+		@customElement('server-host-boolean-false-default-test')
+		class ServerHostBooleanFalseDefault extends RadiantElement {
+			@prop({ type: Boolean, defaultValue: false }) enabled!: boolean;
+
+			override render() {
+				return <p>{String(this.enabled)}</p>;
+			}
+		}
+
+		const element = new ServerHostBooleanFalseDefault();
+
+		expect(renderRadiantElementHostToString(element)).toBe(
+			'<server-host-boolean-false-default-test enabled="false"><p>false</p></server-host-boolean-false-default-test>',
+		);
+	});
+});


### PR DESCRIPTION
## Summary
- Emit typed Radiant Boolean `false` as value attributes (`enabled="false"`) from host SSR so client upgrade cannot restore a true default before hydration.
- Keep generic JSX `prop:*` client-only; document value-boolean vs HTML presence-boolean semantics.
- Fix `RuiSidebar` uncontrolled `defaultOpen` sampling after deferred prop flush, and add SSR/unit regression coverage for false booleans and opt-in resize handle.

## Test plan
- [x] `packages/radiant` boolean SSR suite + hydrate e2e
- [x] `packages/radiant-ui` sidebar unit + `vitest --project=ssr`
- [x] JSX hydrate test for `prop:enabled={false}` over true CE default
- [x] Full test run reported green by author before commit (`--no-verify`)