### PR TITLE
refactor(radiant-ui,jsx): JsxHtmlProps host bag and spread-first views

### DIFF
--- a/apps/docs/src/layouts/docs-layout/docs-layout.tsx
+++ b/apps/docs/src/layouts/docs-layout/docs-layout.tsx
@@ -116,7 +116,7 @@ export const DocsLayout = eco.component<DocsLayoutProps, JsxRenderable>({
 					sidebar={
 						<RuiSidebar
 							id={DOCS_SIDEBAR_ID}
-							data-eco-persist={DOCS_SIDEBAR_ID}
+							data={{ ecoPersist: DOCS_SIDEBAR_ID }}
 							collapsible="off"
 							defaultWidth={250}
 							mobileBreakpoint={768}

--- a/apps/docs/src/layouts/docs-layout/docs-layout.tsx
+++ b/apps/docs/src/layouts/docs-layout/docs-layout.tsx
@@ -116,6 +116,7 @@ export const DocsLayout = eco.component<DocsLayoutProps, JsxRenderable>({
 					sidebar={
 						<RuiSidebar
 							id={DOCS_SIDEBAR_ID}
+							data-eco-persist={DOCS_SIDEBAR_ID}
 							collapsible="off"
 							defaultWidth={250}
 							mobileBreakpoint={768}

--- a/packages/radiant-ui/AGENTS.md
+++ b/packages/radiant-ui/AGENTS.md
@@ -15,6 +15,10 @@ Guidance for humans and agents working on the design system in `packages/radiant
 - Shared types from `src/types.ts` → `@/types`.
 - Same-component and sibling UI imports → `./` and `../` only.
 
+## View host props
+
+Views that render a DOM host should extend `RadiantHostProps` and rest-spread those attrs onto the host (`const { …componentProps, ...host } = props` → `<rui-x {...host} />`). Compose `class` after the spread when needed.
+
 ## CSS architecture (two layers)
 
 1. **Theme** — CSS variables (packs + semantic roles). Loaded by the app or Storybook, not by individual component stylesheets.

--- a/packages/radiant-ui/src/components/ui/button/button.tsx
+++ b/packages/radiant-ui/src/components/ui/button/button.tsx
@@ -45,10 +45,6 @@ function cx(...parts: Array<string | false | null | undefined>): string {
 	return parts.filter(Boolean).join(' ');
 }
 
-function getClassNames({ variant = 'filled', size = 'md', class: className }: RuiButtonProps): string {
-	return cx('rui-button', `rui-button--${variant}`, `rui-button--${size}`, className);
-}
-
 function resolveAriaPressed(
 	pressed: boolean | undefined,
 	toggle: boolean,
@@ -77,23 +73,34 @@ function resolveAriaPressed(
  */
 export function RuiButton(props: RuiButtonProps) {
 	if (props.href !== undefined) {
+		const {
+			href,
+			target,
+			rel,
+			download,
+			'aria-label': ariaLabel,
+			'aria-current': ariaCurrent,
+			'on:click': onClick,
+			children,
+			class: className,
+			variant,
+			size,
+			...host
+		} = props;
+
 		return (
 			<a
-				href={props.href}
-				target={props.target}
-				rel={props.rel}
-				download={props.download}
-				slot={props.slot}
-				class={getClassNames(props)}
-				classes={props.classes}
-				aria-label={props['aria-label']}
-				aria-current={props['aria-current']}
-				aria={props.aria}
-				data={props.data}
-				style={props.style}
-				on:click={props['on:click']}
+				{...host}
+				href={href}
+				target={target}
+				rel={rel}
+				download={download}
+				class={cx('rui-button', `rui-button--${variant ?? 'filled'}`, `rui-button--${size ?? 'md'}`, className)}
+				aria-label={ariaLabel}
+				aria-current={ariaCurrent}
+				on:click={onClick}
 			>
-				{props.children}
+				{children}
 			</a>
 		);
 	}
@@ -102,7 +109,6 @@ export function RuiButton(props: RuiButtonProps) {
 		variant,
 		size,
 		class: className,
-		slot,
 		children,
 		'aria-label': ariaLabel,
 		type = 'button',
@@ -111,7 +117,7 @@ export function RuiButton(props: RuiButtonProps) {
 		defaultPressed = false,
 		toggle = false,
 		'on:click': onClick,
-		...rest
+		...host
 	} = props;
 	const handleClick = (event: Event) => {
 		if (toggle && pressed === undefined) {
@@ -125,15 +131,14 @@ export function RuiButton(props: RuiButtonProps) {
 
 	return (
 		<button
+			{...host}
 			type={type}
-			slot={slot}
 			class={cx('rui-button', `rui-button--${variant ?? 'filled'}`, `rui-button--${size ?? 'md'}`, className)}
 			disabled={disabled}
 			aria-label={ariaLabel}
 			aria-pressed={resolveAriaPressed(pressed, toggle, defaultPressed)}
 			data-toggle={toggle && pressed === undefined ? '' : undefined}
 			on:click={toggle || onClick ? handleClick : undefined}
-			{...rest}
 		>
 			{children}
 		</button>

--- a/packages/radiant-ui/src/components/ui/button/button.tsx
+++ b/packages/radiant-ui/src/components/ui/button/button.tsx
@@ -1,20 +1,16 @@
 import type { JsxRenderable } from '@ecopages/jsx';
-import type { RadiantSlotProps } from '@/types';
+import type { RadiantHostProps } from '@/types';
 
 export type RuiButtonVariant = 'filled' | 'outline' | 'destructive' | 'ghost';
 export type RuiButtonSize = 'sm' | 'md' | 'lg';
 
-type RuiButtonCommonProps = RadiantSlotProps & {
+type RuiButtonCommonProps = RadiantHostProps & {
 	/** Visual style. Default: `filled`. */
 	variant?: RuiButtonVariant;
 	/** Control size. Default: `md`. */
 	size?: RuiButtonSize;
-	/** Extra class names appended after the variant/size classes. */
-	class?: string;
 	/** Accessible name when the button has no visible text. */
 	'aria-label'?: string;
-	/** Data attributes forwarded to the native control. */
-	data?: Record<string, boolean | number | string | undefined>;
 	children?: JsxRenderable;
 };
 
@@ -89,9 +85,12 @@ export function RuiButton(props: RuiButtonProps) {
 				download={props.download}
 				slot={props.slot}
 				class={getClassNames(props)}
+				classes={props.classes}
 				aria-label={props['aria-label']}
 				aria-current={props['aria-current']}
+				aria={props.aria}
 				data={props.data}
+				style={props.style}
 				on:click={props['on:click']}
 			>
 				{props.children}

--- a/packages/radiant-ui/src/components/ui/sidebar/sidebar.tsx
+++ b/packages/radiant-ui/src/components/ui/sidebar/sidebar.tsx
@@ -315,6 +315,11 @@ export type RuiSidebarViewProps = RuiSidebarProps &
 		id: string;
 		children: JsxRenderable;
 		class?: string;
+		/**
+		 * Stable key for `@ecopages/browser-router` DOM persistence.
+		 * When set, morphdom keeps this host (and its scroll position) across SPA navigations.
+		 */
+		'data-eco-persist'?: string;
 	};
 
 export const RuiSidebar = defineRadiantView(
@@ -337,12 +342,14 @@ export const RuiSidebar = defineRadiantView(
 		scrollActiveOnMount,
 		navigationEvents,
 		class: className,
+		'data-eco-persist': ecoPersist,
 		children,
 	}: RuiSidebarViewProps) => (
 		<rui-sidebar
 			slot={slot}
 			id={id}
 			class={className}
+			data-eco-persist={ecoPersist}
 			variant={variant as RuiSidebarVariant | undefined}
 			side={side as RuiSidebarSide | undefined}
 			collapsible={collapsible as RuiSidebarCollapsible | undefined}

--- a/packages/radiant-ui/src/components/ui/sidebar/sidebar.tsx
+++ b/packages/radiant-ui/src/components/ui/sidebar/sidebar.tsx
@@ -315,11 +315,8 @@ export type RuiSidebarViewProps = RuiSidebarProps &
 		id: string;
 		children: JsxRenderable;
 		class?: string;
-		/**
-		 * Stable key for `@ecopages/browser-router` DOM persistence.
-		 * When set, morphdom keeps this host (and its scroll position) across SPA navigations.
-		 */
-		'data-eco-persist'?: string;
+		/** Data attributes forwarded to the host (`data-eco-persist`, etc.). */
+		data?: Record<string, boolean | number | string | undefined>;
 	};
 
 export const RuiSidebar = defineRadiantView(
@@ -342,14 +339,14 @@ export const RuiSidebar = defineRadiantView(
 		scrollActiveOnMount,
 		navigationEvents,
 		class: className,
-		'data-eco-persist': ecoPersist,
+		data,
 		children,
 	}: RuiSidebarViewProps) => (
 		<rui-sidebar
 			slot={slot}
 			id={id}
 			class={className}
-			data-eco-persist={ecoPersist}
+			data={data}
 			variant={variant as RuiSidebarVariant | undefined}
 			side={side as RuiSidebarSide | undefined}
 			collapsible={collapsible as RuiSidebarCollapsible | undefined}

--- a/packages/radiant-ui/src/components/ui/sidebar/sidebar.tsx
+++ b/packages/radiant-ui/src/components/ui/sidebar/sidebar.tsx
@@ -1,5 +1,5 @@
 import type { JsxRenderable } from '@ecopages/jsx';
-import type { RadiantSlotProps } from '@/types';
+import type { RadiantHostProps } from '@/types';
 import { defineRadiantView } from '@/lib/radiant-view';
 import type {
 	RuiSidebarProps,
@@ -311,12 +311,9 @@ export function RuiSidebarInset({ children, class: className, id }: RuiSidebarIn
 }
 
 export type RuiSidebarViewProps = RuiSidebarProps &
-	RadiantSlotProps & {
+	RadiantHostProps & {
 		id: string;
 		children: JsxRenderable;
-		class?: string;
-		/** Data attributes forwarded to the host (`data-eco-persist`, etc.). */
-		data?: Record<string, boolean | number | string | undefined>;
 	};
 
 export const RuiSidebar = defineRadiantView(
@@ -339,14 +336,20 @@ export const RuiSidebar = defineRadiantView(
 		scrollActiveOnMount,
 		navigationEvents,
 		class: className,
+		classes,
 		data,
+		aria,
+		style,
 		children,
 	}: RuiSidebarViewProps) => (
 		<rui-sidebar
 			slot={slot}
 			id={id}
 			class={className}
+			classes={classes}
 			data={data}
+			aria={aria}
+			style={style}
 			variant={variant as RuiSidebarVariant | undefined}
 			side={side as RuiSidebarSide | undefined}
 			collapsible={collapsible as RuiSidebarCollapsible | undefined}
@@ -370,9 +373,8 @@ export const RuiSidebar = defineRadiantView(
 );
 
 export type RuiSidebarTriggerViewProps = RuiSidebarTriggerProps &
-	RadiantSlotProps & {
+	RadiantHostProps & {
 		children?: JsxRenderable;
-		class?: string;
 	};
 
 export const RuiSidebarTrigger = defineRadiantView(
@@ -385,11 +387,19 @@ export const RuiSidebarTrigger = defineRadiantView(
 		variant,
 		size,
 		class: className,
+		classes,
+		data,
+		aria,
+		style,
 		children,
 	}: RuiSidebarTriggerViewProps) => (
 		<rui-sidebar-trigger
 			slot={slot}
 			class={className}
+			classes={classes}
+			data={data}
+			aria={aria}
+			style={style}
 			prop:controls={controls}
 			prop:buttonLabel={triggerLabel ?? 'Toggle sidebar'}
 			attr:data-button-label={triggerLabel ?? 'Toggle sidebar'}

--- a/packages/radiant-ui/src/components/ui/sidebar/sidebar.tsx
+++ b/packages/radiant-ui/src/components/ui/sidebar/sidebar.tsx
@@ -316,10 +316,8 @@ export type RuiSidebarViewProps = RuiSidebarProps &
 		children: JsxRenderable;
 	};
 
-export const RuiSidebar = defineRadiantView(
-	RuiSidebarElement,
-	({
-		slot,
+export const RuiSidebar = defineRadiantView(RuiSidebarElement, (props: RuiSidebarViewProps) => {
+	const {
 		id,
 		variant,
 		side,
@@ -335,21 +333,14 @@ export const RuiSidebar = defineRadiantView(
 		matchMode,
 		scrollActiveOnMount,
 		navigationEvents,
-		class: className,
-		classes,
-		data,
-		aria,
-		style,
 		children,
-	}: RuiSidebarViewProps) => (
+		...host
+	} = props;
+
+	return (
 		<rui-sidebar
-			slot={slot}
+			{...host}
 			id={id}
-			class={className}
-			classes={classes}
-			data={data}
-			aria={aria}
-			style={style}
 			variant={variant as RuiSidebarVariant | undefined}
 			side={side as RuiSidebarSide | undefined}
 			collapsible={collapsible as RuiSidebarCollapsible | undefined}
@@ -367,10 +358,8 @@ export const RuiSidebar = defineRadiantView(
 		>
 			{children}
 		</rui-sidebar>
-	),
-
-	{ stylesheets: ['./sidebar.css'] },
-);
+	);
+}, { stylesheets: ['./sidebar.css'] });
 
 export type RuiSidebarTriggerViewProps = RuiSidebarTriggerProps &
 	RadiantHostProps & {
@@ -379,38 +368,23 @@ export type RuiSidebarTriggerViewProps = RuiSidebarTriggerProps &
 
 export const RuiSidebarTrigger = defineRadiantView(
 	RuiSidebarTriggerElement,
-	({
-		slot,
-		controls,
-		triggerLabel,
-		placement,
-		variant,
-		size,
-		class: className,
-		classes,
-		data,
-		aria,
-		style,
-		children,
-	}: RuiSidebarTriggerViewProps) => (
-		<rui-sidebar-trigger
-			slot={slot}
-			class={className}
-			classes={classes}
-			data={data}
-			aria={aria}
-			style={style}
-			prop:controls={controls}
-			prop:buttonLabel={triggerLabel ?? 'Toggle sidebar'}
-			attr:data-button-label={triggerLabel ?? 'Toggle sidebar'}
-			prop:placement={placement}
-			attr:data-placement={placement}
-			variant={variant}
-			size={size}
-		>
-			{children}
-		</rui-sidebar-trigger>
-	),
+	(props: RuiSidebarTriggerViewProps) => {
+		const { controls, triggerLabel, placement, variant, size, children, ...host } = props;
 
+		return (
+			<rui-sidebar-trigger
+				{...host}
+				prop:controls={controls}
+				prop:buttonLabel={triggerLabel ?? 'Toggle sidebar'}
+				attr:data-button-label={triggerLabel ?? 'Toggle sidebar'}
+				prop:placement={placement}
+				attr:data-placement={placement}
+				variant={variant}
+				size={size}
+			>
+				{children}
+			</rui-sidebar-trigger>
+		);
+	},
 	{ stylesheets: ['./sidebar.css'] },
 );

--- a/packages/radiant-ui/src/types.ts
+++ b/packages/radiant-ui/src/types.ts
@@ -1,4 +1,4 @@
-import type { JsxRenderable } from '@ecopages/jsx';
+import type { JsxHtmlProps, JsxRenderable } from '@ecopages/jsx';
 
 export type WithChildren<T = unknown> = T & { children?: JsxRenderable };
 
@@ -8,6 +8,15 @@ export type WithChildrenAndClassName<T = unknown> = WithChildren<T> & { classNam
 export type RadiantSlotProps = {
 	slot?: string;
 };
+
+/**
+ * Shared host props for radiant-ui views that forward onto a DOM host.
+ *
+ * @remarks
+ * Built from `JsxHtmlProps` plus `slot` so views do not redeclare
+ * `class` / `classes` / `data` / `aria` / `style` per component.
+ */
+export type RadiantHostProps = RadiantSlotProps & Pick<JsxHtmlProps, 'class' | 'classes' | 'data' | 'aria' | 'style'>;
 
 export type FocusableElement =
 	| HTMLAnchorElement


### PR DESCRIPTION
## Summary
- Add `JsxHtmlProps` / `JsxHtmlPropsWithChildren` in `@ecopages/jsx` for shared host attrs (`class`, `classes`, `aria`, `data`, `style`)
- Migrate radiant-ui views to spread-first hosts with explicit `children`; peel only for view-only data, `prop:` bindings, or `cx()` class merges
- Export shared `cx` from `@ecopages/radiant-ui/cx`
- Fix docs sidebar scroll by persisting the sidebar host with `data={{ ecoPersist: 'docs-sidebar' }}`

## Test plan
- [x] Open docs, scroll the sidebar, click several nav links — scroll position preserved
- [x] Confirm active link still updates after navigation
- [x] Confirm theme toggle is not duplicated
- [x] `pnpm --filter @ecopages/radiant-ui typecheck`
- [x] `pnpm --filter @ecopages/radiant-ui build:lib`