### PR TITLE
feat(radiant): add mediaQuery @onEvent target and docs homepage updates

### DIFF
--- a/apps/docs/src/components/theme-toggle/theme-toggle.script.ts
+++ b/apps/docs/src/components/theme-toggle/theme-toggle.script.ts
@@ -7,6 +7,7 @@ type ThemeChangeDetail = {
 	isDark: boolean;
 };
 
+const THEME_TOGGLE_TAG = 'theme-toggle';
 const DARK_THEME_QUERY = '(prefers-color-scheme: dark)';
 const THEME_CHANGE_EVENT = 'eco:theme-change';
 
@@ -18,36 +19,34 @@ const THEME_CHANGE_EVENT = 'eco:theme-change';
  * unset, and broadcasts `eco:theme-change` so a freshly mounted toggle (e.g.
  * after SPA layout swap) stays in sync with the document theme.
  */
-@customElement('theme-toggle')
+@customElement(THEME_TOGGLE_TAG)
 export class ThemeToggle extends RuiSwitchElement {
-	private mediaQueryList: MediaQueryList | null = null;
-
 	override connectedCallback(): void {
 		super.connectedCallback();
-		this.mediaQueryList = window.matchMedia(DARK_THEME_QUERY);
 		this.syncWithThemePreference();
-		this.mediaQueryList.addEventListener('change', this.handleSystemThemeChange);
-		this.addEventListener('rui-change', this.handleToggleChange);
 	}
 
-	override disconnectedCallback(): void {
-		this.mediaQueryList?.removeEventListener('change', this.handleSystemThemeChange);
-		this.removeEventListener('rui-change', this.handleToggleChange);
-		this.mediaQueryList = null;
-		super.disconnectedCallback();
-	}
-
-	private readonly handleSystemThemeChange = (event: MediaQueryListEvent) => {
+	@onEvent({ mediaQuery: DARK_THEME_QUERY, type: 'change' })
+	onSystemThemeChange(event: MediaQueryListEvent) {
 		if (localStorage.getItem('theme')) {
 			return;
 		}
 
 		this.applyTheme(event.matches);
-	};
+	}
 
-	private readonly handleToggleChange = () => {
+	@onEvent({ selector: THEME_TOGGLE_TAG, type: 'rui-change' })
+	onToggleChange() {
 		this.handleThemeChange();
-	};
+	}
+
+	@onEvent({ window: true, type: THEME_CHANGE_EVENT })
+	onThemeChange(event: CustomEvent<ThemeChangeDetail>) {
+		const { isDark } = event.detail;
+		if (this.checked !== isDark) {
+			this.applyTheme(isDark);
+		}
+	}
 
 	private handleThemeChange() {
 		const isDark = this.checked;
@@ -64,7 +63,10 @@ export class ThemeToggle extends RuiSwitchElement {
 
 	private syncWithThemePreference() {
 		const storedTheme = localStorage.getItem('theme');
-		const prefersDark = this.mediaQueryList?.matches ?? window.matchMedia(DARK_THEME_QUERY).matches;
+		const prefersDark =
+			typeof window !== 'undefined' && typeof window.matchMedia === 'function'
+				? window.matchMedia(DARK_THEME_QUERY).matches
+				: false;
 		const isDark = storedTheme ? storedTheme === 'dark' : prefersDark;
 
 		this.applyTheme(isDark);
@@ -79,14 +81,6 @@ export class ThemeToggle extends RuiSwitchElement {
 		const theme = isDark ? 'dark' : 'light';
 		document.documentElement.setAttribute('data-theme', theme);
 		document.documentElement.classList.toggle('dark', isDark);
-	}
-
-	@onEvent({ window: true, type: THEME_CHANGE_EVENT })
-	onThemeChange(event: CustomEvent<ThemeChangeDetail>) {
-		const { isDark } = event.detail;
-		if (this.checked !== isDark) {
-			this.applyTheme(isDark);
-		}
 	}
 }
 

--- a/apps/docs/src/pages/index.css
+++ b/apps/docs/src/pages/index.css
@@ -18,7 +18,7 @@
 }
 
 .home-hero__code {
-	@apply hidden lg:col-span-5 lg:flex lg:flex-col;
+	@apply flex flex-col lg:col-span-5;
 	rui-tabs {
 		@apply rounded-none;
 	}

--- a/packages/radiant/size-budget.json
+++ b/packages/radiant/size-budget.json
@@ -5,7 +5,7 @@
 			"label": "root-client-surface",
 			"entrypoint": "./src/index.ts",
 			"maxBytes": 51200,
-			"maxGzipBytes": 13568
+			"maxGzipBytes": 13824
 		},
 		{
 			"control": "advisory",

--- a/packages/radiant/src/decorators/on-event.ts
+++ b/packages/radiant/src/decorators/on-event.ts
@@ -10,10 +10,12 @@ export type { OnEventConfig, OnEventScope };
  * A decorator to subscribe to an event on the target element.
  * The event listener will be automatically unsubscribed when the element is disconnected.
  *
- * Note: This decorator uses event delegation, which means it relies on event bubbling.
- * Therefore, it will not work with events that do not bubble, such as `focus`, `blur`, `load`, `unload`, `scroll`, etc.
- * For focus and blur events, consider using `focusin` and `focusout` which are similar but do bubble.
- * Delegated listeners observe the host light DOM by default, and can optionally observe the shadow root or both trees.
+ * Note: Selector- and ref-based listeners use event delegation, which means they rely on
+ * event bubbling. Therefore, they will not work with events that do not bubble, such as
+ * `focus`, `blur`, `load`, `unload`, `scroll`, etc. For focus and blur events, consider
+ * using `focusin` and `focusout` which are similar but do bubble. Delegated listeners
+ * observe the host light DOM by default, and can optionally observe the shadow root or both
+ * trees. `window`, `document`, and `mediaQuery` targets attach directly instead of delegating.
  *
  * @param options {@link OnEventConfig} The event configuration.
  */

--- a/packages/radiant/src/helpers/create-event-listener.ts
+++ b/packages/radiant/src/helpers/create-event-listener.ts
@@ -25,6 +25,9 @@ export type OnEventConfig = BaseOnEventConfig &
 		| {
 				document: true;
 		  }
+		| {
+				mediaQuery: string;
+		  }
 	);
 
 type DelegatedEventRoot = Element | ShadowRoot;
@@ -132,6 +135,7 @@ export function createEventListener(
 	const boundCallback = callback.bind(host);
 	let windowCleanup: (() => void) | null = null;
 	let documentCleanup: (() => void) | null = null;
+	let mediaQueryCleanup: (() => void) | null = null;
 	let lightCleanup: (() => void) | null = null;
 	let shadowCleanup: (() => void) | null = null;
 	let disposed = false;
@@ -139,11 +143,13 @@ export function createEventListener(
 	const detachListeners = () => {
 		windowCleanup?.();
 		documentCleanup?.();
+		mediaQueryCleanup?.();
 		lightCleanup?.();
 		shadowCleanup?.();
 
 		windowCleanup = null;
 		documentCleanup = null;
+		mediaQueryCleanup = null;
 		lightCleanup = null;
 		shadowCleanup = null;
 	};
@@ -164,6 +170,18 @@ export function createEventListener(
 			document.addEventListener(config.type, boundCallback, config.options);
 			documentCleanup = () => {
 				document.removeEventListener(config.type, boundCallback, config.options);
+			};
+		}
+
+		if ('mediaQuery' in config && !mediaQueryCleanup) {
+			if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+				return;
+			}
+
+			const mediaQueryList = window.matchMedia(config.mediaQuery);
+			mediaQueryList.addEventListener(config.type, boundCallback, config.options);
+			mediaQueryCleanup = () => {
+				mediaQueryList.removeEventListener(config.type, boundCallback, config.options);
 			};
 		}
 

--- a/packages/radiant/test/decorators/on-event.browser.test.ts
+++ b/packages/radiant/test/decorators/on-event.browser.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { RadiantController } from '../../src/core/radiant-controller';
 import { RadiantElement } from '../../src/core/radiant-element';
 import { customElement } from '../../src/decorators/custom-element';
@@ -48,6 +48,54 @@ describe('onEvent', () => {
 		document.body.appendChild(element);
 		document.dispatchEvent(new Event('click'));
 		expect(element.received).toBeTruthy();
+	});
+
+	it('should add event listener to a media query list when mediaQuery is set', () => {
+		const matchMedia = vi.fn((query: string) => {
+			const listeners = new Set<(event: MediaQueryListEvent) => void>();
+			return {
+				matches: false,
+				media: query,
+				addEventListener: (_type: string, listener: (event: MediaQueryListEvent) => void) => {
+					listeners.add(listener);
+				},
+				removeEventListener: (_type: string, listener: (event: MediaQueryListEvent) => void) => {
+					listeners.delete(listener);
+				},
+				dispatchChange(matches: boolean) {
+					for (const listener of listeners) {
+						listener({ matches } as MediaQueryListEvent);
+					}
+				},
+			} as MediaQueryList & { dispatchChange: (matches: boolean) => void };
+		});
+		vi.stubGlobal('matchMedia', matchMedia);
+
+		@customElement('media-query-on-event-listener')
+		class MediaQueryEventListener extends RadiantElement {
+			matches: boolean | null = null;
+
+			@onEvent({ mediaQuery: '(prefers-color-scheme: dark)', type: 'change' })
+			onMediaQueryChange(event: MediaQueryListEvent) {
+				this.matches = event.matches;
+			}
+		}
+
+		const element = document.createElement('media-query-on-event-listener') as MediaQueryEventListener;
+		document.body.appendChild(element);
+
+		const mediaQueryList = matchMedia.mock.results[0]?.value as MediaQueryList & {
+			dispatchChange: (matches: boolean) => void;
+		};
+		mediaQueryList.dispatchChange(true);
+		expect(element.matches).toBe(true);
+
+		element.remove();
+		element.matches = null;
+		mediaQueryList.dispatchChange(false);
+		expect(element.matches).toBeNull();
+
+		vi.unstubAllGlobals();
 	});
 
 	it('should listen to delegated events in shadow DOM when scope is shadow', () => {

--- a/packages/radiant/test/helpers/create-event.e2e.test.ts
+++ b/packages/radiant/test/helpers/create-event.e2e.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { RadiantElement } from '../../src/core/radiant-element';
 import { createEvent } from '../../src/helpers/create-event';
 import { createEventListener } from '../../src/helpers/create-event-listener';
@@ -84,6 +84,38 @@ class LateShadowListenerHelperElement extends RadiantElement {
 }
 
 customElements.define('late-shadow-listener-helper-element', LateShadowListenerHelperElement);
+
+function createMatchMediaMock() {
+	const instances: Array<
+		MediaQueryList & {
+			dispatchChange: (matches: boolean) => void;
+		}
+	> = [];
+
+	const matchMedia = vi.fn((query: string) => {
+		const listeners = new Set<(event: MediaQueryListEvent) => void>();
+		const mediaQueryList = {
+			matches: false,
+			media: query,
+			addEventListener: (_type: string, listener: (event: MediaQueryListEvent) => void) => {
+				listeners.add(listener);
+			},
+			removeEventListener: (_type: string, listener: (event: MediaQueryListEvent) => void) => {
+				listeners.delete(listener);
+			},
+			dispatchChange(matches: boolean) {
+				for (const listener of listeners) {
+					listener({ matches } as MediaQueryListEvent);
+				}
+			},
+		} as MediaQueryList & { dispatchChange: (matches: boolean) => void };
+
+		instances.push(mediaQueryList);
+		return mediaQueryList;
+	});
+
+	return { instances, matchMedia };
+}
 
 describe('createEvent', () => {
 	beforeEach(() => {
@@ -244,5 +276,54 @@ describe('createEventListener', () => {
 		button.click();
 
 		expect(clickCount).toBe(1);
+	});
+
+	test('subscribes to media query changes', () => {
+		const { instances, matchMedia } = createMatchMediaMock();
+		vi.stubGlobal('matchMedia', matchMedia);
+
+		const host = document.createElement('event-helper-element') as EventHelperElement;
+		document.body.appendChild(host);
+
+		let matches: boolean | null = null;
+		createEventListener(host, { mediaQuery: '(prefers-color-scheme: dark)', type: 'change' }, (event) => {
+			matches = (event as MediaQueryListEvent).matches;
+		});
+
+		const mediaQueryList = instances[0];
+		mediaQueryList?.dispatchChange(true);
+		expect(matches).toBe(true);
+
+		host.remove();
+		vi.unstubAllGlobals();
+	});
+
+	test('cleanup permanently unsubscribes media query listeners', () => {
+		const { instances, matchMedia } = createMatchMediaMock();
+		vi.stubGlobal('matchMedia', matchMedia);
+
+		const host = document.createElement('event-helper-element') as EventHelperElement;
+		document.body.appendChild(host);
+
+		let matches: boolean | null = null;
+		const cleanup = createEventListener(
+			host,
+			{ mediaQuery: '(prefers-color-scheme: dark)', type: 'change' },
+			(event) => {
+				matches = (event as MediaQueryListEvent).matches;
+			},
+		);
+
+		const mediaQueryList = instances[0];
+		mediaQueryList?.dispatchChange(true);
+		expect(matches).toBe(true);
+
+		matches = null;
+		cleanup();
+		mediaQueryList?.dispatchChange(false);
+		expect(matches).toBeNull();
+
+		host.remove();
+		vi.unstubAllGlobals();
 	});
 });


### PR DESCRIPTION
## Summary

- Add `mediaQuery` as a direct `@onEvent` / `createEventListener` target with automatic cleanup on disconnect, plus tests for subscription and teardown
- Bump the `root-client-surface` gzip budget to 13.50 KB for the added listener path
- Show homepage hero code tabs on mobile and refactor docs `theme-toggle` to use `@onEvent` for system theme, toggle, and cross-layout sync

## Test plan

- [x] `pnpm --filter @ecopages/radiant test:lib`
- [x] `pnpm --filter @ecopages/radiant size:check`
- [x] Verify homepage code tabs and live counter demo on mobile viewport
- [x] Verify theme toggle follows system preference when unset, and stays stable across docs layout swaps