### PR TITLE
feat(radiant-ui): add leaf intl and filter utilities

### DIFF
--- a/packages/radiant-ui/src/lib/icons/calendar.tsx
+++ b/packages/radiant-ui/src/lib/icons/calendar.tsx
@@ -1,0 +1,24 @@
+import { cx } from '@/lib/cx';
+import type { RuiIconProps } from './types';
+
+/** Calendar indicator for date picker triggers. */
+export function RuiIconCalendar({ class: className, size = 'sm', ...props }: RuiIconProps) {
+	return (
+		<svg
+			{...props}
+			class={cx('rui-icon', size === 'md' && 'rui-icon--md', className)}
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			stroke-width="2"
+			stroke-linecap="round"
+			stroke-linejoin="round"
+			aria-hidden="true"
+		>
+			<path d="M8 2v4" />
+			<path d="M16 2v4" />
+			<rect width="18" height="18" x="3" y="4" rx="2" />
+			<path d="M3 10h18" />
+		</svg>
+	);
+}

--- a/packages/radiant-ui/src/lib/icons/chevron-down.tsx
+++ b/packages/radiant-ui/src/lib/icons/chevron-down.tsx
@@ -1,0 +1,21 @@
+import { cx } from '@/lib/cx';
+import type { RuiIconProps } from './types';
+
+/** Chevron-down indicator for listbox and combobox toggles. */
+export function RuiIconChevronDown({ class: className, size = 'sm', ...props }: RuiIconProps) {
+	return (
+		<svg
+			{...props}
+			class={cx('rui-icon', size === 'md' && 'rui-icon--md', className)}
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			stroke-width="2"
+			stroke-linecap="round"
+			stroke-linejoin="round"
+			aria-hidden="true"
+		>
+			<path d="m6 9 6 6 6-6" />
+		</svg>
+	);
+}

--- a/packages/radiant-ui/src/lib/icons/icons.css
+++ b/packages/radiant-ui/src/lib/icons/icons.css
@@ -1,0 +1,14 @@
+@reference '../../styles/radiant-ui.css';
+
+@layer components {
+	.rui-icon {
+		width: var(--size-icon-sm);
+		height: var(--size-icon-sm);
+		flex-shrink: 0;
+	}
+
+	.rui-icon--md {
+		width: var(--size-icon-md);
+		height: var(--size-icon-md);
+	}
+}

--- a/packages/radiant-ui/src/lib/icons/index.ts
+++ b/packages/radiant-ui/src/lib/icons/index.ts
@@ -1,0 +1,3 @@
+export { RuiIconCalendar } from './calendar';
+export { RuiIconChevronDown } from './chevron-down';
+export type { RuiIconProps } from './types';

--- a/packages/radiant-ui/src/lib/icons/types.ts
+++ b/packages/radiant-ui/src/lib/icons/types.ts
@@ -1,0 +1,5 @@
+import type { JsxHtmlProps } from '@ecopages/jsx';
+
+export type RuiIconProps = JsxHtmlProps<{
+	size?: 'sm' | 'md';
+}>;

--- a/packages/radiant-ui/src/lib/intl/locale.ts
+++ b/packages/radiant-ui/src/lib/intl/locale.ts
@@ -1,0 +1,14 @@
+export type IntlLocale = string | string[] | undefined;
+
+/** Parses the public comma-separated locale fallback syntax into Intl input. */
+export function resolveLocale(locale?: string): IntlLocale {
+	if (!locale) {
+		return undefined;
+	}
+
+	const tags = locale
+		.split(',')
+		.map((tag) => tag.trim())
+		.filter(Boolean);
+	return tags.length > 1 ? tags : tags[0];
+}

--- a/packages/radiant-ui/src/lib/text-filter.test.ts
+++ b/packages/radiant-ui/src/lib/text-filter.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { textContains } from './text-filter';
+
+describe('textContains', () => {
+	it('matches case-insensitively by default', () => {
+		expect(textContains('California', 'forn')).toBe(true);
+		expect(textContains('California', 'FORN')).toBe(true);
+	});
+
+	it('returns true for empty query', () => {
+		expect(textContains('California', '')).toBe(true);
+	});
+
+	it('supports case-sensitive mode', () => {
+		expect(textContains('California', 'forn', 'case')).toBe(true);
+		expect(textContains('California', 'FORN', 'case')).toBe(false);
+	});
+});

--- a/packages/radiant-ui/src/lib/text-filter.ts
+++ b/packages/radiant-ui/src/lib/text-filter.ts
@@ -1,0 +1,30 @@
+export type TextFilterSensitivity = 'base' | 'accent' | 'case';
+
+/**
+ * Case- and accent-insensitive "contains" matcher for autocomplete filtering.
+ *
+ * @remarks `base` ignores case; `case` is a literal substring match.
+ */
+export function textContains(text: string, query: string, sensitivity: TextFilterSensitivity = 'base'): boolean {
+	if (!query) {
+		return true;
+	}
+
+	if (sensitivity === 'case') {
+		return text.includes(query);
+	}
+
+	const collator = new Intl.Collator(undefined, {
+		sensitivity: sensitivity === 'accent' ? 'accent' : 'base',
+		usage: 'search',
+	});
+
+	for (let index = 0; index <= text.length - query.length; index += 1) {
+		const slice = text.slice(index, index + query.length);
+		if (collator.compare(slice, query) === 0) {
+			return true;
+		}
+	}
+
+	return false;
+}


### PR DESCRIPTION
## Summary
- Add `resolveLocale` helper under `src/lib/intl/`
- Add `textContains` text-filter utility with tests
- Add shared calendar/chevron icon primitives

## Test plan
- [x] `text-filter` unit tests pass
- [x] Pre-commit hooks pass