### PR TITLE
feat(radiant-ui): add intl-date and input masking utilities

### DIFF
--- a/packages/radiant-ui/src/lib/intl-date/calendar.ts
+++ b/packages/radiant-ui/src/lib/intl-date/calendar.ts
@@ -1,0 +1,141 @@
+import { dateToIso, isIsoInRange } from './iso';
+import {
+	getDaySelectionAppearance,
+	parseIsoRange,
+	parseMultipleIsos,
+	type CalendarSelectionMode,
+	type IsoRange,
+} from './selection';
+import type { CalendarWeek, IntlLocale } from './types';
+
+export type { CalendarSelectionMode, IsoRange };
+
+/**
+ * Returns the JS weekday index (0 = Sunday) that starts the week for `locale`.
+ *
+ * @remarks Uses `Intl.Locale.weekInfo` when available; falls back to Monday except en-US.
+ */
+export function getWeekStartsOn(locale: IntlLocale): number {
+	const tag = resolveLocaleTag(locale);
+
+	try {
+		const resolved = new Intl.Locale(tag);
+		const weekInfo = (resolved as Intl.Locale & { weekInfo?: { firstDay: number } }).weekInfo;
+		if (weekInfo?.firstDay != null) {
+			return weekInfo.firstDay === 7 ? 0 : weekInfo.firstDay;
+		}
+	} catch {
+		// Intl.Locale unsupported or invalid tag — use fallback below.
+	}
+
+	return tag.startsWith('en-US') ? 0 : 1;
+}
+
+function resolveLocaleTag(locale: IntlLocale): string {
+	if (Array.isArray(locale)) {
+		return locale[0] ?? navigator.language;
+	}
+	return locale ?? navigator.language;
+}
+
+function startOfDay(date: Date): Date {
+	return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
+function isSameDay(a: Date, b: Date): boolean {
+	return a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth() && a.getDate() === b.getDate();
+}
+
+export type BuildCalendarMonthOptions = {
+	locale: IntlLocale;
+	selectionMode?: CalendarSelectionMode;
+	/** Single mode: selected ISO. Multiple: comma-separated. Range: `start/end`. */
+	value?: string;
+	/** Active range while selecting (anchor + hover preview). */
+	rangeDraft?: { anchor: string | null; hover: string | null };
+	min?: string;
+	max?: string;
+	today?: Date;
+};
+
+function resolveSelectionContext(options: BuildCalendarMonthOptions): {
+	mode: CalendarSelectionMode;
+	singleIso?: string;
+	multipleIsos?: string[];
+	range?: IsoRange | null;
+} {
+	const mode = options.selectionMode ?? 'single';
+	const value = options.value ?? '';
+
+	if (mode === 'multiple') {
+		return { mode, multipleIsos: parseMultipleIsos(value) };
+	}
+
+	if (mode === 'range') {
+		const committed = parseIsoRange(value);
+		if (options.rangeDraft?.anchor) {
+			const hover = options.rangeDraft.hover ?? options.rangeDraft.anchor;
+			return {
+				mode,
+				range: normalizeRangeFromDraft(options.rangeDraft.anchor, hover),
+			};
+		}
+		return { mode, range: committed };
+	}
+
+	return { mode, singleIso: value || undefined };
+}
+
+function normalizeRangeFromDraft(anchor: string, hover: string): IsoRange {
+	if (anchor.localeCompare(hover) <= 0) {
+		return { start: anchor, end: hover };
+	}
+	return { start: hover, end: anchor };
+}
+
+/** Builds a month grid with leading/trailing days from adjacent months. */
+export function buildCalendarMonth(year: number, month: number, options: BuildCalendarMonthOptions): CalendarWeek[] {
+	const weekStartsOn = getWeekStartsOn(options.locale);
+	const today = startOfDay(options.today ?? new Date());
+	const selection = resolveSelectionContext(options);
+	const firstOfMonth = new Date(year, month, 1);
+	const startOffset = (firstOfMonth.getDay() - weekStartsOn + 7) % 7;
+	const gridStart = new Date(year, month, 1 - startOffset);
+
+	const weeks: CalendarWeek[] = [];
+	const cursor = new Date(gridStart);
+
+	for (let week = 0; week < 6; week += 1) {
+		const row: CalendarWeek[number][] = [];
+
+		for (let day = 0; day < 7; day += 1) {
+			const iso = dateToIso(cursor);
+			const appearance = getDaySelectionAppearance(iso, selection.mode, {
+				singleIso: selection.singleIso,
+				multipleIsos: selection.multipleIsos,
+				range: selection.range,
+			});
+
+			row.push({
+				date: new Date(cursor),
+				iso,
+				inMonth: cursor.getMonth() === month,
+				isToday: isSameDay(cursor, today),
+				isSelected: appearance.isSelected,
+				isDisabled: !isIsoInRange(iso, options.min, options.max),
+				isRangeStart: appearance.isRangeStart,
+				isRangeEnd: appearance.isRangeEnd,
+				isRangeMiddle: appearance.isRangeMiddle,
+			});
+			cursor.setDate(cursor.getDate() + 1);
+		}
+
+		weeks.push(row);
+
+		if (week >= 4 && cursor.getMonth() !== month && cursor.getDate() > 7) {
+			break;
+		}
+	}
+
+	return weeks;
+}

--- a/packages/radiant-ui/src/lib/intl-date/formatters.ts
+++ b/packages/radiant-ui/src/lib/intl-date/formatters.ts
@@ -1,0 +1,63 @@
+import type { DateDisplayStyle, IntlLocale } from './types';
+
+const formatterCache = new Map<string, Intl.DateTimeFormat>();
+
+function cacheKey(locale: IntlLocale, options: Intl.DateTimeFormatOptions): string {
+	return `${JSON.stringify(locale ?? null)}|${JSON.stringify(options)}`;
+}
+
+/** Returns a cached `Intl.DateTimeFormat` for the given locale and options. */
+export function getDateTimeFormat(locale: IntlLocale, options: Intl.DateTimeFormatOptions): Intl.DateTimeFormat {
+	const key = cacheKey(locale, options);
+	const cached = formatterCache.get(key);
+	if (cached) {
+		return cached;
+	}
+
+	const formatter = new Intl.DateTimeFormat(locale, options);
+	formatterCache.set(key, formatter);
+	return formatter;
+}
+
+/** Formats a date for display using a `dateStyle` preset. */
+export function formatDisplayDate(date: Date, locale: IntlLocale, style: DateDisplayStyle = 'medium'): string {
+	return getDateTimeFormat(locale, { dateStyle: style }).format(date);
+}
+
+/** Formats the month and year shown in the calendar header. */
+export function formatMonthYear(date: Date, locale: IntlLocale): string {
+	return getDateTimeFormat(locale, { month: 'long', year: 'numeric' }).format(date);
+}
+
+/** Returns localized narrow weekday labels ordered by the locale's first day of week. */
+export function getWeekdayLabels(locale: IntlLocale, weekStartsOn: number): string[] {
+	const formatter = getDateTimeFormat(locale, { weekday: 'narrow' });
+	const labels: string[] = [];
+
+	for (let offset = 0; offset < 7; offset += 1) {
+		const dayIndex = (weekStartsOn + offset) % 7;
+		const reference = new Date(2024, 0, dayIndex === 0 ? 7 : dayIndex);
+		labels.push(formatter.format(reference));
+	}
+
+	return labels;
+}
+
+/** Formats a date range for display using a `dateStyle` preset. */
+export function formatDateRange(
+	start: Date,
+	end: Date,
+	locale: IntlLocale,
+	style: DateDisplayStyle = 'medium',
+): string {
+	const formatter = getDateTimeFormat(locale, { dateStyle: style });
+	if (typeof formatter.formatRange === 'function') {
+		return formatter.formatRange(start, end);
+	}
+	return `${formatter.format(start)} – ${formatter.format(end)}`;
+}
+
+/** Localized label for the "today" shortcut (e.g. "today", "vandaag"). */
+export function formatTodayLabel(locale: IntlLocale): string {
+	return new Intl.RelativeTimeFormat(locale, { numeric: 'auto' }).format(0, 'day');
+}

--- a/packages/radiant-ui/src/lib/intl-date/index.ts
+++ b/packages/radiant-ui/src/lib/intl-date/index.ts
@@ -1,0 +1,31 @@
+export { buildCalendarMonth, getWeekStartsOn } from './calendar';
+export type { BuildCalendarMonthOptions, CalendarSelectionMode, IsoRange } from './calendar';
+export { addMonths, getVisibleMonthViews } from './months';
+export type { CalendarMonthView } from './months';
+export {
+	advanceRangeSelection,
+	compareIso,
+	getActiveRangeBounds,
+	getDaySelectionAppearance,
+	isIsoInSpan,
+	normalizeRange,
+	parseIsoRange,
+	parseMultipleIsos,
+	serializeIsoRange,
+	serializeMultipleIsos,
+	toggleMultipleIso,
+} from './selection';
+export type { DaySelectionAppearance, RangeSelectionDraft } from './selection';
+export { formatDisplayDate, formatDateRange, formatMonthYear, formatTodayLabel, getDateTimeFormat, getWeekdayLabels } from './formatters';
+export { dateToIso, isoToDate, isIsoInRange } from './iso';
+export { getDatePartOrder, getDateSeparators, parseLocaleDateString } from './parts';
+export {
+	buildDateSegments,
+	clampSegmentValue,
+	getEditableSegmentIndices,
+	incrementSegment,
+	maxSegmentLength,
+	segmentsToDate,
+} from './segments';
+export type { CalendarDayCell, CalendarWeek, DateDisplayStyle, DateGranularity, DatePartType, IntlLocale } from './types';
+export type { DateSegmentModel, DateSegmentType } from './segments';

--- a/packages/radiant-ui/src/lib/intl-date/iso.ts
+++ b/packages/radiant-ui/src/lib/intl-date/iso.ts
@@ -1,0 +1,40 @@
+/** Parses an ISO `YYYY-MM-DD` string into a local-midnight `Date`, or `null` when invalid. */
+export function isoToDate(iso: string | null | undefined): Date | null {
+	if (iso == null) {
+		return null;
+	}
+	const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(iso.trim());
+	if (!match) {
+		return null;
+	}
+
+	const year = Number(match[1]);
+	const month = Number(match[2]) - 1;
+	const day = Number(match[3]);
+	const date = new Date(year, month, day);
+
+	if (date.getFullYear() !== year || date.getMonth() !== month || date.getDate() !== day) {
+		return null;
+	}
+
+	return date;
+}
+
+/** Serializes a local calendar date to ISO `YYYY-MM-DD`. */
+export function dateToIso(date: Date): string {
+	const year = date.getFullYear();
+	const month = String(date.getMonth() + 1).padStart(2, '0');
+	const day = String(date.getDate()).padStart(2, '0');
+	return `${year}-${month}-${day}`;
+}
+
+/** Returns true when `iso` falls within optional `min` / `max` bounds (inclusive). */
+export function isIsoInRange(iso: string, min?: string, max?: string): boolean {
+	if (min && iso < min) {
+		return false;
+	}
+	if (max && iso > max) {
+		return false;
+	}
+	return true;
+}

--- a/packages/radiant-ui/src/lib/intl-date/months.ts
+++ b/packages/radiant-ui/src/lib/intl-date/months.ts
@@ -1,0 +1,20 @@
+/** Zero-based month index with year rollover. */
+export function addMonths(year: number, month: number, delta: number): { year: number; month: number } {
+	const date = new Date(year, month + delta, 1);
+	return { year: date.getFullYear(), month: date.getMonth() };
+}
+
+export type CalendarMonthView = {
+	year: number;
+	month: number;
+	offset: number;
+};
+
+/** Returns consecutive month views starting at `year`/`month`. */
+export function getVisibleMonthViews(year: number, month: number, count: number): CalendarMonthView[] {
+	const safeCount = Math.max(1, Math.min(count, 12));
+	return Array.from({ length: safeCount }, (_, offset) => {
+		const next = addMonths(year, month, offset);
+		return { year: next.year, month: next.month, offset };
+	});
+}

--- a/packages/radiant-ui/src/lib/intl-date/parts.test.ts
+++ b/packages/radiant-ui/src/lib/intl-date/parts.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { dateToIso, isoToDate } from './iso';
+import { getDatePartOrder, parseLocaleDateString } from './parts';
+
+describe('iso', () => {
+	it('round-trips valid dates', () => {
+		const date = new Date(2026, 11, 9);
+		expect(dateToIso(date)).toBe('2026-12-09');
+		expect(isoToDate('2026-12-09')).toEqual(date);
+	});
+
+	it('rejects invalid calendar dates', () => {
+		expect(isoToDate('2026-02-30')).toBeNull();
+	});
+});
+
+describe('getDatePartOrder', () => {
+	it('returns MDY for en-US', () => {
+		expect(getDatePartOrder('en-US')).toEqual(['month', 'day', 'year']);
+	});
+
+	it('returns DMY for en-GB', () => {
+		expect(getDatePartOrder('en-GB')).toEqual(['day', 'month', 'year']);
+	});
+});
+
+describe('parseLocaleDateString', () => {
+	it('parses ISO strings', () => {
+		expect(parseLocaleDateString('2026-12-09', 'en-US')?.getDate()).toBe(9);
+	});
+
+	it('parses en-US numeric input', () => {
+		const parsed = parseLocaleDateString('12/9/2026', 'en-US');
+		expect(dateToIso(parsed!)).toBe('2026-12-09');
+	});
+
+	it('parses en-GB numeric input', () => {
+		const parsed = parseLocaleDateString('9/12/2026', 'en-GB');
+		expect(dateToIso(parsed!)).toBe('2026-12-09');
+	});
+});

--- a/packages/radiant-ui/src/lib/intl-date/parts.ts
+++ b/packages/radiant-ui/src/lib/intl-date/parts.ts
@@ -1,0 +1,166 @@
+import { isoToDate } from './iso';
+import type { DatePartType, IntlLocale } from './types';
+import { getDateTimeFormat } from './formatters';
+import {
+	buildDateMaskPattern,
+	extractMaskDigits as extractDateMaskDigits,
+	maskDigitCapacity,
+	maskedDigitsToParts,
+	partsToDate,
+} from '@/lib/mask/date-mask';
+
+const REFERENCE_DATE = new Date(2001, 8, 3);
+
+/**
+ * Uses `formatToParts()` on a fixed reference date to discover the locale's
+ * year/month/day field order (e.g. MDY for en-US, DMY for en-GB, YMD for ja-JP).
+ */
+export function getDatePartOrder(locale: IntlLocale): DatePartType[] {
+	const parts = getDateTimeFormat(locale, {
+		year: 'numeric',
+		month: 'numeric',
+		day: 'numeric',
+	}).formatToParts(REFERENCE_DATE);
+
+	return parts
+		.filter((part) => part.type === 'year' || part.type === 'month' || part.type === 'day')
+		.map((part) => part.type as DatePartType);
+}
+
+/** Literal separators between numeric date parts for the locale (e.g. `['/']` for en-US). */
+export function getDateSeparators(locale: IntlLocale): string[] {
+	const parts = getDateTimeFormat(locale, {
+		year: 'numeric',
+		month: 'numeric',
+		day: 'numeric',
+	}).formatToParts(REFERENCE_DATE);
+
+	return parts.filter((part) => part.type === 'literal').map((part) => part.value);
+}
+
+function normalizeYear(value: number): number {
+	if (value >= 100) {
+		return value;
+	}
+	return value >= 69 ? 1900 + value : 2000 + value;
+}
+
+function buildDateFromParts(parts: Record<DatePartType, number>): Date | null {
+	const year = parts.year;
+	const month = parts.month;
+	const day = parts.day;
+
+	if (!Number.isFinite(year) || !Number.isFinite(month) || !Number.isFinite(day)) {
+		return null;
+	}
+
+	const date = new Date(year, month - 1, day);
+	if (date.getFullYear() !== year || date.getMonth() !== month - 1 || date.getDate() !== day) {
+		return null;
+	}
+
+	return date;
+}
+
+/**
+ * Parses a user-typed date string according to locale conventions.
+ *
+ * Accepts ISO `YYYY-MM-DD`, masked numeric input (`08/21/2002`), locale-ordered
+ * numeric input (`9/3/2026`), and text month names (`Aug 21, 2002`).
+ */
+export function parseLocaleDateString(input: string | null | undefined, locale: IntlLocale): Date | null {
+	const trimmed = (input ?? '').trim();
+	if (!trimmed) {
+		return null;
+	}
+
+	const isoDate = isoToDate(trimmed);
+	if (isoDate) {
+		return isoDate;
+	}
+
+	const fromMask = parseMaskedInput(trimmed, locale);
+	if (fromMask) {
+		return fromMask;
+	}
+
+	const fromMonthName = parseDateWithMonthNames(trimmed, locale);
+	if (fromMonthName) {
+		return fromMonthName;
+	}
+
+	const order = getDatePartOrder(locale);
+	const numbers = trimmed.match(/\d+/g);
+	if (!numbers || numbers.length < 3) {
+		return null;
+	}
+
+	const values: Record<DatePartType, number> = { day: 0, month: 0, year: 0 };
+	for (let index = 0; index < 3; index += 1) {
+		const partType = order[index];
+		if (!partType) {
+			return null;
+		}
+
+		let numeric = Number(numbers[index]);
+		if (partType === 'year') {
+			numeric = normalizeYear(numeric);
+		}
+		values[partType] = numeric;
+	}
+
+	return buildDateFromParts(values);
+}
+
+function parseMaskedInput(input: string, locale: IntlLocale): Date | null {
+	const pattern = buildDateMaskPattern(locale);
+	const digits = extractDateMaskDigits(input);
+	if (digits.length < maskDigitCapacity(pattern)) {
+		return null;
+	}
+	return partsToDate(maskedDigitsToParts(digits, locale) ?? {});
+}
+
+function getMonthNameLookup(locale: IntlLocale): Map<string, number> {
+	const lookup = new Map<string, number>();
+	for (const style of ['short', 'long'] as const) {
+		for (let month = 0; month < 12; month += 1) {
+			const label = getDateTimeFormat(locale, { month: style })
+				.formatToParts(new Date(2020, month, 1))
+				.find((part) => part.type === 'month')?.value;
+			if (label) {
+				lookup.set(label.toLowerCase(), month + 1);
+			}
+		}
+	}
+	return lookup;
+}
+
+function parseDateWithMonthNames(input: string, locale: IntlLocale): Date | null {
+	const months = getMonthNameLookup(locale);
+	const normalized = input.toLowerCase();
+
+	for (const [name, month] of months) {
+		const index = normalized.indexOf(name);
+		if (index < 0) {
+			continue;
+		}
+
+		const numbers = input.match(/\d+/g);
+		if (!numbers || numbers.length < 2) {
+			continue;
+		}
+
+		const yearToken = numbers.find((token) => token.length === 4) ?? numbers[numbers.length - 1];
+		const dayToken = numbers.find((token) => token !== yearToken && Number(token) <= 31);
+		if (!dayToken || !yearToken) {
+			continue;
+		}
+
+		const year = normalizeYear(Number(yearToken));
+		const day = Number(dayToken);
+		return buildDateFromParts({ year, month, day });
+	}
+
+	return null;
+}

--- a/packages/radiant-ui/src/lib/intl-date/segments.test.ts
+++ b/packages/radiant-ui/src/lib/intl-date/segments.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { dateToIso } from './iso';
+import { buildDateSegments, segmentsToDate } from './segments';
+
+describe('buildDateSegments', () => {
+	it('orders segments for en-US as month/day/year', () => {
+		const segments = buildDateSegments(new Date(2026, 7, 2), 'en-US');
+		const editable = segments.filter((segment) => segment.editable).map((segment) => segment.type);
+		expect(editable).toEqual(['month', 'day', 'year']);
+	});
+
+	it('shows placeholders when value is empty', () => {
+		const segments = buildDateSegments(null, 'en-US');
+		const month = segments.find((segment) => segment.type === 'month');
+		expect(month?.isPlaceholder).toBe(true);
+		expect(month?.placeholder.length).toBeGreaterThan(0);
+	});
+});
+
+describe('segmentsToDate', () => {
+	it('builds a date from filled segments', () => {
+		const segments = buildDateSegments(null, 'en-US').map((segment) => {
+			if (segment.type === 'month') {
+				return { ...segment, value: '08', isPlaceholder: false };
+			}
+			if (segment.type === 'day') {
+				return { ...segment, value: '02', isPlaceholder: false };
+			}
+			if (segment.type === 'year') {
+				return { ...segment, value: '2026', isPlaceholder: false };
+			}
+			return segment;
+		});
+
+		expect(dateToIso(segmentsToDate(segments)!)).toBe('2026-08-02');
+	});
+});

--- a/packages/radiant-ui/src/lib/intl-date/segments.ts
+++ b/packages/radiant-ui/src/lib/intl-date/segments.ts
@@ -1,0 +1,174 @@
+import { getDateTimeFormat } from './formatters';
+import type { DateGranularity, DatePartType, IntlLocale } from './types';
+
+export type DateSegmentType = DatePartType | 'literal';
+
+/** @experimental Segment model reserved for a future segment-editor field. */
+export type DateSegmentModel = {
+	type: DateSegmentType;
+	/** Visible text for literals; numeric string for editable segments. */
+	value: string;
+	placeholder: string;
+	isPlaceholder: boolean;
+	editable: boolean;
+};
+
+const PLACEHOLDER_DATE = new Date(2000, 0, 1);
+
+function granularityIncludes(granularity: DateGranularity, part: DatePartType): boolean {
+	if (granularity === 'year') {
+		return part === 'year';
+	}
+	if (granularity === 'month') {
+		return part === 'year' || part === 'month';
+	}
+	return true;
+}
+
+function placeholderForPart(type: DatePartType, locale: IntlLocale): string {
+	const sample = getDateTimeFormat(locale, { [type]: type === 'year' ? 'numeric' : '2-digit' }).formatToParts(
+		PLACEHOLDER_DATE,
+	);
+	const part = sample.find((entry) => entry.type === type);
+	if (!part) {
+		return type === 'year' ? 'yyyy' : 'mm';
+	}
+	return part.value.replace(/\d/g, type === 'year' ? 'y' : type === 'month' ? 'm' : 'd');
+}
+
+function formatPartValue(type: DatePartType, date: Date, locale: IntlLocale): string {
+	const options: Intl.DateTimeFormatOptions =
+		type === 'year' ? { year: 'numeric' } : { [type]: '2-digit' };
+	return getDateTimeFormat(locale, options).formatToParts(date).find((part) => part.type === type)?.value ?? '';
+}
+
+/**
+ * Builds locale-ordered date segments from `Intl.DateTimeFormat.prototype.formatToParts()`.
+ *
+ * @remarks Mirrors the React Aria `DateInput` segment list — literals plus editable fields.
+ * @experimental Reserved for a future segment-editor field.
+ */
+export function buildDateSegments(
+	date: Date | null,
+	locale: IntlLocale,
+	options: { granularity?: DateGranularity; placeholderDate?: Date } = {},
+): DateSegmentModel[] {
+	const granularity = options.granularity ?? 'day';
+	const reference = date ?? options.placeholderDate ?? new Date();
+	const parts = getDateTimeFormat(locale, {
+		year: 'numeric',
+		month: '2-digit',
+		day: '2-digit',
+	}).formatToParts(reference);
+
+	return parts
+		.filter((part) => part.type !== 'era')
+		.map((part) => {
+			if (part.type === 'literal') {
+				return {
+					type: 'literal',
+					value: part.value,
+					placeholder: part.value,
+					isPlaceholder: false,
+					editable: false,
+				};
+			}
+
+			const type = part.type as DatePartType;
+			if (!granularityIncludes(granularity, type)) {
+				return null;
+			}
+
+			const hasValue = date != null;
+			return {
+				type,
+				value: hasValue ? formatPartValue(type, date, locale) : '',
+				placeholder: placeholderForPart(type, locale),
+				isPlaceholder: !hasValue,
+				editable: true,
+			};
+		})
+		.filter((segment): segment is DateSegmentModel => segment != null);
+}
+
+function parseSegmentNumber(segment: DateSegmentModel): number | null {
+	if (segment.isPlaceholder || segment.value === '') {
+		return null;
+	}
+	const parsed = Number(segment.value);
+	return Number.isFinite(parsed) ? parsed : null;
+}
+
+function normalizeYear(value: number): number {
+	if (value >= 100) {
+		return value;
+	}
+	return value >= 69 ? 1900 + value : 2000 + value;
+}
+
+/**
+ * Converts editable segment values into a local calendar `Date`, or `null` when incomplete.
+ *
+ * @experimental Reserved for a future segment-editor field.
+ */
+export function segmentsToDate(segments: DateSegmentModel[]): Date | null {
+	const values: Partial<Record<DatePartType, number>> = {};
+
+	for (const segment of segments) {
+		if (!segment.editable) {
+			continue;
+		}
+		const numeric = parseSegmentNumber(segment);
+		if (numeric == null) {
+			return null;
+		}
+		values[segment.type as DatePartType] =
+			segment.type === 'year' ? normalizeYear(numeric) : numeric;
+	}
+
+	if (values.year == null || values.month == null || values.day == null) {
+		return null;
+	}
+
+	const date = new Date(values.year, values.month - 1, values.day);
+	if (
+		date.getFullYear() !== values.year ||
+		date.getMonth() !== values.month - 1 ||
+		date.getDate() !== values.day
+	) {
+		return null;
+	}
+
+	return date;
+}
+
+/** @experimental Reserved for a future segment-editor field. */
+export function getEditableSegmentIndices(segments: DateSegmentModel[]): number[] {
+	return segments.map((segment, index) => (segment.editable ? index : -1)).filter((index) => index >= 0);
+}
+
+export function maxSegmentLength(type: DatePartType): number {
+	if (type === 'year') {
+		return 4;
+	}
+	return 2;
+}
+
+export function clampSegmentValue(type: DatePartType, raw: string): string {
+	const digits = raw.replace(/\D/g, '');
+	return digits.slice(0, maxSegmentLength(type));
+}
+
+export function incrementSegment(type: DatePartType, value: string, delta: number): string {
+	const numeric = Number(value || '0') + delta;
+	if (type === 'month') {
+		const wrapped = ((numeric - 1 + 12) % 12) + 1;
+		return String(wrapped).padStart(2, '0');
+	}
+	if (type === 'day') {
+		const wrapped = ((numeric - 1 + 31) % 31) + 1;
+		return String(wrapped).padStart(2, '0');
+	}
+	const next = Math.max(1, numeric);
+	return String(next).padStart(4, '0').slice(-4);
+}

--- a/packages/radiant-ui/src/lib/intl-date/selection.test.ts
+++ b/packages/radiant-ui/src/lib/intl-date/selection.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import { buildCalendarMonth } from './calendar';
+import { addMonths, getVisibleMonthViews } from './months';
+import {
+	advanceRangeSelection,
+	getDaySelectionAppearance,
+	normalizeRange,
+	parseIsoRange,
+	parseMultipleIsos,
+	serializeIsoRange,
+	serializeMultipleIsos,
+	toggleMultipleIso,
+} from './selection';
+
+describe('selection utilities', () => {
+	it('normalizes inverted ranges', () => {
+		expect(normalizeRange('2026-08-20', '2026-08-02')).toEqual({
+			start: '2026-08-02',
+			end: '2026-08-20',
+		});
+	});
+
+	it('serializes and parses range values', () => {
+		const range = { start: '2026-02-03', end: '2026-02-12' };
+		expect(serializeIsoRange(range)).toBe('2026-02-03/2026-02-12');
+		expect(parseIsoRange('2026-02-03/2026-02-12')).toEqual(range);
+	});
+
+	it('toggles multiple selection values', () => {
+		expect(toggleMultipleIso(['2026-08-01'], '2026-08-15')).toEqual(['2026-08-01', '2026-08-15']);
+		expect(toggleMultipleIso(['2026-08-01', '2026-08-15'], '2026-08-01')).toEqual(['2026-08-15']);
+		expect(serializeMultipleIsos(parseMultipleIsos('2026-08-15,2026-08-01'))).toBe('2026-08-01,2026-08-15');
+	});
+
+	it('advances range selection from anchor to committed range', () => {
+		const first = advanceRangeSelection(null, { anchor: null, hover: null }, '2026-08-05');
+		expect(first.draft.anchor).toBe('2026-08-05');
+
+		const second = advanceRangeSelection(first.committed, first.draft, '2026-08-20');
+		expect(second.committed).toEqual({ start: '2026-08-05', end: '2026-08-20' });
+		expect(second.draft.anchor).toBeNull();
+	});
+
+	it('marks range middle days', () => {
+		const range = { start: '2026-08-05', end: '2026-08-07' };
+		expect(getDaySelectionAppearance('2026-08-05', 'range', { range }).isRangeStart).toBe(true);
+		expect(getDaySelectionAppearance('2026-08-06', 'range', { range }).isRangeMiddle).toBe(true);
+		expect(getDaySelectionAppearance('2026-08-07', 'range', { range }).isRangeEnd).toBe(true);
+		expect(getDaySelectionAppearance('2026-08-04', 'range', { range }).isSelected).toBe(false);
+	});
+});
+
+describe('month utilities', () => {
+	it('adds months with year rollover', () => {
+		expect(addMonths(2026, 10, 2)).toEqual({ year: 2027, month: 0 });
+		expect(addMonths(2026, 0, -1)).toEqual({ year: 2025, month: 11 });
+	});
+
+	it('builds visible month views', () => {
+		expect(getVisibleMonthViews(2026, 7, 2)).toEqual([
+			{ year: 2026, month: 7, offset: 0 },
+			{ year: 2026, month: 8, offset: 1 },
+		]);
+	});
+});
+
+describe('buildCalendarMonth selection modes', () => {
+	const base = { locale: 'en-US' as const };
+
+	it('highlights a single selected day', () => {
+		const weeks = buildCalendarMonth(2026, 7, { ...base, value: '2026-08-15' });
+		const day = weeks.flat().find((cell) => cell.iso === '2026-08-15');
+		expect(day?.isSelected).toBe(true);
+	});
+
+	it('highlights multiple selected days', () => {
+		const weeks = buildCalendarMonth(2026, 7, {
+			...base,
+			selectionMode: 'multiple',
+			value: '2026-08-05,2026-08-20',
+		});
+		expect(weeks.flat().find((cell) => cell.iso === '2026-08-05')?.isSelected).toBe(true);
+		expect(weeks.flat().find((cell) => cell.iso === '2026-08-20')?.isSelected).toBe(true);
+	});
+
+	it('highlights range preview while drafting', () => {
+		const weeks = buildCalendarMonth(2026, 7, {
+			...base,
+			selectionMode: 'range',
+			value: '',
+			rangeDraft: { anchor: '2026-08-05', hover: '2026-08-10' },
+		});
+		expect(weeks.flat().find((cell) => cell.iso === '2026-08-07')?.isRangeMiddle).toBe(true);
+	});
+});

--- a/packages/radiant-ui/src/lib/intl-date/selection.ts
+++ b/packages/radiant-ui/src/lib/intl-date/selection.ts
@@ -1,0 +1,159 @@
+export type CalendarSelectionMode = 'single' | 'multiple' | 'range';
+
+export type IsoRange = {
+	start: string;
+	end: string;
+};
+
+export type RangeSelectionDraft = {
+	anchor: string | null;
+	hover: string | null;
+};
+
+export type DaySelectionAppearance = {
+	isSelected: boolean;
+	isRangeStart: boolean;
+	isRangeEnd: boolean;
+	isRangeMiddle: boolean;
+};
+
+const RANGE_SEPARATOR = '/';
+const MULTIPLE_SEPARATOR = ',';
+
+/** Lexicographic compare for ISO `YYYY-MM-DD` strings. */
+export function compareIso(a: string, b: string): number {
+	return a.localeCompare(b);
+}
+
+export function normalizeRange(start: string, end: string): IsoRange {
+	if (compareIso(start, end) <= 0) {
+		return { start, end };
+	}
+	return { start: end, end: start };
+}
+
+export function parseIsoRange(value: string | null | undefined): IsoRange | null {
+	if (!value) {
+		return null;
+	}
+	const [start, end] = value.split(RANGE_SEPARATOR);
+	if (!start || !end) {
+		return null;
+	}
+	return normalizeRange(start, end);
+}
+
+export function serializeIsoRange(range: IsoRange | null): string {
+	if (!range) {
+		return '';
+	}
+	const normalized = normalizeRange(range.start, range.end);
+	return `${normalized.start}${RANGE_SEPARATOR}${normalized.end}`;
+}
+
+export function parseMultipleIsos(value: string | null | undefined): string[] {
+	if (!value) {
+		return [];
+	}
+	return value
+		.split(MULTIPLE_SEPARATOR)
+		.map((iso) => iso.trim())
+		.filter(Boolean)
+		.sort(compareIso);
+}
+
+export function serializeMultipleIsos(values: Iterable<string>): string {
+	return [...new Set(values)].sort(compareIso).join(MULTIPLE_SEPARATOR);
+}
+
+export function toggleMultipleIso(selected: readonly string[], iso: string): string[] {
+	const set = new Set(selected);
+	if (set.has(iso)) {
+		set.delete(iso);
+	} else {
+		set.add(iso);
+	}
+	return [...set].sort(compareIso);
+}
+
+export function isIsoInSpan(iso: string, range: IsoRange): boolean {
+	const normalized = normalizeRange(range.start, range.end);
+	return compareIso(iso, normalized.start) >= 0 && compareIso(iso, normalized.end) <= 0;
+}
+
+export function getActiveRangeBounds(
+	committed: IsoRange | null,
+	draft: RangeSelectionDraft,
+): IsoRange | null {
+	if (draft.anchor) {
+		const hover = draft.hover ?? draft.anchor;
+		return normalizeRange(draft.anchor, hover);
+	}
+	return committed;
+}
+
+export function getDaySelectionAppearance(
+	iso: string,
+	mode: CalendarSelectionMode,
+	options: {
+		singleIso?: string;
+		multipleIsos?: readonly string[];
+		range?: IsoRange | null;
+	},
+): DaySelectionAppearance {
+	if (mode === 'single') {
+		const selected = options.singleIso === iso;
+		return {
+			isSelected: selected,
+			isRangeStart: selected,
+			isRangeEnd: selected,
+			isRangeMiddle: false,
+		};
+	}
+
+	if (mode === 'multiple') {
+		const selected = options.multipleIsos?.includes(iso) ?? false;
+		return {
+			isSelected: selected,
+			isRangeStart: selected,
+			isRangeEnd: selected,
+			isRangeMiddle: false,
+		};
+	}
+
+	const range = options.range;
+	if (!range) {
+		return { isSelected: false, isRangeStart: false, isRangeEnd: false, isRangeMiddle: false };
+	}
+
+	const normalized = normalizeRange(range.start, range.end);
+	const inSpan = isIsoInSpan(iso, normalized);
+	const isStart = iso === normalized.start;
+	const isEnd = iso === normalized.end;
+	const isMiddle = inSpan && !isStart && !isEnd;
+
+	return {
+		isSelected: inSpan,
+		isRangeStart: isStart,
+		isRangeEnd: isEnd,
+		isRangeMiddle: isMiddle,
+	};
+}
+
+/**
+ * Advances range selection after a day click.
+ *
+ * First click sets the anchor; second click commits the range.
+ */
+export function advanceRangeSelection(
+	committed: IsoRange | null,
+	draft: RangeSelectionDraft,
+	iso: string,
+): { committed: IsoRange | null; draft: RangeSelectionDraft } {
+	if (!draft.anchor) {
+		return { committed, draft: { anchor: iso, hover: iso } };
+	}
+
+	const next = normalizeRange(draft.anchor, iso);
+	return { committed: next, draft: { anchor: null, hover: null } };
+}

--- a/packages/radiant-ui/src/lib/intl-date/types.ts
+++ b/packages/radiant-ui/src/lib/intl-date/types.ts
@@ -1,0 +1,22 @@
+export type IntlLocale = string | string[] | undefined;
+
+export type DatePartType = 'day' | 'month' | 'year';
+
+export type DateDisplayStyle = 'short' | 'medium' | 'long' | 'full';
+
+/** Smallest displayed unit — mirrors React Aria `granularity`. */
+export type DateGranularity = 'day' | 'month' | 'year';
+
+export type CalendarDayCell = {
+	date: Date;
+	iso: string;
+	inMonth: boolean;
+	isToday: boolean;
+	isSelected: boolean;
+	isDisabled: boolean;
+	isRangeStart: boolean;
+	isRangeEnd: boolean;
+	isRangeMiddle: boolean;
+};
+
+export type CalendarWeek = CalendarDayCell[];

--- a/packages/radiant-ui/src/lib/mask/date-mask.test.ts
+++ b/packages/radiant-ui/src/lib/mask/date-mask.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { applyDateMask, buildDateMaskPattern, getDefaultDatePlaceholder, maskedDigitsToParts, partsToDate } from './date-mask';
+
+describe('applyDateMask', () => {
+	it('inserts literals for en-US', () => {
+		expect(applyDateMask('08212002', '00/00/0000')).toBe('08/21/2002');
+	});
+});
+
+describe('getDefaultDatePlaceholder', () => {
+	it('returns locale pattern hints', () => {
+		expect(getDefaultDatePlaceholder('en-US')).toMatch(/mm.*dd.*yyyy/);
+	});
+});
+
+describe('maskedDigitsToParts', () => {
+	it('maps digits to parts for en-US', () => {
+		const parts = maskedDigitsToParts('08212002', 'en-US');
+		const date = partsToDate(parts ?? {});
+		expect(date && [date.getFullYear(), date.getMonth() + 1, date.getDate()]).toEqual([2002, 8, 21]);
+	});
+});
+
+describe('buildDateMaskPattern', () => {
+	it('uses hash slots per locale', () => {
+		expect(buildDateMaskPattern('en-US')).toBe('00/00/0000');
+	});
+});

--- a/packages/radiant-ui/src/lib/mask/date-mask.ts
+++ b/packages/radiant-ui/src/lib/mask/date-mask.ts
@@ -1,0 +1,148 @@
+import { applyInputMask, maskInputSlotCount, parseMaskPattern } from './input-mask';
+import { getDateTimeFormat } from '@/lib/intl-date/formatters';
+import type { DatePartType, IntlLocale } from '@/lib/intl-date/types';
+
+/** IMask pattern for locale date digits (`0` = digit slot). */
+export type DateMaskPattern = string;
+
+const REFERENCE_DATE = new Date(2001, 8, 3);
+
+function getNumericPartOrder(locale: IntlLocale): DatePartType[] {
+	return getDateTimeFormat(locale, {
+		year: 'numeric',
+		month: '2-digit',
+		day: '2-digit',
+	})
+		.formatToParts(REFERENCE_DATE)
+		.filter((part) => part.type === 'year' || part.type === 'month' || part.type === 'day')
+		.map((part) => part.type as DatePartType);
+}
+
+/**
+ * Builds a mask pattern from `formatToParts()` (e.g. `00/00/0000` for en-US).
+ *
+ * Consecutive `0` runs map to month, day, or year in locale order.
+ */
+export function buildDateMaskPattern(locale: IntlLocale): DateMaskPattern {
+	const parts = getDateTimeFormat(locale, {
+		year: 'numeric',
+		month: '2-digit',
+		day: '2-digit',
+	}).formatToParts(REFERENCE_DATE);
+
+	let pattern = '';
+	for (const part of parts) {
+		if (part.type === 'literal') {
+			pattern += part.value;
+			continue;
+		}
+		if (part.type === 'month' || part.type === 'day' || part.type === 'year') {
+			pattern += part.value.replace(/\d/g, '0');
+		}
+	}
+	return pattern;
+}
+
+/** Human-readable placeholder derived from the locale mask (e.g. `mm/dd/yyyy`). */
+export function getDefaultDatePlaceholder(locale: IntlLocale): string {
+	const parts = getDateTimeFormat(locale, {
+		year: 'numeric',
+		month: '2-digit',
+		day: '2-digit',
+	}).formatToParts(REFERENCE_DATE);
+
+	return parts
+		.map((part) => {
+			if (part.type === 'literal') {
+				return part.value;
+			}
+			if (part.type === 'year') {
+				return 'yyyy';
+			}
+			if (part.type === 'month') {
+				return 'mm';
+			}
+			if (part.type === 'day') {
+				return 'dd';
+			}
+			return '';
+		})
+		.join('');
+}
+
+/** @deprecated Use `getDefaultDatePlaceholder`. */
+export function maskPatternToPlaceholder(pattern: DateMaskPattern): string {
+	return pattern.replace(/0/g, '·');
+}
+
+/** Strips non-digits from user input. */
+export function extractMaskDigits(value: string): string {
+	return value.replace(/\D/g, '');
+}
+
+/**
+ * Applies `digits` to a mask pattern, inserting literals as needed.
+ *
+ * @example
+ * applyDateMask('08212002', '00/00/0000') // → '08/21/2002'
+ */
+export function applyDateMask(digits: string, pattern: DateMaskPattern): string {
+	return applyInputMask(extractMaskDigits(digits), pattern);
+}
+
+/** Maximum number of digit slots in a mask pattern. */
+export function maskDigitCapacity(pattern: DateMaskPattern): number {
+	return maskInputSlotCount(parseMaskPattern(pattern), { requiredOnly: true });
+}
+
+function normalizeYear(value: number): number {
+	if (value >= 100) {
+		return value;
+	}
+	return value >= 69 ? 1900 + value : 2000 + value;
+}
+
+/** Maps masked digits back to year/month/day using the locale field order. */
+export function maskedDigitsToParts(
+	digits: string,
+	locale: IntlLocale,
+): Partial<Record<DatePartType, number>> | null {
+	const order = getNumericPartOrder(locale);
+	let cursor = 0;
+	const values: Partial<Record<DatePartType, number>> = {};
+
+	for (const type of order) {
+		const width = type === 'year' ? 4 : 2;
+		const slice = digits.slice(cursor, cursor + width);
+		if (slice.length < width) {
+			return null;
+		}
+		let numeric = Number(slice);
+		if (type === 'year') {
+			numeric = normalizeYear(numeric);
+		}
+		values[type] = numeric;
+		cursor += width;
+	}
+
+	return values;
+}
+
+export function partsToDate(parts: Partial<Record<DatePartType, number>>): Date | null {
+	if (parts.year == null || parts.month == null || parts.day == null) {
+		return null;
+	}
+
+	const date = new Date(parts.year, parts.month - 1, parts.day);
+	if (
+		date.getFullYear() !== parts.year ||
+		date.getMonth() !== parts.month - 1 ||
+		date.getDate() !== parts.day
+	) {
+		return null;
+	}
+
+	return date;
+}
+
+export { getNumericPartOrder };

--- a/packages/radiant-ui/src/lib/mask/index.ts
+++ b/packages/radiant-ui/src/lib/mask/index.ts
@@ -1,0 +1,23 @@
+export {
+	applyDateMask,
+	buildDateMaskPattern,
+	extractMaskDigits as extractDateMaskDigits,
+	getDefaultDatePlaceholder,
+	getNumericPartOrder,
+	maskDigitCapacity,
+	maskedDigitsToParts,
+	maskPatternToPlaceholder,
+	partsToDate,
+} from './date-mask';
+export type { DateMaskPattern } from './date-mask';
+export {
+	applyInputMask,
+	extractMaskDigits,
+	extractMaskInput,
+	formatWithMask,
+	maskDigitSlotCount,
+	maskInputSlotCount,
+	maskToPlaceholder,
+	parseMaskPattern,
+} from './input-mask';
+export type { MaskDefinitions, MaskInputKind, MaskToken } from './input-mask';

--- a/packages/radiant-ui/src/lib/mask/input-mask.test.ts
+++ b/packages/radiant-ui/src/lib/mask/input-mask.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { applyInputMask, formatWithMask, maskToPlaceholder, parseMaskPattern } from './input-mask';
+
+describe('parseMaskPattern', () => {
+	it('parses fixed segments and digit slots', () => {
+		const tokens = parseMaskPattern('+{7}(000)000-00-00');
+		expect(tokens.filter((token) => token.type === 'input')).toHaveLength(10);
+		expect(tokens.find((token) => token.type === 'fixed')).toEqual({ type: 'fixed', value: '7' });
+	});
+
+	it('parses optional sections', () => {
+		const tokens = parseMaskPattern('0[00]');
+		expect(tokens).toEqual([
+			{ type: 'input', definition: '0', kind: 'digit', optional: false },
+			{ type: 'input', definition: '0', kind: 'digit', optional: true },
+			{ type: 'input', definition: '0', kind: 'digit', optional: true },
+		]);
+	});
+
+	it('parses escaped literals', () => {
+		const tokens = parseMaskPattern('\\0');
+		expect(tokens).toEqual([{ type: 'literal', value: '0' }]);
+	});
+});
+
+describe('applyInputMask', () => {
+	it('formats a Russian phone number', () => {
+		expect(applyInputMask('9123456789', '+{7}(000)000-00-00')).toBe('+7(912)345-67-89');
+	});
+
+	it('returns empty for no digits', () => {
+		expect(applyInputMask('', '+{7}(000)000-00-00')).toBe('');
+	});
+
+	it('ignores the fixed country code when reformatting', () => {
+		expect(applyInputMask('+7(912)345-67-897', '+{7}(000)000-00-00')).toBe('+7(912)345-67-89');
+		expect(applyInputMask('+7(777)777-77-777', '+{7}(000)000-00-00')).toBe('+7(777)777-77-77');
+	});
+
+	it('starts formatting from the first user digit', () => {
+		expect(applyInputMask('9', '+{7}(000)000-00-00')).toBe('+7(9');
+	});
+});
+
+describe('maskToPlaceholder', () => {
+	it('replaces digit slots with underscores', () => {
+		expect(maskToPlaceholder('+{7}(000)000-00-00')).toBe('+7(___)___-__-__');
+	});
+});
+
+describe('formatWithMask', () => {
+	it('formats IMask digit slots', () => {
+		const tokens = parseMaskPattern('00/00/0000');
+		expect(formatWithMask('08212002', tokens)).toBe('08/21/2002');
+	});
+});

--- a/packages/radiant-ui/src/lib/mask/input-mask.ts
+++ b/packages/radiant-ui/src/lib/mask/input-mask.ts
@@ -1,0 +1,286 @@
+/**
+ * IMask-compatible pattern mask utilities.
+ *
+ * @see https://imask.js.org/guide.html#masked-pattern
+ *
+ * Default slot definitions:
+ * - `0` — digit
+ * - `a` — letter
+ * - `*` — any character
+ *
+ * Other syntax:
+ * - `{text}` — fixed value (included in extracted input)
+ * - `[…]` — optional section
+ * - `\` — escape the next character (e.g. `\0` for a literal zero)
+ * - all other characters — fixed literals (`+`, `(`, `-`, …)
+ */
+
+export type MaskInputKind = 'digit' | 'letter' | 'any';
+
+export type MaskToken =
+	| { type: 'literal'; value: string }
+	| { type: 'fixed'; value: string }
+	| { type: 'input'; definition: string; kind: MaskInputKind; pattern?: RegExp; optional?: boolean };
+
+export type MaskDefinitions = Record<string, MaskInputKind | RegExp>;
+
+const DEFAULT_DEFINITIONS: Record<string, MaskInputKind> = {
+	'0': 'digit',
+	a: 'letter',
+	'*': 'any',
+};
+
+const LETTER = /\p{L}/u;
+
+function resolveDefinition(
+	char: string,
+	definitions?: MaskDefinitions,
+): { kind: MaskInputKind; pattern?: RegExp } | null {
+	const custom = definitions?.[char];
+	if (custom instanceof RegExp) {
+		return { kind: 'any', pattern: custom };
+	}
+	if (custom) {
+		return { kind: custom };
+	}
+	const builtIn = DEFAULT_DEFINITIONS[char];
+	return builtIn ? { kind: builtIn } : null;
+}
+
+function matchesInput(char: string, kind: MaskInputKind, pattern?: RegExp): boolean {
+	if (pattern) {
+		return pattern.test(char);
+	}
+	if (kind === 'digit') {
+		return /\d/.test(char);
+	}
+	if (kind === 'letter') {
+		return LETTER.test(char);
+	}
+	return char.length > 0;
+}
+
+function parseMaskPatternInternal(
+	pattern: string,
+	definitions?: MaskDefinitions,
+	optional = false,
+): MaskToken[] {
+	const tokens: MaskToken[] = [];
+	let index = 0;
+
+	while (index < pattern.length) {
+		const char = pattern[index];
+
+		if (char === '\\') {
+			const next = pattern[index + 1];
+			if (next) {
+				tokens.push({ type: 'literal', value: next });
+			}
+			index += 2;
+			continue;
+		}
+
+		if (char === '{') {
+			const end = pattern.indexOf('}', index + 1);
+			if (end < 0) {
+				tokens.push({ type: 'literal', value: '{' });
+				index += 1;
+				continue;
+			}
+			tokens.push({ type: 'fixed', value: pattern.slice(index + 1, end) });
+			index = end + 1;
+			continue;
+		}
+
+		if (char === '[') {
+			const end = findClosingBracket(pattern, index + 1);
+			if (end < 0) {
+				tokens.push({ type: 'literal', value: '[' });
+				index += 1;
+				continue;
+			}
+			const inner = parseMaskPatternInternal(pattern.slice(index + 1, end), definitions, true);
+			tokens.push(...inner);
+			index = end + 1;
+			continue;
+		}
+
+		if (char === ']') {
+			break;
+		}
+
+		const definition = resolveDefinition(char, definitions);
+		if (definition) {
+			tokens.push({
+				type: 'input',
+				definition: char,
+				kind: definition.kind,
+				pattern: definition.pattern,
+				optional,
+			});
+			index += 1;
+			continue;
+		}
+
+		tokens.push({ type: 'literal', value: char });
+		index += 1;
+	}
+
+	return tokens;
+}
+
+function findClosingBracket(pattern: string, start: number): number {
+	let depth = 1;
+	for (let index = start; index < pattern.length; index += 1) {
+		if (pattern[index] === '[' && pattern[index - 1] !== '\\') {
+			depth += 1;
+		}
+		if (pattern[index] === ']' && pattern[index - 1] !== '\\') {
+			depth -= 1;
+			if (depth === 0) {
+				return index;
+			}
+		}
+	}
+	return -1;
+}
+
+/** Parses an IMask pattern string into tokens. */
+export function parseMaskPattern(pattern: string, definitions?: MaskDefinitions): MaskToken[] {
+	return parseMaskPatternInternal(pattern, definitions);
+}
+
+export function maskInputSlotCount(tokens: MaskToken[], options: { requiredOnly?: boolean } = {}): number {
+	return tokens.filter(
+		(token) => token.type === 'input' && (!options.requiredOnly || !token.optional),
+	).length;
+}
+
+/** @deprecated Use `maskInputSlotCount`. */
+export function maskDigitSlotCount(tokens: MaskToken[]): number {
+	return maskInputSlotCount(tokens, { requiredOnly: true });
+}
+
+/** Placeholder using IMask's default `_` for input slots. */
+export function maskToPlaceholder(pattern: string, definitions?: MaskDefinitions): string {
+	const tokens = parseMaskPattern(pattern, definitions);
+	let result = '';
+
+	for (const token of tokens) {
+		if (token.type === 'literal' || token.type === 'fixed') {
+			result += token.value;
+			continue;
+		}
+		result += '_';
+	}
+
+	return result;
+}
+
+/** Extracts user-typed characters from a masked value (skips fixed segments and literals). */
+export function extractMaskInput(masked: string, tokens: MaskToken[]): string {
+	let input = '';
+	let cursor = 0;
+
+	for (const token of tokens) {
+		if (token.type === 'fixed' || token.type === 'literal') {
+			if (masked.slice(cursor, cursor + token.value.length) === token.value) {
+				cursor += token.value.length;
+			}
+			continue;
+		}
+
+		if (cursor >= masked.length) {
+			continue;
+		}
+
+		const char = masked[cursor];
+		if (matchesInput(char, token.kind, token.pattern)) {
+			input += char;
+			cursor += 1;
+		}
+	}
+
+	return input;
+}
+
+/** @deprecated Use `extractMaskInput`. */
+export function extractMaskDigits(masked: string, tokens: MaskToken[]): string {
+	return extractMaskInput(masked, tokens).replace(/\D/g, '');
+}
+
+/**
+ * Formats extracted input characters into a masked display string.
+ *
+ * Returns `''` when `input` is empty.
+ */
+export function formatWithMask(input: string, tokens: MaskToken[]): string {
+	if (!input) {
+		return '';
+	}
+
+	let inputIndex = 0;
+	let result = '';
+
+	for (const token of tokens) {
+		if (token.type === 'fixed' || token.type === 'literal') {
+			result += token.value;
+			continue;
+		}
+
+		if (inputIndex >= input.length) {
+			if (token.optional) {
+				continue;
+			}
+			break;
+		}
+
+		const char = input[inputIndex];
+		if (!matchesInput(char, token.kind, token.pattern)) {
+			if (token.optional) {
+				continue;
+			}
+			break;
+		}
+
+		result += char;
+		inputIndex += 1;
+	}
+
+	return result;
+}
+
+function isDigitOnlyPattern(tokens: MaskToken[]): boolean {
+	return tokens.every((token) => token.type !== 'input' || token.kind === 'digit');
+}
+
+function looseInputFromRaw(raw: string, tokens: MaskToken[]): string {
+	const loose = raw.replace(/\D/g, '');
+	const fixedDigits = tokens
+		.filter((token) => token.type === 'fixed')
+		.map((token) => token.value.replace(/\D/g, ''))
+		.join('');
+
+	if (fixedDigits && loose.startsWith(fixedDigits)) {
+		return loose.slice(fixedDigits.length);
+	}
+
+	return loose;
+}
+
+/** Normalizes user input to a masked display value. */
+export function applyInputMask(raw: string, pattern: string, definitions?: MaskDefinitions): string {
+	const tokens = parseMaskPattern(pattern, definitions);
+	const capacity = maskInputSlotCount(tokens);
+	let input = extractMaskInput(raw, tokens);
+
+	if (input.length === 0 && /\S/.test(raw) && isDigitOnlyPattern(tokens)) {
+		input = looseInputFromRaw(raw, tokens);
+	}
+
+	if (input.length > capacity) {
+		input = input.slice(0, capacity);
+	}
+
+	return formatWithMask(input, tokens);
+}


### PR DESCRIPTION
## Summary
- Add intl-date module (calendar grid, segments, ISO, formatters)
- Add input-mask and date-mask helpers

## Test plan
- [x] intl-date and mask unit tests
- [x] Pre-commit hooks pass