### PR TITLE
feat(radiant-ui): add headline component

### DIFF
--- a/packages/radiant-ui/package.json
+++ b/packages/radiant-ui/package.json
@@ -264,6 +264,13 @@
     "./grid/styles.css": {
       "default": "./dist/components/ui/grid/grid.css"
     },
+    "./headline": {
+      "types": "./dist/components/ui/headline/index.d.ts",
+      "import": "./dist/components/ui/headline/index.js"
+    },
+    "./headline/styles.css": {
+      "default": "./dist/components/ui/headline/headline.css"
+    },
     "./input": {
       "types": "./dist/components/ui/input/index.d.ts",
       "import": "./dist/components/ui/input/index.js"

--- a/packages/radiant-ui/src/Introduction.mdx
+++ b/packages/radiant-ui/src/Introduction.mdx
@@ -27,7 +27,8 @@ Not every entry under **Components/** is a full APG widget. Read the component T
       <td><strong>Native</strong></td>
       <td>Thin styling / wiring around platform controls</td>
       <td>
-        <code>RuiButton</code>, <code>RuiInput</code>, <code>RuiTextarea</code>, Switch, Checkbox, Slider (single + range), Meter, Radio Group
+        <code>RuiButton</code>, <code>RuiInput</code>, <code>RuiTextarea</code>, Switch, Checkbox, Slider (single + range), Meter, Radio Group,
+        <code>RuiHeadline</code>
       </td>
     </tr>
     <tr>
@@ -106,7 +107,7 @@ import '@ecopages/radiant-ui/styles.css';
 import '@ecopages/radiant-ui';
 ```
 
-Presentational helpers that are not custom elements (today: `RuiButton`, `RuiInput`, `RuiTextarea`, `RuiLabel`, `RuiFieldDescription`, `RuiFieldError`) are still imported from their subpath:
+Presentational helpers that are not custom elements (today: `RuiButton`, `RuiInput`, `RuiTextarea`, `RuiLabel`, `RuiFieldDescription`, `RuiFieldError`, `RuiHeadline`) are still imported from their subpath:
 
 ```ts
 import { RuiButton } from '@ecopages/radiant-ui/button';

--- a/packages/radiant-ui/src/components/ui/headline/headline.css
+++ b/packages/radiant-ui/src/components/ui/headline/headline.css
@@ -1,0 +1,33 @@
+@reference '../../../styles/radiant-ui.css';
+
+@layer components {
+	.rui-headline {
+		@apply m-0 font-semibold text-on-background;
+		line-height: var(--leading-compact);
+		letter-spacing: -0.02em;
+		text-wrap: balance;
+	}
+
+	.rui-headline--size-sm {
+		font-size: var(--text-xl);
+		letter-spacing: -0.015em;
+	}
+
+	.rui-headline--size-md {
+		font-size: var(--text-3xl);
+		line-height: 1.2;
+		letter-spacing: -0.02em;
+	}
+
+	.rui-headline--size-lg {
+		font-size: var(--text-4xl);
+		line-height: 1.15;
+		letter-spacing: -0.025em;
+	}
+
+	.rui-headline--size-xl {
+		font-size: var(--text-4xl);
+		line-height: 1.1;
+		letter-spacing: -0.03em;
+	}
+}

--- a/packages/radiant-ui/src/components/ui/headline/headline.stories.tsx
+++ b/packages/radiant-ui/src/components/ui/headline/headline.stories.tsx
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from '@ecopages/storybook-radiant-vite';
+import { RuiHeadline } from './headline';
+
+const meta = {
+	title: 'Components/Headline',
+	component: RuiHeadline,
+	args: {
+		children: 'Display title',
+	},
+} satisfies Meta<typeof RuiHeadline>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Sizes: Story = {
+	render: () => (
+		<div class="flex flex-col gap-stack">
+			<RuiHeadline size="sm">Small headline</RuiHeadline>
+			<RuiHeadline size="md">Medium headline</RuiHeadline>
+			<RuiHeadline size="lg">Large headline</RuiHeadline>
+			<RuiHeadline size="xl">Extra large headline</RuiHeadline>
+		</div>
+	),
+};
+
+export const HeadingLevels: Story = {
+	render: () => (
+		<div class="flex flex-col gap-stack">
+			<RuiHeadline as="h1" size="lg">
+				Page title (h1)
+			</RuiHeadline>
+			<RuiHeadline as="h2">Section title (h2)</RuiHeadline>
+			<RuiHeadline as="h3" size="sm">
+				Subsection (h3)
+			</RuiHeadline>
+		</div>
+	),
+};

--- a/packages/radiant-ui/src/components/ui/headline/headline.tsx
+++ b/packages/radiant-ui/src/components/ui/headline/headline.tsx
@@ -1,0 +1,33 @@
+import type { JsxHtmlPropsWithChildren } from '@ecopages/jsx';
+import { cx } from '@/lib/cx';
+import { Intrinsic, type IntrinsicTag } from '@/lib/intrinsic';
+import { attachRadiantStylesheets } from '@/lib/radiant-view';
+
+export type RuiHeadlineSize = 'sm' | 'md' | 'lg' | 'xl';
+export type RuiHeadlineAs = Extract<IntrinsicTag, 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p' | 'span'>;
+
+export type RuiHeadlineProps = JsxHtmlPropsWithChildren<{
+	/** Semantic element. Default: `h2`. */
+	as?: RuiHeadlineAs;
+	/**
+	 * Type scale. Default: `md`.
+	 * Pass `false` when a parent (e.g. `RuiHeading`) owns size via CSS variables.
+	 */
+	size?: RuiHeadlineSize | false;
+	id?: string;
+}>;
+
+/** Standalone display title outside a heading block. */
+export function RuiHeadline({ children, as = 'h2', size = 'md', class: className, ...props }: RuiHeadlineProps) {
+	return (
+		<Intrinsic
+			as={as}
+			{...props}
+			class={cx('rui-headline', size !== false && `rui-headline--size-${size}`, className)}
+		>
+			{children}
+		</Intrinsic>
+	);
+}
+
+attachRadiantStylesheets(RuiHeadline, ['./headline.css'], import.meta.url);

--- a/packages/radiant-ui/src/components/ui/headline/index.ts
+++ b/packages/radiant-ui/src/components/ui/headline/index.ts
@@ -1,0 +1,6 @@
+export {
+	RuiHeadline,
+	type RuiHeadlineAs,
+	type RuiHeadlineProps,
+	type RuiHeadlineSize,
+} from './headline';

--- a/packages/radiant-ui/src/index.ts
+++ b/packages/radiant-ui/src/index.ts
@@ -19,6 +19,7 @@ export * from './components/ui/feed';
 export * from './components/ui/field';
 export * from './components/ui/form';
 export * from './components/ui/grid';
+export * from './components/ui/headline';
 export * from './components/ui/input';
 export * from './components/ui/label';
 export * from './components/ui/listbox';

--- a/packages/radiant-ui/src/lib/intrinsic.tsx
+++ b/packages/radiant-ui/src/lib/intrinsic.tsx
@@ -1,0 +1,22 @@
+import type { JsxHtmlPropsWithChildren } from '@ecopages/jsx';
+
+export type IntrinsicTag = keyof HTMLElementTagNameMap;
+
+export type IntrinsicProps<Tag extends IntrinsicTag> = JsxHtmlPropsWithChildren<{
+	as?: Tag;
+}>;
+
+/**
+ * Renders a dynamic intrinsic element via JSX (`<Tag>`), avoiding per-tag switch blocks.
+ *
+ * @remarks Default tag is `div`; pass `as` on each call site.
+ */
+export function Intrinsic<Tag extends IntrinsicTag = 'div'>({
+	as,
+	children,
+	...props
+}: IntrinsicProps<Tag> & { as?: Tag }) {
+	const Tag = (as ?? 'div') as Tag;
+
+	return <Tag {...props}>{children}</Tag>;
+}

--- a/packages/radiant-ui/src/styles/styles.css
+++ b/packages/radiant-ui/src/styles/styles.css
@@ -19,6 +19,7 @@
 @import '../components/ui/field/field.css';
 @import '../components/ui/form/form.css';
 @import '../components/ui/grid/grid.css';
+@import '../components/ui/headline/headline.css';
 @import '../components/ui/input/input.css';
 @import '../components/ui/label/label.css';
 @import '../components/ui/listbox/listbox.css';

--- a/packages/radiant-ui/src/styles/tokens/typography/default.css
+++ b/packages/radiant-ui/src/styles/tokens/typography/default.css
@@ -11,6 +11,10 @@
 	--text-sm: 0.875rem;
 	--text-body: 1rem;
 	--text-lg: 1.125rem;
+	--text-xl: 1.25rem;
+	--text-2xl: 1.5rem;
+	--text-3xl: 1.875rem;
+	--text-4xl: 2.25rem;
 	--text-label: 0.875rem;
 	--text-control: 0.875rem;
 
@@ -32,6 +36,10 @@
 	--text-sm: var(--text-sm);
 	--text-body: var(--text-body);
 	--text-lg: var(--text-lg);
+	--text-xl: var(--text-xl);
+	--text-2xl: var(--text-2xl);
+	--text-3xl: var(--text-3xl);
+	--text-4xl: var(--text-4xl);
 	--font-weight-medium: var(--weight-medium);
 	--font-weight-semibold: var(--weight-semibold);
 }


### PR DESCRIPTION
## Summary
- Add `Intrinsic` helper for polymorphic JSX elements
- Add display typography tokens (`--text-xl` through `--text-4xl`)
- Add `RuiHeadline` presentational component with stories and exports

## Test plan
- [ ] Storybook: Headline stories render at all sizes
- [ ] Import from `@ecopages/radiant-ui/headline`