### PR TITLE
feat(radiant-ui): add heading component

### DIFF
--- a/packages/radiant-ui/package.json
+++ b/packages/radiant-ui/package.json
@@ -271,6 +271,13 @@
     "./headline/styles.css": {
       "default": "./dist/components/ui/headline/headline.css"
     },
+    "./heading": {
+      "types": "./dist/components/ui/heading/index.d.ts",
+      "import": "./dist/components/ui/heading/index.js"
+    },
+    "./heading/styles.css": {
+      "default": "./dist/components/ui/heading/heading.css"
+    },
     "./input": {
       "types": "./dist/components/ui/input/index.d.ts",
       "import": "./dist/components/ui/input/index.js"

--- a/packages/radiant-ui/src/Introduction.mdx
+++ b/packages/radiant-ui/src/Introduction.mdx
@@ -28,7 +28,7 @@ Not every entry under **Components/** is a full APG widget. Read the component T
       <td>Thin styling / wiring around platform controls</td>
       <td>
         <code>RuiButton</code>, <code>RuiInput</code>, <code>RuiTextarea</code>, Switch, Checkbox, Slider (single + range), Meter, Radio Group,
-        <code>RuiHeadline</code>
+        <code>RuiHeading</code>, <code>RuiHeadline</code>
       </td>
     </tr>
     <tr>
@@ -107,7 +107,7 @@ import '@ecopages/radiant-ui/styles.css';
 import '@ecopages/radiant-ui';
 ```
 
-Presentational helpers that are not custom elements (today: `RuiButton`, `RuiInput`, `RuiTextarea`, `RuiLabel`, `RuiFieldDescription`, `RuiFieldError`, `RuiHeadline`) are still imported from their subpath:
+Presentational helpers that are not custom elements (today: `RuiButton`, `RuiInput`, `RuiTextarea`, `RuiLabel`, `RuiFieldDescription`, `RuiFieldError`, `RuiHeading`, `RuiHeadline`) are still imported from their subpath:
 
 ```ts
 import { RuiButton } from '@ecopages/radiant-ui/button';

--- a/packages/radiant-ui/src/components/ui/heading/heading.css
+++ b/packages/radiant-ui/src/components/ui/heading/heading.css
@@ -1,0 +1,105 @@
+@reference '../../../styles/radiant-ui.css';
+
+@layer components {
+	.rui-heading {
+		@apply flex flex-col text-on-background;
+	}
+
+	.rui-heading--align-start {
+		@apply items-start text-left;
+	}
+
+	.rui-heading--align-center {
+		@apply items-center text-center;
+	}
+
+	.rui-heading--align-center .rui-heading__description {
+		@apply mx-auto;
+	}
+
+	/**
+	 * Size packs: eyebrow stays close to the title (8–12px);
+	 * description sits farther below so the title+eyebrow read as one unit.
+	 */
+	.rui-heading--size-sm {
+		--heading-eyebrow-font-size: var(--text-xs);
+		--heading-title-font-size: var(--text-xl);
+		--heading-description-font-size: var(--text-sm);
+		--heading-title-leading: var(--leading-compact);
+		--heading-title-tracking: -0.015em;
+		--heading-eyebrow-gap: var(--space-2);
+		--heading-description-gap: var(--space-3);
+		--heading-description-measure: 36rem;
+	}
+
+	.rui-heading--size-md {
+		--heading-eyebrow-font-size: var(--text-xs);
+		--heading-title-font-size: var(--text-3xl);
+		--heading-description-font-size: var(--text-body);
+		--heading-title-leading: 1.2;
+		--heading-title-tracking: -0.02em;
+		--heading-eyebrow-gap: var(--space-2);
+		--heading-description-gap: var(--space-4);
+		--heading-description-measure: 40rem;
+	}
+
+	.rui-heading--size-lg {
+		--heading-eyebrow-font-size: var(--text-sm);
+		--heading-title-font-size: var(--text-4xl);
+		--heading-description-font-size: var(--text-lg);
+		--heading-title-leading: 1.15;
+		--heading-title-tracking: -0.025em;
+		--heading-eyebrow-gap: var(--space-3);
+		--heading-description-gap: var(--space-5);
+		--heading-description-measure: 42rem;
+	}
+
+	.rui-heading--size-xl {
+		--heading-eyebrow-font-size: var(--text-sm);
+		--heading-title-font-size: var(--text-4xl);
+		--heading-description-font-size: var(--text-lg);
+		--heading-title-leading: 1.1;
+		--heading-title-tracking: -0.03em;
+		--heading-eyebrow-gap: var(--space-3);
+		--heading-description-gap: var(--space-6);
+		--heading-description-measure: 36rem;
+	}
+
+	.rui-heading__eyebrow {
+		@apply m-0 font-semibold uppercase text-primary;
+		font-size: var(--heading-eyebrow-font-size);
+		letter-spacing: 0.08em;
+		line-height: var(--leading-compact);
+	}
+
+	.rui-heading__eyebrow:not(:last-child) {
+		margin-bottom: var(--heading-eyebrow-gap);
+	}
+
+	.rui-heading__eyebrow:empty {
+		@apply hidden;
+	}
+
+	.rui-heading__title {
+		font-size: var(--heading-title-font-size);
+		line-height: var(--heading-title-leading, var(--leading-compact));
+		letter-spacing: var(--heading-title-tracking, -0.02em);
+		text-wrap: balance;
+	}
+
+	.rui-heading__description {
+		@apply m-0 text-on-surface;
+		font-size: var(--heading-description-font-size);
+		line-height: var(--leading-relaxed);
+		max-width: var(--heading-description-measure, 40rem);
+		text-wrap: pretty;
+	}
+
+	.rui-heading__title + .rui-heading__description {
+		margin-top: var(--heading-description-gap);
+	}
+
+	.rui-heading__description:empty {
+		@apply hidden;
+	}
+}

--- a/packages/radiant-ui/src/components/ui/heading/heading.stories.tsx
+++ b/packages/radiant-ui/src/components/ui/heading/heading.stories.tsx
@@ -1,0 +1,113 @@
+import type { Meta, StoryObj } from '@ecopages/storybook-radiant-vite';
+import {
+	RuiHeading,
+	RuiHeadingDescription,
+	RuiHeadingEyebrow,
+	RuiHeadingTitle,
+} from './heading';
+
+const meta = {
+	title: 'Components/Heading',
+	component: RuiHeading,
+} satisfies Meta<typeof RuiHeading>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Hero: Story = {
+	render: () => (
+		<div class="flex min-h-72 items-center justify-center rounded-container bg-surface-container-low px-8 py-16">
+			<RuiHeading align="center" size="xl">
+				<RuiHeadingEyebrow>Design system</RuiHeadingEyebrow>
+				<RuiHeadingTitle as="h1">Build interfaces that feel inevitable</RuiHeadingTitle>
+				<RuiHeadingDescription>
+					Composable typography with a clear rhythm — eyebrow tight to the title, supporting line with room
+					to breathe.
+				</RuiHeadingDescription>
+			</RuiHeading>
+		</div>
+	),
+};
+
+export const DocsSection: Story = {
+	render: () => (
+		<div class="max-w-2xl border-l-2 border-primary pl-6">
+			<RuiHeading as="header" size="md">
+				<RuiHeadingEyebrow>Getting started</RuiHeadingEyebrow>
+				<RuiHeadingTitle as="h2">Installation</RuiHeadingTitle>
+				<RuiHeadingDescription>
+					Load a theme and component styles before registering elements. One import graph keeps tokens and
+					widgets in sync.
+				</RuiHeadingDescription>
+			</RuiHeading>
+		</div>
+	),
+};
+
+export const FeaturePair: Story = {
+	render: () => (
+		<div class="grid max-w-4xl gap-10 md:grid-cols-2">
+			<RuiHeading size="lg">
+				<RuiHeadingEyebrow>Primitives</RuiHeadingEyebrow>
+				<RuiHeadingTitle as="h2">Typography that scales</RuiHeadingTitle>
+				<RuiHeadingDescription>
+					Display sizes inherit from a shared token pack so heroes, docs, and dense settings panels stay in
+					one family.
+				</RuiHeadingDescription>
+			</RuiHeading>
+			<RuiHeading size="lg">
+				<RuiHeadingEyebrow>Composition</RuiHeadingEyebrow>
+				<RuiHeadingTitle as="h2">Slots over prop bags</RuiHeadingTitle>
+				<RuiHeadingDescription>
+					Omit empty parts. Drop chips, avatars, and actions beside the heading — never as optional string
+					props on a shared base.
+				</RuiHeadingDescription>
+			</RuiHeading>
+		</div>
+	),
+};
+
+export const DashboardSection: Story = {
+	render: () => (
+		<section class="max-w-md rounded-container border border-border bg-background p-inset">
+			<RuiHeading size="sm">
+				<RuiHeadingEyebrow>Account</RuiHeadingEyebrow>
+				<RuiHeadingTitle as="h3">Profile settings</RuiHeadingTitle>
+				<RuiHeadingDescription>
+					Update your name, email, and notification preferences for this workspace.
+				</RuiHeadingDescription>
+			</RuiHeading>
+		</section>
+	),
+};
+
+export const TitleOnly: Story = {
+	render: () => (
+		<RuiHeading size="md">
+			<RuiHeadingTitle>Quick start</RuiHeadingTitle>
+		</RuiHeading>
+	),
+};
+
+export const SizeLadder: Story = {
+	render: () => (
+		<div class="flex max-w-3xl flex-col divide-y divide-border">
+			{(
+				[
+					['sm', 'Settings group', 'Compact rhythm for nested panels and dense app UI.'],
+					['md', 'Documentation page', 'Default scale for docs sections and product pages.'],
+					['lg', 'Feature overview', 'More presence for landing sections without extra wrappers.'],
+					['xl', 'Product hero', 'Maximum display weight for first-viewport messaging.'],
+				] as const
+			).map(([size, title, description]) => (
+				<div class="py-8 first:pt-0 last:pb-0">
+					<RuiHeading size={size}>
+						<RuiHeadingEyebrow>{size}</RuiHeadingEyebrow>
+						<RuiHeadingTitle as="h2">{title}</RuiHeadingTitle>
+						<RuiHeadingDescription>{description}</RuiHeadingDescription>
+					</RuiHeading>
+				</div>
+			))}
+		</div>
+	),
+};

--- a/packages/radiant-ui/src/components/ui/heading/heading.tsx
+++ b/packages/radiant-ui/src/components/ui/heading/heading.tsx
@@ -1,0 +1,78 @@
+import type { JsxHtmlPropsWithChildren } from '@ecopages/jsx';
+import { cx } from '@/lib/cx';
+import { Intrinsic, type IntrinsicTag } from '@/lib/intrinsic';
+import { attachRadiantStylesheets } from '@/lib/radiant-view';
+import { RuiHeadline, type RuiHeadlineAs } from '../headline/headline';
+
+export type RuiHeadingAlign = 'start' | 'center';
+export type RuiHeadingSize = 'sm' | 'md' | 'lg' | 'xl';
+export type RuiHeadingRootAs = Extract<IntrinsicTag, 'div' | 'header' | 'section' | 'article' | 'aside'>;
+export type RuiHeadingTitleAs = RuiHeadlineAs;
+
+export type RuiHeadingProps = JsxHtmlPropsWithChildren<{
+	/** Root element. Default: `div`. */
+	as?: RuiHeadingRootAs;
+	/** Text and flex alignment. Default: `start`. */
+	align?: RuiHeadingAlign;
+	/** Type scale and vertical rhythm between slots. Default: `md`. */
+	size?: RuiHeadingSize;
+}>;
+
+function headingRootClassName(align: RuiHeadingAlign, size: RuiHeadingSize, className?: string) {
+	return cx('rui-heading', `rui-heading--align-${align}`, `rui-heading--size-${size}`, className);
+}
+
+/** Groups eyebrow, title, and description with shared spacing and type scale. */
+export function RuiHeading({
+	children,
+	as = 'div',
+	align = 'start',
+	size = 'md',
+	class: className,
+	...props
+}: RuiHeadingProps) {
+	return (
+		<Intrinsic as={as} {...props} class={headingRootClassName(align, size, className)}>
+			{children}
+		</Intrinsic>
+	);
+}
+
+export type RuiHeadingEyebrowProps = JsxHtmlPropsWithChildren;
+
+/** Kicker line above the title. */
+export function RuiHeadingEyebrow({ children, class: className, ...props }: RuiHeadingEyebrowProps) {
+	return (
+		<p {...props} class={cx('rui-heading__eyebrow', className)}>
+			{children}
+		</p>
+	);
+}
+
+export type RuiHeadingTitleProps = JsxHtmlPropsWithChildren<{
+	/** Heading level. Default: `h2`. */
+	as?: RuiHeadingTitleAs;
+	id?: string;
+}>;
+
+/** Main title within a heading block — `RuiHeadline` sized by the parent `RuiHeading`. */
+export function RuiHeadingTitle({ children, as = 'h2', class: className, ...props }: RuiHeadingTitleProps) {
+	return (
+		<RuiHeadline as={as} size={false} class={cx('rui-heading__title', className)} {...props}>
+			{children}
+		</RuiHeadline>
+	);
+}
+
+export type RuiHeadingDescriptionProps = JsxHtmlPropsWithChildren;
+
+/** Supporting copy below the title. */
+export function RuiHeadingDescription({ children, class: className, ...props }: RuiHeadingDescriptionProps) {
+	return (
+		<p {...props} class={cx('rui-heading__description', className)}>
+			{children}
+		</p>
+	);
+}
+
+attachRadiantStylesheets(RuiHeading, ['./heading.css', '../headline/headline.css'], import.meta.url);

--- a/packages/radiant-ui/src/components/ui/heading/index.ts
+++ b/packages/radiant-ui/src/components/ui/heading/index.ts
@@ -1,0 +1,14 @@
+export {
+	RuiHeading,
+	RuiHeadingDescription,
+	RuiHeadingEyebrow,
+	RuiHeadingTitle,
+	type RuiHeadingAlign,
+	type RuiHeadingDescriptionProps,
+	type RuiHeadingEyebrowProps,
+	type RuiHeadingProps,
+	type RuiHeadingRootAs,
+	type RuiHeadingSize,
+	type RuiHeadingTitleAs,
+	type RuiHeadingTitleProps,
+} from './heading';

--- a/packages/radiant-ui/src/index.ts
+++ b/packages/radiant-ui/src/index.ts
@@ -20,6 +20,7 @@ export * from './components/ui/field';
 export * from './components/ui/form';
 export * from './components/ui/grid';
 export * from './components/ui/headline';
+export * from './components/ui/heading';
 export * from './components/ui/input';
 export * from './components/ui/label';
 export * from './components/ui/listbox';

--- a/packages/radiant-ui/src/styles/styles.css
+++ b/packages/radiant-ui/src/styles/styles.css
@@ -20,6 +20,7 @@
 @import '../components/ui/form/form.css';
 @import '../components/ui/grid/grid.css';
 @import '../components/ui/headline/headline.css';
+@import '../components/ui/heading/heading.css';
 @import '../components/ui/input/input.css';
 @import '../components/ui/label/label.css';
 @import '../components/ui/listbox/listbox.css';


### PR DESCRIPTION
## Summary
- Add `RuiHeading` compound component (eyebrow, title, description)
- Title delegates to `RuiHeadline` with parent-controlled sizing

## Test plan
- [ ] Storybook: Heading stories render all size variants
- [ ] Import from `@ecopages/radiant-ui/heading`