### PR TITLE
feat(radiant-ui): add avatar component

### DIFF
--- a/packages/radiant-ui/package.json
+++ b/packages/radiant-ui/package.json
@@ -166,6 +166,13 @@
     "./autocomplete/styles.css": {
       "default": "./dist/components/ui/autocomplete/autocomplete.css"
     },
+    "./avatar": {
+      "types": "./dist/components/ui/avatar/index.d.ts",
+      "import": "./dist/components/ui/avatar/index.js"
+    },
+    "./avatar/styles.css": {
+      "default": "./dist/components/ui/avatar/avatar.css"
+    },
     "./breadcrumb": {
       "types": "./dist/components/ui/breadcrumb/index.d.ts",
       "import": "./dist/components/ui/breadcrumb/index.js"

--- a/packages/radiant-ui/src/Introduction.mdx
+++ b/packages/radiant-ui/src/Introduction.mdx
@@ -28,7 +28,7 @@ Not every entry under **Components/** is a full APG widget. Read the component T
       <td>Thin styling / wiring around platform controls</td>
       <td>
         <code>RuiButton</code>, <code>RuiInput</code>, <code>RuiTextarea</code>, Switch, Checkbox, Slider (single + range), Meter, Radio Group,
-        <code>RuiHeading</code>, <code>RuiHeadline</code>
+        <code>RuiHeading</code>, <code>RuiHeadline</code>, <code>RuiAvatar</code>
       </td>
     </tr>
     <tr>
@@ -107,7 +107,7 @@ import '@ecopages/radiant-ui/styles.css';
 import '@ecopages/radiant-ui';
 ```
 
-Presentational helpers that are not custom elements (today: `RuiButton`, `RuiInput`, `RuiTextarea`, `RuiLabel`, `RuiFieldDescription`, `RuiFieldError`, `RuiHeading`, `RuiHeadline`) are still imported from their subpath:
+Presentational helpers that are not custom elements (today: `RuiButton`, `RuiInput`, `RuiTextarea`, `RuiLabel`, `RuiFieldDescription`, `RuiFieldError`, `RuiHeading`, `RuiHeadline`, `RuiAvatar`) are still imported from their subpath:
 
 ```ts
 import { RuiButton } from '@ecopages/radiant-ui/button';

--- a/packages/radiant-ui/src/components/ui/avatar/avatar.css
+++ b/packages/radiant-ui/src/components/ui/avatar/avatar.css
@@ -1,0 +1,27 @@
+@reference '../../../styles/radiant-ui.css';
+
+@layer components {
+	.rui-avatar {
+		@apply relative inline-flex shrink-0 items-center justify-center overflow-hidden rounded-pill bg-surface-container font-medium text-on-surface;
+	}
+
+	.rui-avatar--sm {
+		@apply size-8 text-xs;
+	}
+
+	.rui-avatar--md {
+		@apply size-10 text-sm;
+	}
+
+	.rui-avatar--lg {
+		@apply size-12 text-body;
+	}
+
+	.rui-avatar__image {
+		@apply size-full object-cover;
+	}
+
+	.rui-avatar__fallback {
+		@apply flex size-full items-center justify-center uppercase;
+	}
+}

--- a/packages/radiant-ui/src/components/ui/avatar/avatar.stories.tsx
+++ b/packages/radiant-ui/src/components/ui/avatar/avatar.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from '@ecopages/storybook-radiant-vite';
+import { RuiAvatar } from './avatar';
+
+const meta = {
+	title: 'Components/Avatar',
+	component: RuiAvatar,
+} satisfies Meta<typeof RuiAvatar>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Initials: Story = {
+	args: {
+		alt: 'Jane Doe',
+	},
+};
+
+export const Sizes: Story = {
+	render: () => (
+		<div class="flex items-center gap-inline">
+			<RuiAvatar size="sm" alt="Ada Lovelace" />
+			<RuiAvatar size="md" alt="Grace Hopper" />
+			<RuiAvatar size="lg" alt="Alan Turing" />
+		</div>
+	),
+};
+
+export const WithImage: Story = {
+	args: {
+		src: 'https://avatars.githubusercontent.com/u/9919?v=4',
+		alt: 'GitHub',
+	},
+};

--- a/packages/radiant-ui/src/components/ui/avatar/avatar.tsx
+++ b/packages/radiant-ui/src/components/ui/avatar/avatar.tsx
@@ -1,0 +1,49 @@
+import type { JsxHtmlPropsWithChildren } from '@ecopages/jsx';
+import { cx } from '@/lib/cx';
+import { attachRadiantStylesheets } from '@/lib/radiant-view';
+
+export type RuiAvatarSize = 'sm' | 'md' | 'lg';
+
+export type RuiAvatarProps = JsxHtmlPropsWithChildren<{
+	/** Image URL. When omitted or broken, initials from `alt` / `fallback` are shown. */
+	src?: string;
+	/** Accessible name for the image. Also used to derive initials when `fallback` is omitted. */
+	alt?: string;
+	/** Explicit fallback initials / text when there is no image. */
+	fallback?: string;
+	size?: RuiAvatarSize;
+}>;
+
+function initialsFrom(label: string): string {
+	const parts = label.trim().split(/\s+/).filter(Boolean);
+	if (parts.length === 0) return '?';
+	if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+	return `${parts[0][0] ?? ''}${parts[1][0] ?? ''}`.toUpperCase();
+}
+
+/** Image avatar with initials fallback. */
+export function RuiAvatar({
+	src,
+	alt = '',
+	fallback,
+	size = 'md',
+	class: className,
+	children,
+	...props
+}: RuiAvatarProps) {
+	const label = fallback ?? (alt ? initialsFrom(alt) : undefined);
+
+	return (
+		<span {...props} class={cx('rui-avatar', `rui-avatar--${size}`, className)} role={src ? undefined : 'img'} aria-label={src ? undefined : alt || fallback}>
+			{src ? (
+				<img class="rui-avatar__image" src={src} alt={alt} />
+			) : (
+				<span class="rui-avatar__fallback" aria-hidden={alt || fallback ? 'true' : undefined}>
+					{children ?? label ?? '?'}
+				</span>
+			)}
+		</span>
+	);
+}
+
+attachRadiantStylesheets(RuiAvatar, ['./avatar.css'], import.meta.url);

--- a/packages/radiant-ui/src/components/ui/avatar/index.ts
+++ b/packages/radiant-ui/src/components/ui/avatar/index.ts
@@ -1,0 +1,1 @@
+export { RuiAvatar, type RuiAvatarProps, type RuiAvatarSize } from './avatar';

--- a/packages/radiant-ui/src/index.ts
+++ b/packages/radiant-ui/src/index.ts
@@ -5,6 +5,7 @@
 export { cx } from './lib/cx';
 export * from './components/ui/alert';
 export * from './components/ui/autocomplete';
+export * from './components/ui/avatar';
 export * from './components/ui/breadcrumb';
 export * from './components/ui/button';
 export * from './components/ui/calendar';

--- a/packages/radiant-ui/src/styles/styles.css
+++ b/packages/radiant-ui/src/styles/styles.css
@@ -5,6 +5,7 @@
 @import './components/button.css';
 @import '../components/ui/alert/alert.css';
 @import '../components/ui/autocomplete/autocomplete.css';
+@import '../components/ui/avatar/avatar.css';
 @import '../components/ui/breadcrumb/breadcrumb.css';
 @import '../components/ui/calendar/calendar.css';
 @import '../components/ui/carousel/carousel.css';


### PR DESCRIPTION
## Summary
- Add `RuiAvatar` with image and initials fallback

## Test plan
- [ ] Storybook: Avatar stories render all sizes
- [ ] Import from `@ecopages/radiant-ui/avatar`