### PR TITLE
feat(radiant-ui): add chip component

### DIFF
--- a/packages/radiant-ui/package.json
+++ b/packages/radiant-ui/package.json
@@ -212,6 +212,13 @@
     "./checkbox/styles.css": {
       "default": "./dist/components/ui/checkbox/checkbox.css"
     },
+    "./chip": {
+      "types": "./dist/components/ui/chip/index.d.ts",
+      "import": "./dist/components/ui/chip/index.js"
+    },
+    "./chip/styles.css": {
+      "default": "./dist/components/ui/chip/chip.css"
+    },
     "./combobox": {
       "types": "./dist/components/ui/combobox/index.d.ts",
       "import": "./dist/components/ui/combobox/index.js"

--- a/packages/radiant-ui/src/Introduction.mdx
+++ b/packages/radiant-ui/src/Introduction.mdx
@@ -28,7 +28,7 @@ Not every entry under **Components/** is a full APG widget. Read the component T
       <td>Thin styling / wiring around platform controls</td>
       <td>
         <code>RuiButton</code>, <code>RuiInput</code>, <code>RuiTextarea</code>, Switch, Checkbox, Slider (single + range), Meter, Radio Group,
-        <code>RuiHeading</code>, <code>RuiHeadline</code>, <code>RuiAvatar</code>, <code>RuiButtonGroup</code>
+        <code>RuiHeading</code>, <code>RuiHeadline</code>, <code>RuiAvatar</code>, <code>RuiChip</code>, <code>RuiButtonGroup</code>
       </td>
     </tr>
     <tr>
@@ -107,7 +107,7 @@ import '@ecopages/radiant-ui/styles.css';
 import '@ecopages/radiant-ui';
 ```
 
-Presentational helpers that are not custom elements (today: `RuiButton`, `RuiInput`, `RuiTextarea`, `RuiLabel`, `RuiFieldDescription`, `RuiFieldError`, `RuiHeading`, `RuiHeadline`, `RuiAvatar`, `RuiButtonGroup`) are still imported from their subpath:
+Presentational helpers that are not custom elements (today: `RuiButton`, `RuiInput`, `RuiTextarea`, `RuiLabel`, `RuiFieldDescription`, `RuiFieldError`, `RuiHeading`, `RuiHeadline`, `RuiAvatar`, `RuiChip`, `RuiButtonGroup`) are still imported from their subpath:
 
 ```ts
 import { RuiButton } from '@ecopages/radiant-ui/button';

--- a/packages/radiant-ui/src/components/ui/chip/chip.css
+++ b/packages/radiant-ui/src/components/ui/chip/chip.css
@@ -1,0 +1,19 @@
+@reference '../../../styles/radiant-ui.css';
+
+@layer components {
+	.rui-chip {
+		@apply inline-flex items-center rounded-pill px-2 py-0.5 font-medium text-xs;
+	}
+
+	.rui-chip--default {
+		@apply border border-border bg-surface-container-low text-on-surface;
+	}
+
+	.rui-chip--muted {
+		@apply bg-surface-container text-on-surface;
+	}
+
+	.rui-chip--primary {
+		@apply bg-primary-container text-on-primary-container;
+	}
+}

--- a/packages/radiant-ui/src/components/ui/chip/chip.stories.tsx
+++ b/packages/radiant-ui/src/components/ui/chip/chip.stories.tsx
@@ -1,0 +1,25 @@
+import type { Meta, StoryObj } from '@ecopages/storybook-radiant-vite';
+import { RuiChip } from './chip';
+
+const meta = {
+	title: 'Components/Chip',
+	component: RuiChip,
+	args: {
+		children: 'Mexican',
+	},
+} satisfies Meta<typeof RuiChip>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Variants: Story = {
+	render: () => (
+		<div class="flex flex-wrap gap-inline">
+			<RuiChip>Default</RuiChip>
+			<RuiChip variant="muted">Muted</RuiChip>
+			<RuiChip variant="primary">Primary</RuiChip>
+		</div>
+	),
+};

--- a/packages/radiant-ui/src/components/ui/chip/chip.tsx
+++ b/packages/radiant-ui/src/components/ui/chip/chip.tsx
@@ -1,0 +1,24 @@
+import type { JsxHtmlPropsWithChildren } from '@ecopages/jsx';
+import { cx } from '@/lib/cx';
+import { attachRadiantStylesheets } from '@/lib/radiant-view';
+
+export type RuiChipVariant = 'default' | 'muted' | 'primary';
+
+export type RuiChipProps = JsxHtmlPropsWithChildren<{
+	variant?: RuiChipVariant;
+}>;
+
+/**
+ * Presentational category chip.
+ *
+ * @remarks For removable / selectable tags use `RuiTagGroup` instead.
+ */
+export function RuiChip({ children, variant = 'default', class: className, ...props }: RuiChipProps) {
+	return (
+		<span {...props} class={cx('rui-chip', `rui-chip--${variant}`, className)}>
+			{children}
+		</span>
+	);
+}
+
+attachRadiantStylesheets(RuiChip, ['./chip.css'], import.meta.url);

--- a/packages/radiant-ui/src/components/ui/chip/index.ts
+++ b/packages/radiant-ui/src/components/ui/chip/index.ts
@@ -1,0 +1,1 @@
+export { RuiChip, type RuiChipProps, type RuiChipVariant } from './chip';

--- a/packages/radiant-ui/src/index.ts
+++ b/packages/radiant-ui/src/index.ts
@@ -12,6 +12,7 @@ export * from './components/ui/button-group';
 export * from './components/ui/calendar';
 export * from './components/ui/carousel';
 export * from './components/ui/checkbox';
+export * from './components/ui/chip';
 export * from './components/ui/combobox';
 export * from './components/ui/date-field';
 export * from './components/ui/date-range-picker';

--- a/packages/radiant-ui/src/styles/styles.css
+++ b/packages/radiant-ui/src/styles/styles.css
@@ -11,6 +11,7 @@
 @import '../components/ui/calendar/calendar.css';
 @import '../components/ui/carousel/carousel.css';
 @import '../components/ui/checkbox/checkbox.css';
+@import '../components/ui/chip/chip.css';
 @import '../components/ui/combobox/combobox.css';
 @import '../components/ui/date-field/date-field.css';
 @import '../components/ui/date-range-picker/date-range-picker.css';


### PR DESCRIPTION
## Summary
- Add presentational `RuiChip` with default, muted, and primary variants

## Test plan
- [ ] Storybook: Chip stories render all variants
- [ ] Import from `@ecopages/radiant-ui/chip`