### PR TITLE
feat(radiant-ui): add chip-list component

### DIFF
--- a/packages/radiant-ui/package.json
+++ b/packages/radiant-ui/package.json
@@ -219,6 +219,13 @@
     "./chip/styles.css": {
       "default": "./dist/components/ui/chip/chip.css"
     },
+    "./chip-list": {
+      "types": "./dist/components/ui/chip-list/index.d.ts",
+      "import": "./dist/components/ui/chip-list/index.js"
+    },
+    "./chip-list/styles.css": {
+      "default": "./dist/components/ui/chip-list/chip-list.css"
+    },
     "./combobox": {
       "types": "./dist/components/ui/combobox/index.d.ts",
       "import": "./dist/components/ui/combobox/index.js"

--- a/packages/radiant-ui/src/Introduction.mdx
+++ b/packages/radiant-ui/src/Introduction.mdx
@@ -107,7 +107,7 @@ import '@ecopages/radiant-ui/styles.css';
 import '@ecopages/radiant-ui';
 ```
 
-Presentational helpers that are not custom elements (today: `RuiButton`, `RuiInput`, `RuiTextarea`, `RuiLabel`, `RuiFieldDescription`, `RuiFieldError`, `RuiHeading`, `RuiHeadline`, `RuiAvatar`, `RuiChip`, `RuiButtonGroup`) are still imported from their subpath:
+Presentational helpers that are not custom elements (today: `RuiButton`, `RuiInput`, `RuiTextarea`, `RuiLabel`, `RuiFieldDescription`, `RuiFieldError`, `RuiHeading`, `RuiHeadline`, `RuiAvatar`, `RuiChip`, `RuiChipList`, `RuiButtonGroup`) are still imported from their subpath:
 
 ```ts
 import { RuiButton } from '@ecopages/radiant-ui/button';

--- a/packages/radiant-ui/src/components/ui/chip-list/chip-list.css
+++ b/packages/radiant-ui/src/components/ui/chip-list/chip-list.css
@@ -1,0 +1,11 @@
+@reference '../../../styles/radiant-ui.css';
+
+@layer components {
+	.rui-chip-list {
+		@apply m-0 flex list-none flex-wrap gap-inline p-0;
+	}
+
+	.rui-chip-list__item {
+		@apply m-0 p-0;
+	}
+}

--- a/packages/radiant-ui/src/components/ui/chip-list/chip-list.stories.tsx
+++ b/packages/radiant-ui/src/components/ui/chip-list/chip-list.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from '@ecopages/storybook-radiant-vite';
+import { RuiChip } from '../chip/chip';
+import { RuiChipList, RuiChipListItem } from './chip-list';
+
+const meta = {
+	title: 'Components/Chip list',
+	component: RuiChipList,
+} satisfies Meta<typeof RuiChipList>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+	render: () => (
+		<RuiChipList aria-label="Cuisine">
+			<RuiChipListItem>
+				<RuiChip>Mexican</RuiChip>
+			</RuiChipListItem>
+			<RuiChipListItem>
+				<RuiChip>Tacos</RuiChip>
+			</RuiChipListItem>
+			<RuiChipListItem>
+				<RuiChip variant="muted">San Dimas</RuiChip>
+			</RuiChipListItem>
+		</RuiChipList>
+	),
+};

--- a/packages/radiant-ui/src/components/ui/chip-list/chip-list.tsx
+++ b/packages/radiant-ui/src/components/ui/chip-list/chip-list.tsx
@@ -1,0 +1,30 @@
+import type { JsxHtmlPropsWithChildren } from '@ecopages/jsx';
+import { cx } from '@/lib/cx';
+import { attachRadiantStylesheets } from '@/lib/radiant-view';
+
+export type RuiChipListProps = JsxHtmlPropsWithChildren<{
+	'aria-label'?: string;
+	id?: string;
+}>;
+
+/** Horizontal wrap list for presentational chips. */
+export function RuiChipList({ children, class: className, 'aria-label': ariaLabel, ...props }: RuiChipListProps) {
+	return (
+		<ul {...props} class={cx('rui-chip-list', className)} aria-label={ariaLabel}>
+			{children}
+		</ul>
+	);
+}
+
+export type RuiChipListItemProps = JsxHtmlPropsWithChildren;
+
+/** List item wrapper for a chip. */
+export function RuiChipListItem({ children, class: className, ...props }: RuiChipListItemProps) {
+	return (
+		<li {...props} class={cx('rui-chip-list__item', className)}>
+			{children}
+		</li>
+	);
+}
+
+attachRadiantStylesheets(RuiChipList, ['./chip-list.css'], import.meta.url);

--- a/packages/radiant-ui/src/components/ui/chip-list/index.ts
+++ b/packages/radiant-ui/src/components/ui/chip-list/index.ts
@@ -1,0 +1,1 @@
+export { RuiChipList, RuiChipListItem, type RuiChipListItemProps, type RuiChipListProps } from './chip-list';

--- a/packages/radiant-ui/src/index.ts
+++ b/packages/radiant-ui/src/index.ts
@@ -13,6 +13,7 @@ export * from './components/ui/calendar';
 export * from './components/ui/carousel';
 export * from './components/ui/checkbox';
 export * from './components/ui/chip';
+export * from './components/ui/chip-list';
 export * from './components/ui/combobox';
 export * from './components/ui/date-field';
 export * from './components/ui/date-range-picker';

--- a/packages/radiant-ui/src/styles/styles.css
+++ b/packages/radiant-ui/src/styles/styles.css
@@ -12,6 +12,7 @@
 @import '../components/ui/carousel/carousel.css';
 @import '../components/ui/checkbox/checkbox.css';
 @import '../components/ui/chip/chip.css';
+@import '../components/ui/chip-list/chip-list.css';
 @import '../components/ui/combobox/combobox.css';
 @import '../components/ui/date-field/date-field.css';
 @import '../components/ui/date-range-picker/date-range-picker.css';


### PR DESCRIPTION
## Summary
- Add `RuiChipList` and `RuiChipListItem` for grouping presentational chips

## Test plan
- [ ] Storybook: ChipList story composes with Chip
- [ ] Import from `@ecopages/radiant-ui/chip-list`