### PR TITLE
chore(release): publish 0.3.0-beta.6 and radiant-ui 0.1.0-beta.5

### DIFF
--- a/.changeset/number-field-components.md
+++ b/.changeset/number-field-components.md
@@ -1,5 +1,0 @@
----
-'@ecopages/radiant-ui': minor
----
-
-Add calendar, date, number, popover, select, autocomplete, and tag-group components. `RuiNumberField` is the only number-entry component; use its `minValue` and `maxValue` props.

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,13 +1,18 @@
 {
-	"mode": "pre",
-	"tag": "beta",
-	"initialVersions": {
-		"@ecopages/jsx": "0.3.0-beta.3",
-		"@ecopages/radiant": "0.3.0-beta.3",
-		"@ecopages/signals": "0.3.0-beta.3",
-		"@ecopages/vite-plugin-radiant": "0.0.0",
-		"@ecopages/storybook-radiant-vite": "0.1.0-beta.0",
-		"@ecopages/radiant-ui": "0.1.0-beta.0"
-	},
-	"changesets": ["drop-floating-ui-native-positioning", "next-beta-release"]
+  "mode": "pre",
+  "tag": "beta",
+  "initialVersions": {
+    "@ecopages/jsx": "0.3.0-beta.3",
+    "@ecopages/radiant": "0.3.0-beta.3",
+    "@ecopages/signals": "0.3.0-beta.3",
+    "@ecopages/vite-plugin-radiant": "0.0.0",
+    "@ecopages/storybook-radiant-vite": "0.1.0-beta.0",
+    "@ecopages/radiant-ui": "0.1.0-beta.0"
+  },
+  "changesets": [
+    "content-building-blocks",
+    "drop-floating-ui-native-positioning",
+    "next-beta-release",
+    "number-field-components"
+  ]
 }

--- a/packages/jsx/CHANGELOG.md
+++ b/packages/jsx/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @ecopages/jsx
 
+## 0.3.0-beta.6
+
+### Patch Changes
+
+- Prepare the next beta release.
+
+- Updated dependencies []:
+    - @ecopages/signals@0.3.0-beta.6
+
 ## 0.3.0-beta.5
 
 ### Patch Changes

--- a/packages/jsx/package.json
+++ b/packages/jsx/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ecopages/jsx",
-	"version": "0.3.0-beta.5",
+	"version": "0.3.0-beta.6",
 	"license": "MIT",
 	"main": "dist/index.js",
 	"module": "dist/index.js",
@@ -71,6 +71,6 @@
 		"typescript": "catalog:"
 	},
 	"peerDependencies": {
-		"@ecopages/signals": ">=0.3.0-beta.5"
+		"@ecopages/signals": ">=0.3.0-beta.6"
 	}
 }

--- a/packages/radiant-ui/CHANGELOG.md
+++ b/packages/radiant-ui/CHANGELOG.md
@@ -1,5 +1,29 @@
 # @ecopages/radiant-ui
 
+## 0.1.0-beta.5
+
+### Minor Changes
+
+- Add composable presentational building blocks and refactor Feed to a compound API.
+
+    **@ecopages/radiant-ui**
+
+    - Add `RuiHeadline`, `RuiHeading`, `RuiAvatar`, `RuiButtonGroup`, `RuiChip`, and `RuiChipList`.
+    - Refactor `RuiFeed` to a presentational compound component and remove the `rui-feed` custom element.
+
+### Patch Changes
+
+- Updated dependencies []:
+    - @ecopages/radiant@0.3.0-beta.6
+    - @ecopages/signals@0.3.0-beta.6
+    - @ecopages/jsx@0.3.0-beta.6
+
+## 0.1.0-beta.4
+
+### Minor Changes
+
+- [#105](https://github.com/ecopages/radiant/pull/105) [`99c22cf`](https://github.com/ecopages/radiant/commit/99c22cf843d2363ffc9e81b86c6da1595b3e67cd) Thanks [@andeeplus](https://github.com/andeeplus)! - Add calendar, date, number, popover, select, autocomplete, and tag-group components. `RuiNumberField` is the only number-entry component; use its `minValue` and `maxValue` props.
+
 ## 0.1.0-beta.3
 
 ### Patch Changes

--- a/packages/radiant-ui/package.json
+++ b/packages/radiant-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ecopages/radiant-ui",
-  "version": "0.1.0-beta.3",
+  "version": "0.1.0-beta.5",
   "description": "Accessible light-DOM UI components built with @ecopages/radiant, documented in Storybook",
   "license": "MIT",
   "type": "module",
@@ -32,9 +32,9 @@
     "typecheck": "tsc --noEmit -p tsconfig.app.json"
   },
   "peerDependencies": {
-    "@ecopages/jsx": ">=0.3.0-beta.5",
-    "@ecopages/radiant": ">=0.3.0-beta.5",
-    "@ecopages/signals": ">=0.3.0-beta.5"
+    "@ecopages/jsx": ">=0.3.0-beta.6",
+    "@ecopages/radiant": ">=0.3.0-beta.6",
+    "@ecopages/signals": ">=0.3.0-beta.6"
   },
   "devDependencies": {
     "@babel/core": "^7.28.0",

--- a/packages/radiant/CHANGELOG.md
+++ b/packages/radiant/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @ecopages/radiant
 
+## 0.3.0-beta.6
+
+### Patch Changes
+
+- Prepare the next beta release.
+
+- Updated dependencies []:
+    - @ecopages/signals@0.3.0-beta.6
+    - @ecopages/jsx@0.3.0-beta.6
+
 ## 0.3.0-beta.5
 
 ### Patch Changes

--- a/packages/radiant/package.json
+++ b/packages/radiant/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ecopages/radiant",
-	"version": "0.3.0-beta.5",
+	"version": "0.3.0-beta.6",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/ecopages/radiant.git"
@@ -29,7 +29,7 @@
 		"test:lib:coverage": "vitest run --coverage --project node && vitest run --coverage --project node -- --legacy"
 	},
 	"dependencies": {
-		"@ecopages/signals": ">=0.3.0-beta.5"
+		"@ecopages/signals": ">=0.3.0-beta.6"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.28.0",
@@ -55,7 +55,7 @@
 		"vitest": "^4.1.10"
 	},
 	"peerDependencies": {
-		"@ecopages/jsx": ">=0.3.0-beta.5"
+		"@ecopages/jsx": ">=0.3.0-beta.6"
 	},
 	"files": [
 		"dist/**"

--- a/packages/signals/CHANGELOG.md
+++ b/packages/signals/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ecopages/signals
 
+## 0.3.0-beta.6
+
+### Patch Changes
+
+- Prepare the next beta release.
+
 ## 0.3.0-beta.5
 
 ### Patch Changes

--- a/packages/signals/package.json
+++ b/packages/signals/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@ecopages/signals",
-	"version": "0.3.0-beta.5",
+	"version": "0.3.0-beta.6",
 	"description": "Renderer-agnostic signal primitives based on the TC39 Signals proposal",
 	"repository": {
 		"type": "git",

--- a/packages/storybook-radiant-vite/package.json
+++ b/packages/storybook-radiant-vite/package.json
@@ -69,9 +69,9 @@
 		"vitest": "^4.1.10"
 	},
 	"peerDependencies": {
-		"@ecopages/jsx": ">=0.3.0-beta.5",
-		"@ecopages/radiant": ">=0.3.0-beta.5",
-		"@ecopages/signals": ">=0.3.0-beta.5",
+		"@ecopages/jsx": ">=0.3.0-beta.6",
+		"@ecopages/radiant": ">=0.3.0-beta.6",
+		"@ecopages/signals": ">=0.3.0-beta.6",
 		"storybook": "^10.5.2",
 		"vite": "^8.0.0"
 	},

--- a/packages/vite-plugin-radiant/package.json
+++ b/packages/vite-plugin-radiant/package.json
@@ -90,9 +90,9 @@
 		"@babel/plugin-proposal-decorators": "^7.0.0",
 		"@babel/plugin-syntax-typescript": "^7.0.0",
 		"@babel/plugin-transform-class-properties": "^7.0.0",
-		"@ecopages/jsx": ">=0.3.0-beta.5",
-		"@ecopages/radiant": ">=0.3.0-beta.5",
-		"@ecopages/signals": ">=0.3.0-beta.5",
+		"@ecopages/jsx": ">=0.3.0-beta.6",
+		"@ecopages/radiant": ">=0.3.0-beta.6",
+		"@ecopages/signals": ">=0.3.0-beta.6",
 		"@rolldown/plugin-babel": "^0.2.0",
 		"nitro": "^3.0.260311-beta",
 		"vite": "^8.0.0"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,6 +11,6 @@ allowBuilds:
     '@swc/core': true
 
 minimumReleaseAgeExclude:
-    - '@ecopages/jsx@0.3.0-beta.5'
-    - '@ecopages/radiant@0.3.0-beta.5'
-    - '@ecopages/signals@0.3.0-beta.5'
+    - '@ecopages/jsx@0.3.0-beta.6'
+    - '@ecopages/radiant@0.3.0-beta.6'
+    - '@ecopages/signals@0.3.0-beta.6'


### PR DESCRIPTION
## Summary
- Bump `@ecopages/jsx`, `@ecopages/signals`, and `@ecopages/radiant` to `0.3.0-beta.6`
- Bump `@ecopages/radiant-ui` to `0.1.0-beta.5` with composable building blocks and Feed compound refactor

## Test plan
- [ ] `pnpm run build:all`
- [ ] `pnpm exec changeset publish --tag beta`