### PR TITLE
perf(jsx): count hydration nodes structurally instead of building the subtree

### DIFF
--- a/packages/jsx/src/dom-render/hydration-iterable.ts
+++ b/packages/jsx/src/dom-render/hydration-iterable.ts
@@ -39,7 +39,7 @@ export function hydrateIterableRoot(
 	let nextBindingIndex = 0;
 
 	for (const child of jsxChildren) {
-		const nodeCount = countHydratedRangeNodes(child, target);
+		const nodeCount = countHydratedRangeNodes(child);
 		const slice = domChildren.slice(domOffset, domOffset + nodeCount);
 
 		if (slice.length !== nodeCount) {

--- a/packages/jsx/src/dom-render/hydration-mounted-range.ts
+++ b/packages/jsx/src/dom-render/hydration-mounted-range.ts
@@ -216,7 +216,7 @@ function hydrateIndexedRangeContent(
 	let nextNodeIndex = 0;
 
 	for (const child of children) {
-		const childNodeCount = countHydratedRangeNodes(child, endMarker.parentNode);
+		const childNodeCount = countHydratedRangeNodes(child);
 		const childNodes = existingNodes.slice(nextNodeIndex, nextNodeIndex + childNodeCount);
 
 		if (childNodes.length !== childNodeCount) {
@@ -249,7 +249,7 @@ function hydrateKeyedRangeContent(
 	let nextNodeIndex = 0;
 
 	for (const child of children) {
-		const childNodeCount = countHydratedRangeNodes(child.value, endMarker.parentNode);
+		const childNodeCount = countHydratedRangeNodes(child.value);
 		const childNodes = existingNodes.slice(nextNodeIndex, nextNodeIndex + childNodeCount);
 
 		if (childNodes.length !== childNodeCount) {

--- a/packages/jsx/src/dom-render/hydration-planning.ts
+++ b/packages/jsx/src/dom-render/hydration-planning.ts
@@ -1,11 +1,12 @@
-import { clearDelegationRoot } from './event-delegation.ts';
+import { createNodesFromJsxNodeLike } from './dom-operations.ts';
 import { getNodeAtPath, getPathKey } from './path-utils.ts';
-import { createTemplateInstance } from './template-instance.ts';
+import { getCompiledTemplate } from './template-compiler.ts';
 import {
 	canRenderAsTextNode,
-	createNodesFromValue,
-	isReactiveChildSource,
-	readReactiveChildSourceValue,
+	isIterableRenderable,
+	isJsxNodeLike,
+	isTemplateResultLike,
+	resolveReactiveSnapshot,
 	unwrapKeyedValue,
 } from './runtime-helpers.ts';
 import { CHILD_BINDING_END_PREFIX, CHILD_BINDING_START_PREFIX } from './constants.ts';
@@ -63,7 +64,7 @@ export function collectHydratedChildRanges(
 				continue;
 			}
 
-			const nodeCount = countHydratedRangeNodes(values[part.index], parentNode);
+			const nodeCount = countHydratedRangeNodes(values[part.index]);
 			ranges.set(part.index, {
 				actualStartIndex: actualIndex,
 				blueprintStartIndex: part.startPath[part.startPath.length - 1] ?? 0,
@@ -129,12 +130,48 @@ export function isolateHydratedTextRange(
 	}
 }
 
-/** Counts DOM nodes `value` would produce when mounted, for hydration slice planning. */
-export function countHydratedRangeNodes(value: unknown, contextParent: Node | null): number {
-	const rootTarget = document.createElement('div');
-	const nodes = createNodesFromValue(value, rootTarget, [], createTemplateInstance, contextParent);
-	clearDelegationRoot(rootTarget);
-	return nodes.length;
+/**
+ * Counts the DOM nodes `value` produces when mounted, for hydration slice planning.
+ *
+ * This is a pure structural measurement: it never builds the subtree it measures.
+ * Node count is a static property of the value's shape, so each variant is counted
+ * from metadata that is already cached (template blueprints) or trivially derived.
+ *
+ * Reactive sources are resolved to their current snapshot because the SSR serializer
+ * resolves them too, so the counted shape matches the emitted HTML.
+ */
+export function countHydratedRangeNodes(value: unknown): number {
+	const resolvedValue = resolveReactiveSnapshot(unwrapKeyedValue(value));
+
+	if (resolvedValue == null || typeof resolvedValue === 'boolean') {
+		return 0;
+	}
+
+	if (isTemplateResultLike(resolvedValue)) {
+		return getCompiledTemplate(resolvedValue).blueprint.content.childNodes.length;
+	}
+
+	if (resolvedValue instanceof Node) {
+		return 1;
+	}
+
+	// Markup stand-ins carry arbitrary HTML, so their node count is only knowable by
+	// parsing. This stays cheap: no template instances, listeners, or subscriptions.
+	if (isJsxNodeLike(resolvedValue)) {
+		return createNodesFromJsxNodeLike(resolvedValue).length;
+	}
+
+	if (isIterableRenderable(resolvedValue)) {
+		let total = 0;
+
+		for (const child of resolvedValue) {
+			total += countHydratedRangeNodes(child);
+		}
+
+		return total;
+	}
+
+	return 1;
 }
 
 function getHydratedNodeContribution(node: Node | undefined): number {
@@ -149,6 +186,5 @@ function getHydratedNodeContribution(node: Node | undefined): number {
 }
 
 function resolveHydratedRangeValue(value: unknown): unknown {
-	const nextValue = unwrapKeyedValue(value);
-	return isReactiveChildSource(nextValue) ? unwrapKeyedValue(readReactiveChildSourceValue(nextValue)) : nextValue;
+	return unwrapKeyedValue(resolveReactiveSnapshot(unwrapKeyedValue(value)));
 }

--- a/packages/jsx/src/dom-render/hydration.ts
+++ b/packages/jsx/src/dom-render/hydration.ts
@@ -61,7 +61,7 @@ export function hydrateTemplateInstance(
 		return undefined;
 	}
 
-	const nodeCount = countHydratedRangeNodes(template, target);
+	const nodeCount = countHydratedRangeNodes(template);
 	const instance: TemplateInstance = {
 		compiled: compiledTemplate,
 		parts,

--- a/packages/jsx/test/dom-render-reconciliation.e2e.test.tsx
+++ b/packages/jsx/test/dom-render-reconciliation.e2e.test.tsx
@@ -1018,6 +1018,45 @@ describe('Radiant JSX DOM reconciliation behavior', () => {
 		expect(container.querySelector('p')?.textContent).toBe('Count: 16');
 	});
 
+	test('hydration subscribes exactly once per reactive child and leaves nothing behind on unmount', async () => {
+		const [{ createSubscribableJsxValue, jsxs }, { createRoot }] = await Promise.all([
+			loadJsxRuntime(),
+			loadJsxModule(),
+		]);
+		const container = document.createElement('div');
+		const root = createRoot(container);
+		const subscribers = new Set<(value: number) => void>();
+		let subscribeCalls = 0;
+		let count = 15;
+		const boundCount = createSubscribableJsxValue({
+			getValue: () => count,
+			subscribe: (notify) => {
+				subscribeCalls += 1;
+				subscribers.add(notify);
+				return () => {
+					subscribers.delete(notify);
+				};
+			},
+		});
+
+		container.innerHTML = HYDRATE_METRIC_HTML;
+		root.hydrate(
+			jsxs('p', {
+				class: 'component-metric',
+				children: ['Count: ', boundCount],
+			}),
+		);
+
+		// Hydration planning must never mount the subtree it is measuring: one live
+		// binding means exactly one subscription, with no detached extras retained.
+		expect(subscribeCalls).toBe(1);
+		expect(subscribers.size).toBe(1);
+
+		root.unmount();
+
+		expect(subscribers.size).toBe(0);
+	});
+
 	test('hydrated fragment subscribable child values patch without rerendering the parent tree', async () => {
 		const [{ createSubscribableJsxValue, Fragment, jsx, jsxs }, { createRoot }] = await Promise.all([
 			loadJsxRuntime(),


### PR DESCRIPTION
countHydratedRangeNodes materialized the entire subtree it was measuring —
cloning template blueprints, creating live parts, and running instance.update
— then discarded all of it to read nodes.length. It is called per child from
four sites, so hydrating a nested list built the whole tree once per nesting
level on top of walking the SSR DOM.

That mount was also not side-effect free: instance.update reaches
mountReactiveChildSource, which subscribes to every signal in the measured
subtree. clearDelegationRoot removed delegated listeners but never touched
those subscriptions, and the returned MountedSubscription was discarded, so
each measured reactive child leaked a live subscription writing into a
detached <div>.

Node count is a static property of a value's shape, so it is now derived from
metadata that already exists: cached blueprints for templates, recursion for
iterables, and a constant for text and nodes. Only markup stand-ins still
parse, since arbitrary HTML has no precomputable count — and that path creates
no instances, listeners, or subscriptions.

Reactive sources are now resolved for both SubscribableJsxValue and SignalLike.
Previously a bare signal fell through to a single stringified text node, which
disagreed with the SSR serializer (it resolves both) and with updateRangeContent
(it mounts both), so counts could be wrong for signal children.

The contextParent argument is gone: it only fed namespace normalization, which
cannot change node count.

Adds a regression test asserting one subscription per reactive child during
hydration and none retained after unmount. It fails with 2 subscriptions
against the previous implementation.
