### PR TITLE
refactor(jsx): collapse the three hydration paths into one dispatch

### DIFF
--- a/packages/jsx/src/dom-render.ts
+++ b/packages/jsx/src/dom-render.ts
@@ -1,13 +1,7 @@
-import {
-	HYDRATION_INVALID_BINDING_INDEX_WARNING,
-	HYDRATION_MALFORMED_BINDING_DESCRIPTOR_WARNING,
-	HYDRATION_MISSING_BINDING_WARNING,
-	warnRuntime,
-} from './warnings/dev-warnings.ts';
 import { captureFocusSnapshot, restoreFocusSnapshot } from './dom-render/focus-snapshot.ts';
+import { hydrateFlatBindings } from './dom-render/hydration-flat.ts';
 import { hydrateIterableRoot } from './dom-render/hydration-iterable.ts';
 import { hydrateTemplateInstance } from './dom-render/hydration.ts';
-import { applyBindingToElement } from './dom-render/bindings.ts';
 import { disposeMountedRoot } from './dom-render/mounted-disposal.ts';
 import {
 	createNodesFromValue,
@@ -17,15 +11,11 @@ import {
 } from './dom-render/runtime-helpers.ts';
 import { getCompiledTemplate } from './dom-render/template-compiler.ts';
 import { createTemplateInstance } from './dom-render/template-instance.ts';
-import type { DeferredPropertyBinding, MountedRoot, TemplateInstance } from './dom-render/types.ts';
-import {
-	ATTRIBUTE_BINDING_PREFIX,
-	collectHydrationBindings,
-	parseBindingDescriptor,
-	visitHydrationBindingMarkers,
-} from './hydration/hydration-bindings.ts';
+import type { DeferredPropertyBinding, MountedRoot } from './dom-render/types.ts';
+import { visitHydrationBindingMarkers } from './hydration/hydration-bindings.ts';
 import { isIterableRenderable } from './types/renderable-guards.ts';
-import type { JsxRenderable, TemplateResultLike } from './types/index.ts';
+import type { JsxRenderable } from './types/index.ts';
+
 /**
  * Per-root render state used to decide whether a subsequent render can update
  * an existing template instance in place or must dispose and remount.
@@ -45,47 +35,10 @@ export interface JsxRoot {
 	unmount: () => void;
 }
 
-type TemplateHydrationOutcome =
-	| {
-			deferredProperties: DeferredPropertyBinding[];
-			focusSnapshot: ReturnType<typeof captureFocusSnapshot>;
-			instance: TemplateInstance;
-			kind: 'safe-reconnect';
-	  }
-	| {
-			kind: 'recoverable-mismatch';
-	  }
-	| {
-			kind: 'full-rerender';
-	  };
-
-type FlatHydrationOutcome =
-	| {
-			deferredProperties: DeferredPropertyBinding[];
-			focusSnapshot: ReturnType<typeof captureFocusSnapshot>;
-			kind: 'safe-reconnect';
-	  }
-	| {
-			kind: 'full-rerender';
-	  };
-
-type IterableHydrationOutcome =
-	| {
-			deferredProperties: DeferredPropertyBinding[];
-			focusSnapshot: ReturnType<typeof captureFocusSnapshot>;
-			kind: 'safe-reconnect';
-	  }
-	| {
-			kind: 'recoverable-mismatch';
-	  }
-	| {
-			kind: 'full-rerender';
-	  };
-
 /**
  * Renders a JSX value into a target element.
  *
- * Template results now keep a live instance when the template shape is stable,
+ * Template results keep a live instance when the template shape is stable,
  * allowing repeated renders to patch existing parts instead of replacing the
  * whole subtree.
  */
@@ -117,7 +70,7 @@ export function render(element: JsxRenderable, target: HTMLElement): void {
 		target.replaceChildren(
 			...createNodesFromValue(nextValue, target, deferredProperties, createTemplateInstance, target),
 		);
-		ROOT_RENDER_STATE.set(target, { kind: 'value' });
+		ROOT_RENDER_STATE.set(target, { kind: 'value', rootTarget: target });
 	}
 
 	flushDeferredProperties(deferredProperties);
@@ -127,6 +80,8 @@ export function render(element: JsxRenderable, target: HTMLElement): void {
 
 /**
  * Hydrates an SSR-rendered JSX subtree by attaching event and property bindings in place.
+ *
+ * Falls back to a full client render whenever the SSR DOM cannot be reconnected.
  */
 export function hydrate(element: JsxRenderable, target: HTMLElement): void {
 	const currentRenderState = ROOT_RENDER_STATE.get(target);
@@ -137,141 +92,57 @@ export function hydrate(element: JsxRenderable, target: HTMLElement): void {
 
 	ROOT_RENDER_STATE.delete(target);
 
-	const nextValue = unwrapKeyedValue(element);
+	const focusSnapshot = captureFocusSnapshot(target);
+	const deferredProperties: DeferredPropertyBinding[] = [];
+	const reconnectedRoot = reconnectSsrRoot(element, target, deferredProperties);
 
-	if (isTemplateResultLike(nextValue)) {
-		const outcome = attemptTemplateHydration(nextValue, target);
-
-		switch (outcome.kind) {
-			case 'full-rerender':
-			case 'recoverable-mismatch':
-				render(element, target);
-				return;
-
-			case 'safe-reconnect':
-				ROOT_RENDER_STATE.set(target, { instance: outcome.instance, kind: 'template' });
-				flushDeferredProperties(outcome.deferredProperties);
-				restoreFocusSnapshot(target, outcome.focusSnapshot);
-				return;
-		}
-	}
-
-	if (isIterableRenderable(nextValue)) {
-		const outcome = attemptIterableHydration(nextValue, target);
-
-		switch (outcome.kind) {
-			case 'full-rerender':
-			case 'recoverable-mismatch':
-				render(element, target);
-				return;
-
-			case 'safe-reconnect':
-				ROOT_RENDER_STATE.set(target, { kind: 'value' });
-				flushDeferredProperties(outcome.deferredProperties);
-				restoreFocusSnapshot(target, outcome.focusSnapshot);
-				return;
-		}
-	}
-
-	const outcome = attemptFlatHydration(element, target);
-
-	if (outcome.kind === 'full-rerender') {
+	if (!reconnectedRoot) {
 		render(element, target);
 		return;
 	}
 
-	flushDeferredProperties(outcome.deferredProperties);
-	restoreFocusSnapshot(target, outcome.focusSnapshot);
+	ROOT_RENDER_STATE.set(target, reconnectedRoot);
+	flushDeferredProperties(deferredProperties);
+	restoreFocusSnapshot(target, focusSnapshot);
 }
 
-function attemptTemplateHydration(template: TemplateResultLike, target: HTMLElement): TemplateHydrationOutcome {
-	if (!hasHydrationMarkers(target)) {
-		return { kind: 'full-rerender' };
+/**
+ * Reconnects SSR DOM for whichever root shape `element` describes.
+ *
+ * The three shapes — a single template result, an iterable of children, and the
+ * flat marker-walk fallback — differ only in how they locate bindings, so each
+ * reports the same way: a mounted root on success, `undefined` to fall back to a
+ * full client render.
+ *
+ * @returns The mounted root state, or `undefined` when the DOM cannot be recovered.
+ */
+function reconnectSsrRoot(
+	element: JsxRenderable,
+	target: HTMLElement,
+	deferredProperties: DeferredPropertyBinding[],
+): MountedRoot | undefined {
+	const nextValue = unwrapKeyedValue(element);
+
+	if (isTemplateResultLike(nextValue)) {
+		if (!hasHydrationMarkers(target)) {
+			return undefined;
+		}
+
+		const instance = hydrateTemplateInstance(nextValue, target, deferredProperties);
+		return instance ? { instance, kind: 'template' } : undefined;
 	}
 
-	const focusSnapshot = captureFocusSnapshot(target);
-	const deferredProperties: DeferredPropertyBinding[] = [];
-	const instance = hydrateTemplateInstance(template, target, deferredProperties);
+	if (isIterableRenderable(nextValue)) {
+		if (!hasHydrationMarkers(target)) {
+			return undefined;
+		}
 
-	if (!instance) {
-		return { kind: 'recoverable-mismatch' };
+		return hydrateIterableRoot(nextValue, target, deferredProperties, { rootTarget: target })
+			? { kind: 'value', rootTarget: target }
+			: undefined;
 	}
 
-	return {
-		deferredProperties,
-		focusSnapshot,
-		instance,
-		kind: 'safe-reconnect',
-	};
-}
-
-function attemptIterableHydration(value: Iterable<unknown>, target: HTMLElement): IterableHydrationOutcome {
-	if (!hasHydrationMarkers(target)) {
-		return { kind: 'full-rerender' };
-	}
-
-	const focusSnapshot = captureFocusSnapshot(target);
-	const deferredProperties: DeferredPropertyBinding[] = [];
-
-	if (!hydrateIterableRoot(value, target, deferredProperties, { rootTarget: target })) {
-		return { kind: 'recoverable-mismatch' };
-	}
-
-	return {
-		deferredProperties,
-		focusSnapshot,
-		kind: 'safe-reconnect',
-	};
-}
-
-function attemptFlatHydration(element: JsxRenderable, target: HTMLElement): FlatHydrationOutcome {
-	const focusSnapshot = captureFocusSnapshot(target);
-	const deferredProperties: DeferredPropertyBinding[] = [];
-	const bindings = collectHydrationBindings(element, { skipNestedCustomElementRoots: true });
-
-	if (
-		!visitHydrationBindingMarkers(target, (element, attribute) => {
-			const bindingIndex = Number(attribute.name.slice(ATTRIBUTE_BINDING_PREFIX.length));
-			const parsedBinding = parseBindingDescriptor(attribute.value);
-			element.removeAttribute(attribute.name);
-
-			if (Number.isNaN(bindingIndex)) {
-				warnRuntime(HYDRATION_INVALID_BINDING_INDEX_WARNING, attribute.name, {
-					code: `hydrate-invalid-binding-index:${attribute.name}`,
-				});
-				return;
-			}
-
-			if (!parsedBinding) {
-				warnRuntime(HYDRATION_MALFORMED_BINDING_DESCRIPTOR_WARNING, attribute.value, {
-					code: `hydrate-invalid-binding-descriptor:${attribute.value}`,
-				});
-				return;
-			}
-
-			const binding = bindings.get(bindingIndex);
-
-			if (!binding) {
-				warnRuntime(HYDRATION_MISSING_BINDING_WARNING, attribute.name, {
-					code: `hydrate-missing-binding:${bindingIndex}`,
-				});
-				return;
-			}
-
-			applyBindingToElement(element, parsedBinding, binding.value, {
-				rootTarget: target,
-				deferredProperties,
-			});
-		})
-	) {
-		return { kind: 'full-rerender' };
-	}
-
-	return {
-		deferredProperties,
-		focusSnapshot,
-		kind: 'safe-reconnect',
-	};
+	return hydrateFlatBindings(element, target, deferredProperties) ? { kind: 'value', rootTarget: target } : undefined;
 }
 
 /**

--- a/packages/jsx/src/dom-render/hydration-flat.ts
+++ b/packages/jsx/src/dom-render/hydration-flat.ts
@@ -1,0 +1,70 @@
+import {
+	HYDRATION_INVALID_BINDING_INDEX_WARNING,
+	HYDRATION_MALFORMED_BINDING_DESCRIPTOR_WARNING,
+	HYDRATION_MISSING_BINDING_WARNING,
+	warnRuntime,
+} from '../warnings/dev-warnings.ts';
+import {
+	ATTRIBUTE_BINDING_PREFIX,
+	collectHydrationBindings,
+	parseBindingDescriptor,
+	visitHydrationBindingMarkers,
+} from '../hydration/hydration-bindings.ts';
+import { applyBindingToElement } from './bindings.ts';
+import type { DeferredPropertyBinding } from './types.ts';
+import type { JsxRenderable } from '../types/index.ts';
+
+/**
+ * Reconnects SSR bindings by walking marker attributes directly, without
+ * reconstructing a template instance.
+ *
+ * This is the fallback root shape: it handles values that are neither a single
+ * template result nor an iterable, and it recovers bindings positionally from the
+ * marker indexes embedded during SSR.
+ *
+ * Markers that cannot be resolved are reported and skipped rather than failing the
+ * whole pass, because a single stale marker should not force a full client render.
+ *
+ * @returns `true` when the subtree carried hydration markers, `false` when a full render is needed.
+ */
+export function hydrateFlatBindings(
+	element: JsxRenderable,
+	target: HTMLElement,
+	deferredProperties: DeferredPropertyBinding[],
+): boolean {
+	const bindings = collectHydrationBindings(element, { skipNestedCustomElementRoots: true });
+
+	return visitHydrationBindingMarkers(target, (markerElement, attribute) => {
+		const bindingIndex = Number(attribute.name.slice(ATTRIBUTE_BINDING_PREFIX.length));
+		const parsedBinding = parseBindingDescriptor(attribute.value);
+		markerElement.removeAttribute(attribute.name);
+
+		if (Number.isNaN(bindingIndex)) {
+			warnRuntime(HYDRATION_INVALID_BINDING_INDEX_WARNING, attribute.name, {
+				code: `hydrate-invalid-binding-index:${attribute.name}`,
+			});
+			return;
+		}
+
+		if (!parsedBinding) {
+			warnRuntime(HYDRATION_MALFORMED_BINDING_DESCRIPTOR_WARNING, attribute.value, {
+				code: `hydrate-invalid-binding-descriptor:${attribute.value}`,
+			});
+			return;
+		}
+
+		const binding = bindings.get(bindingIndex);
+
+		if (!binding) {
+			warnRuntime(HYDRATION_MISSING_BINDING_WARNING, attribute.name, {
+				code: `hydrate-missing-binding:${bindingIndex}`,
+			});
+			return;
+		}
+
+		applyBindingToElement(markerElement, parsedBinding, binding.value, {
+			rootTarget: target,
+			deferredProperties,
+		});
+	});
+}

--- a/packages/jsx/src/dom-render/hydration-mounted-range.ts
+++ b/packages/jsx/src/dom-render/hydration-mounted-range.ts
@@ -1,4 +1,4 @@
-import type { KeyedJsxValue, TemplateResultLike } from '../types/index.ts';
+import type { JsxKey, TemplateResultLike } from '../types/index.ts';
 import { mountReactiveChildSource, updateRangeContent } from './child-range-update.ts';
 import { getNodeAtPath } from './path-utils.ts';
 import { countHydratedRangeNodes } from './hydration-planning.ts';
@@ -22,6 +22,7 @@ import type {
 	MountedIndexedList,
 	MountedKeyedList,
 	MountedRangeContent,
+	MountedRangeRecord,
 	TemplateInstance,
 } from './types.ts';
 
@@ -74,9 +75,9 @@ function hydrateMountedRangeContentSnapshot(
 		);
 
 		if (hydratedTemplateInstance) {
-			const nextDeferredProperties: DeferredPropertyBinding[] = [];
-			hydratedTemplateInstance.update(nextValue.values, nextDeferredProperties);
-			flushDeferredProperties(nextDeferredProperties);
+			flushWithDeferredProperties((deferredProperties) =>
+				hydratedTemplateInstance.update(nextValue.values, deferredProperties),
+			);
 			return { instance: hydratedTemplateInstance, kind: 'template' };
 		}
 	}
@@ -84,66 +85,52 @@ function hydrateMountedRangeContentSnapshot(
 	const iterableChildren = getIterableChildren(nextValue);
 
 	if (iterableChildren) {
-		const keyedChildren = getKeyedChildren(iterableChildren);
+		const hydratedListState = hydrateListRangeContent(endMarker, iterableChildren, existingNodes, rootTarget);
 
-		if (keyedChildren) {
-			const hydratedKeyedState = hydrateKeyedRangeContent(endMarker, keyedChildren, existingNodes, rootTarget);
-
-			if (hydratedKeyedState) {
-				return hydratedKeyedState;
-			}
-		}
-
-		const hydratedIndexedState = hydrateIndexedRangeContent(endMarker, iterableChildren, existingNodes, rootTarget);
-
-		if (hydratedIndexedState) {
-			return hydratedIndexedState;
+		if (hydratedListState) {
+			return hydratedListState;
 		}
 	}
 
+	// Anything still unresolved is reconciled against the SSR nodes as-is. Text-like
+	// values keep their existing node so hydration patches `data` instead of
+	// replacing it; every other shape rebuilds from the bootstrap snapshot.
+	if (!needsReconciliationAgainstSsrNodes(nextValue, bootstrapMounted)) {
+		return bootstrapMounted;
+	}
+
+	return flushWithDeferredProperties((deferredProperties) =>
+		updateRangeContent(startMarker, endMarker, nextValue, bootstrapMounted, rootTarget, deferredProperties),
+	);
+}
+
+/**
+ * Returns whether a hydrated range still needs a reconciliation pass, or whether the
+ * SSR nodes already represent the value exactly.
+ */
+function needsReconciliationAgainstSsrNodes(nextValue: unknown, bootstrapMounted: MountedRangeContent): boolean {
 	if (isTemplateResultLike(nextValue) || isIterableRenderable(nextValue)) {
-		const nextDeferredProperties: DeferredPropertyBinding[] = [];
-		const mounted = updateRangeContent(
-			startMarker,
-			endMarker,
-			nextValue,
-			existingNodes.length === 0 ? { kind: 'empty' } : { kind: 'nodes', nodes: existingNodes },
-			rootTarget,
-			nextDeferredProperties,
-		);
-		flushDeferredProperties(nextDeferredProperties);
-		return mounted;
+		return true;
 	}
 
 	if (nextValue === undefined || nextValue === null || nextValue === false) {
-		const nextDeferredProperties: DeferredPropertyBinding[] = [];
-		const mounted = updateRangeContent(
-			startMarker,
-			endMarker,
-			nextValue,
-			bootstrapMounted,
-			rootTarget,
-			nextDeferredProperties,
-		);
-		flushDeferredProperties(nextDeferredProperties);
-		return mounted;
+		return true;
 	}
 
-	if (existingNodes.length === 1 && existingNodes[0] instanceof Text && canRenderAsTextNode(nextValue)) {
-		const nextDeferredProperties: DeferredPropertyBinding[] = [];
-		const mounted = updateRangeContent(
-			startMarker,
-			endMarker,
-			nextValue,
-			{ kind: 'text', node: existingNodes[0] },
-			rootTarget,
-			nextDeferredProperties,
-		);
-		flushDeferredProperties(nextDeferredProperties);
-		return mounted;
-	}
+	return bootstrapMounted.kind === 'text' && canRenderAsTextNode(nextValue);
+}
 
-	return bootstrapMounted;
+/**
+ * Runs `mount` with a fresh deferred-property queue and flushes it before returning.
+ *
+ * Hydration mounts each range eagerly rather than joining the caller's render pass,
+ * so property writes are flushed at the end of the range that produced them.
+ */
+function flushWithDeferredProperties<T>(mount: (deferredProperties: DeferredPropertyBinding[]) => T): T {
+	const deferredProperties: DeferredPropertyBinding[] = [];
+	const result = mount(deferredProperties);
+	flushDeferredProperties(deferredProperties);
+	return result;
 }
 
 function createHydratedBootstrapMounted(existingNodes: readonly Node[]): MountedRangeContent {
@@ -206,17 +193,31 @@ function hydrateStaticTemplateRange(
 	return instance;
 }
 
-function hydrateIndexedRangeContent(
+/**
+ * Wraps each child of an iterable range in its own hydrated sub-range.
+ *
+ * Keyed and indexed lists walk the SSR nodes identically — only how a child's
+ * ownership is recorded differs — so the traversal is shared and the list flavour
+ * is decided once, up front.
+ *
+ * @returns The mounted list state, or `undefined` when the SSR nodes do not line up
+ *   with the child values, in which case the caller falls back to reconciliation.
+ */
+function hydrateListRangeContent(
 	endMarker: Text,
 	children: readonly unknown[],
 	existingNodes: readonly Node[],
 	rootTarget: HTMLElement,
-): MountedIndexedList | undefined {
-	const records = [];
+): MountedIndexedList | MountedKeyedList | undefined {
+	const keyedChildren = getKeyedChildren(children);
+	const indexedRecords: MountedRangeRecord[] = [];
+	const keyedRecords = new Map<JsxKey, MountedRangeRecord>();
 	let nextNodeIndex = 0;
 
-	for (const child of children) {
-		const childNodeCount = countHydratedRangeNodes(child);
+	for (const [index, child] of children.entries()) {
+		const keyedChild = keyedChildren?.[index];
+		const childValue = keyedChild ? keyedChild.value : child;
+		const childNodeCount = countHydratedRangeNodes(childValue);
 		const childNodes = existingNodes.slice(nextNodeIndex, nextNodeIndex + childNodeCount);
 
 		if (childNodes.length !== childNodeCount) {
@@ -227,49 +228,24 @@ function hydrateIndexedRangeContent(
 			childNodes,
 			existingNodes[nextNodeIndex + childNodeCount] ?? endMarker,
 		);
-		record.mounted = hydrateMountedRangeContent(record.start, record.end, child, childNodes, rootTarget);
-		records.push(record);
+		record.mounted = hydrateMountedRangeContent(record.start, record.end, childValue, childNodes, rootTarget);
 		nextNodeIndex += childNodeCount;
-	}
 
-	if (nextNodeIndex !== existingNodes.length) {
-		return undefined;
-	}
-
-	return { kind: 'indexed-list', records };
-}
-
-function hydrateKeyedRangeContent(
-	endMarker: Text,
-	children: readonly KeyedJsxValue[],
-	existingNodes: readonly Node[],
-	rootTarget: HTMLElement,
-): MountedKeyedList | undefined {
-	const records = new Map();
-	let nextNodeIndex = 0;
-
-	for (const child of children) {
-		const childNodeCount = countHydratedRangeNodes(child.value);
-		const childNodes = existingNodes.slice(nextNodeIndex, nextNodeIndex + childNodeCount);
-
-		if (childNodes.length !== childNodeCount) {
-			return undefined;
+		if (keyedChild) {
+			keyedRecords.set(keyedChild.key, record);
+			continue;
 		}
 
-		const record = createHydratedRangeRecord(
-			childNodes,
-			existingNodes[nextNodeIndex + childNodeCount] ?? endMarker,
-		);
-		record.mounted = hydrateMountedRangeContent(record.start, record.end, child.value, childNodes, rootTarget);
-		records.set(child.key, record);
-		nextNodeIndex += childNodeCount;
+		indexedRecords.push(record);
 	}
 
 	if (nextNodeIndex !== existingNodes.length) {
 		return undefined;
 	}
 
-	return { kind: 'keyed-list', records };
+	return keyedChildren
+		? { kind: 'keyed-list', records: keyedRecords }
+		: { kind: 'indexed-list', records: indexedRecords };
 }
 
 function createHydratedRangeRoot(startMarker: Text, endMarker: Text): { childNodes: readonly ChildNode[] } {

--- a/packages/jsx/src/dom-render/mounted-disposal.ts
+++ b/packages/jsx/src/dom-render/mounted-disposal.ts
@@ -10,8 +10,8 @@ import type {
 /**
  * Releases runtime state associated with a root-level mounted tree.
  *
- * Currently only template-mounted roots carry disposable state (event listeners and
- * subscriptions held in live parts).
+ * Template roots additionally tear down their live parts; every root releases the
+ * host's delegated listeners, since flat and iterable hydration attach those too.
  *
  * @param root Mounted root descriptor stored in the root render state.
  */
@@ -19,7 +19,10 @@ export function disposeMountedRoot(root: MountedRoot): void {
 	if (root.kind === 'template') {
 		disposeTemplateInstance(root.instance);
 		clearDelegationRoot(root.instance.rootTarget);
+		return;
 	}
+
+	clearDelegationRoot(root.rootTarget);
 }
 
 /**

--- a/packages/jsx/src/dom-render/types.ts
+++ b/packages/jsx/src/dom-render/types.ts
@@ -251,7 +251,13 @@ export type MountedRangeContent =
 	| MountedTemplate
 	| MountedText;
 
-/** Mounted representation for the current render root. */
+/**
+ * Mounted representation for the current render root.
+ *
+ * Both variants carry the host element so disposal can release root-scoped
+ * delegated listeners, which are registered on the host regardless of whether the
+ * root mounted as a template instance or as loose nodes.
+ */
 export type MountedRoot =
 	| {
 			instance: TemplateInstance;
@@ -259,4 +265,5 @@ export type MountedRoot =
 	  }
 	| {
 			kind: 'value';
+			rootTarget: HTMLElement;
 	  };

--- a/packages/jsx/test/dom-render-reconciliation.e2e.test.tsx
+++ b/packages/jsx/test/dom-render-reconciliation.e2e.test.tsx
@@ -640,6 +640,37 @@ describe('Radiant JSX DOM reconciliation behavior', () => {
 		expect(container.innerHTML).not.toContain('data-radiant-jsx-bind-');
 	});
 
+	test('unmount releases delegated listeners attached during iterable-root hydration', async () => {
+		const [{ jsx }, { createRoot }] = await Promise.all([loadJsxRuntime(), loadJsxModule()]);
+		const container = document.createElement('div');
+		document.body.append(container);
+		const root = createRoot(container);
+		let clickTotal = 0;
+		const increment = () => {
+			clickTotal += 1;
+		};
+
+		container.innerHTML = HYDRATE_ITERABLE_ROOT_HTML;
+		root.hydrate([
+			jsx('button', { 'on:click': increment, children: 'Alpha' }),
+			jsx('button', { 'on:click': increment, children: 'Beta' }),
+		]);
+
+		const hydratedButton = container.querySelector('button');
+		hydratedButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+		expect(clickTotal).toBe(1);
+
+		// Iterable roots register delegated listeners on the host, so unmount must
+		// release them even though no template instance owns the root.
+		root.unmount();
+		container.append(hydratedButton!);
+		hydratedButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+		expect(clickTotal).toBe(1);
+
+		container.remove();
+	});
+
 	test('removes SSR hydration marker attributes after template hydration', async () => {
 		const [{ jsx }, { createRoot }] = await Promise.all([loadJsxRuntime(), loadJsxModule()]);
 		const container = document.createElement('div');


### PR DESCRIPTION
dom-render.ts declared three near-identical outcome unions and three switch
statements, but every consumer handled 'full-rerender' and 'recoverable-mismatch'
identically — the distinction was never observed. The unions were only that wide
because each attempt* helper captured the focus snapshot internally and threaded
it back out through its result type.

Focus is now captured once in hydrate() before dispatch, so the three shapes
collapse to one function returning `MountedRoot | undefined`: a mounted root on
success, undefined to fall back to a full render. Three types, three switches,
and three helpers become one.

Also in this pass:

- extract the 40-line inline marker-walk callback out of the entry file into
  dom-render/hydration-flat.ts, which takes the four warning imports with it
- merge hydrateIndexedRangeContent and hydrateKeyedRangeContent, which were the
  same traversal differing only in how a child's ownership is recorded
- collapse the four repeated build-queue/update/flush blocks in
  hydrateMountedRangeContentSnapshot into one tail plus a
  needsReconciliationAgainstSsrNodes predicate; the inline bootstrap at the
  iterable branch also silently omitted the text case that
  createHydratedBootstrapMounted handles

Fixes root disposal for non-template roots. Iterable and flat hydration register
delegated listeners on the host, but MountedRoot's 'value' variant carried no
reference to it, so disposeMountedRoot could not release them and listeners
survived unmount. The variant now carries rootTarget. The flat path also failed
to record any root state at all, so a later render never disposed what hydration
had attached.

Adds a regression test asserting delegated listeners are released on unmount
after iterable-root hydration; it fires twice against the previous disposal.
