### PR TITLE
feat(jsx): reconcile the render root through the child-range engine

### DIFF
--- a/packages/jsx/src/dom-render.ts
+++ b/packages/jsx/src/dom-render.ts
@@ -1,24 +1,21 @@
+import { updateRangeContent } from './dom-render/child-range-update.ts';
+import { createBoundaryMarker } from './dom-render/dom-operations.ts';
 import { captureFocusSnapshot, restoreFocusSnapshot } from './dom-render/focus-snapshot.ts';
 import { hydrateFlatBindings } from './dom-render/hydration-flat.ts';
 import { hydrateIterableRoot } from './dom-render/hydration-iterable.ts';
 import { hydrateTemplateInstance } from './dom-render/hydration.ts';
 import { disposeMountedRoot } from './dom-render/mounted-disposal.ts';
-import {
-	createNodesFromValue,
-	flushDeferredProperties,
-	isTemplateResultLike,
-	unwrapKeyedValue,
-} from './dom-render/runtime-helpers.ts';
-import { getCompiledTemplate } from './dom-render/template-compiler.ts';
-import { createTemplateInstance } from './dom-render/template-instance.ts';
-import type { DeferredPropertyBinding, MountedRoot } from './dom-render/types.ts';
+import { flushDeferredProperties, isTemplateResultLike, unwrapKeyedValue } from './dom-render/runtime-helpers.ts';
+import type { DeferredPropertyBinding, MountedRangeContent, MountedRoot } from './dom-render/types.ts';
 import { visitHydrationBindingMarkers } from './hydration/hydration-bindings.ts';
 import { isIterableRenderable } from './types/renderable-guards.ts';
 import type { JsxRenderable } from './types/index.ts';
 
 /**
- * Per-root render state used to decide whether a subsequent render can update
- * an existing template instance in place or must dispose and remount.
+ * Per-root render state.
+ *
+ * A mounted root is just a child range that happens to span the whole host, so
+ * every root reuses the same reconciliation engine as any nested dynamic slot.
  */
 const ROOT_RENDER_STATE = new WeakMap<HTMLElement, MountedRoot>();
 
@@ -38,43 +35,19 @@ export interface JsxRoot {
 /**
  * Renders a JSX value into a target element.
  *
- * Template results keep a live instance when the template shape is stable,
- * allowing repeated renders to patch existing parts instead of replacing the
- * whole subtree.
+ * The root is reconciled through the same range engine used for nested child
+ * slots, so every value shape behaves identically at the root as it does inside a
+ * template: stable templates patch in place, keyed lists preserve identity, text
+ * updates mutate node data, and reactive sources stay subscribed.
  */
 export function render(element: JsxRenderable, target: HTMLElement): void {
 	const focusSnapshot = captureFocusSnapshot(target);
 	const deferredProperties: DeferredPropertyBinding[] = [];
-	const nextValue = unwrapKeyedValue(element);
-	const currentRenderState = ROOT_RENDER_STATE.get(target);
+	const root = getOrCreateMountedRoot(target);
 
-	if (isTemplateResultLike(nextValue)) {
-		const compiledTemplate = getCompiledTemplate(nextValue);
-
-		if (currentRenderState?.kind === 'template' && currentRenderState.instance.compiled === compiledTemplate) {
-			currentRenderState.instance.update(nextValue.values, deferredProperties);
-		} else {
-			if (currentRenderState) {
-				disposeMountedRoot(currentRenderState);
-			}
-
-			const instance = createTemplateInstance(nextValue, target, deferredProperties, target);
-			target.replaceChildren(...instance.rootNodes);
-			ROOT_RENDER_STATE.set(target, { instance, kind: 'template' });
-		}
-	} else {
-		if (currentRenderState) {
-			disposeMountedRoot(currentRenderState);
-		}
-
-		target.replaceChildren(
-			...createNodesFromValue(nextValue, target, deferredProperties, createTemplateInstance, target),
-		);
-		ROOT_RENDER_STATE.set(target, { kind: 'value', rootTarget: target });
-	}
+	root.mounted = updateRangeContent(root.start, root.end, element, root.mounted, target, deferredProperties);
 
 	flushDeferredProperties(deferredProperties);
-
 	restoreFocusSnapshot(target, focusSnapshot);
 }
 
@@ -94,14 +67,14 @@ export function hydrate(element: JsxRenderable, target: HTMLElement): void {
 
 	const focusSnapshot = captureFocusSnapshot(target);
 	const deferredProperties: DeferredPropertyBinding[] = [];
-	const reconnectedRoot = reconnectSsrRoot(element, target, deferredProperties);
+	const reconnectedContent = reconnectSsrRoot(element, target, deferredProperties);
 
-	if (!reconnectedRoot) {
+	if (!reconnectedContent) {
 		render(element, target);
 		return;
 	}
 
-	ROOT_RENDER_STATE.set(target, reconnectedRoot);
+	ROOT_RENDER_STATE.set(target, adoptHydratedRootRange(target, reconnectedContent));
 	flushDeferredProperties(deferredProperties);
 	restoreFocusSnapshot(target, focusSnapshot);
 }
@@ -111,16 +84,16 @@ export function hydrate(element: JsxRenderable, target: HTMLElement): void {
  *
  * The three shapes — a single template result, an iterable of children, and the
  * flat marker-walk fallback — differ only in how they locate bindings, so each
- * reports the same way: a mounted root on success, `undefined` to fall back to a
+ * reports the same way: mounted content on success, `undefined` to fall back to a
  * full client render.
  *
- * @returns The mounted root state, or `undefined` when the DOM cannot be recovered.
+ * @returns The reconnected range content, or `undefined` when the DOM cannot be recovered.
  */
 function reconnectSsrRoot(
 	element: JsxRenderable,
 	target: HTMLElement,
 	deferredProperties: DeferredPropertyBinding[],
-): MountedRoot | undefined {
+): MountedRangeContent | undefined {
 	const nextValue = unwrapKeyedValue(element);
 
 	if (isTemplateResultLike(nextValue)) {
@@ -138,11 +111,48 @@ function reconnectSsrRoot(
 		}
 
 		return hydrateIterableRoot(nextValue, target, deferredProperties, { rootTarget: target })
-			? { kind: 'value', rootTarget: target }
+			? { kind: 'nodes', nodes: Array.from(target.childNodes) }
 			: undefined;
 	}
 
-	return hydrateFlatBindings(element, target, deferredProperties) ? { kind: 'value', rootTarget: target } : undefined;
+	return hydrateFlatBindings(element, target, deferredProperties)
+		? { kind: 'nodes', nodes: Array.from(target.childNodes) }
+		: undefined;
+}
+
+function getOrCreateMountedRoot(target: HTMLElement): MountedRoot {
+	const existingRoot = ROOT_RENDER_STATE.get(target);
+
+	if (existingRoot) {
+		return existingRoot;
+	}
+
+	target.replaceChildren();
+
+	const startMarker = createBoundaryMarker();
+	const endMarker = createBoundaryMarker();
+	target.append(startMarker, endMarker);
+
+	const root: MountedRoot = { end: endMarker, mounted: { kind: 'empty' }, rootTarget: target, start: startMarker };
+	ROOT_RENDER_STATE.set(target, root);
+	return root;
+}
+
+/**
+ * Brackets already-hydrated SSR content with boundary markers so later renders
+ * reconcile it through the same range engine as a client-mounted root.
+ *
+ * Markers are added only after reconnection completes, because hydration resolves
+ * blueprint paths against the host's original child indexes.
+ */
+function adoptHydratedRootRange(target: HTMLElement, mounted: MountedRangeContent): MountedRoot {
+	const startMarker = createBoundaryMarker();
+	const endMarker = createBoundaryMarker();
+
+	target.prepend(startMarker);
+	target.append(endMarker);
+
+	return { end: endMarker, mounted, rootTarget: target, start: startMarker };
 }
 
 /**

--- a/packages/jsx/src/dom-render/focus-snapshot.ts
+++ b/packages/jsx/src/dom-render/focus-snapshot.ts
@@ -5,6 +5,7 @@ import { getNodeAtPath, getNodePath } from './path-utils.ts';
  * replace DOM nodes.
  */
 export type FocusSnapshot = {
+	element: HTMLElement;
 	path: number[];
 	selectionStart?: number | null;
 	selectionEnd?: number | null;
@@ -14,6 +15,11 @@ export type FocusSnapshot = {
 /**
  * Captures the currently focused descendant and selection state so rerenders can
  * preserve editing continuity when possible.
+ *
+ * Both the element itself and its child-index path are recorded. Identity is the
+ * accurate signal when reconciliation patches nodes in place; the path is the
+ * fallback for the case where the element was replaced outright and only its
+ * position survives.
  */
 export function captureFocusSnapshot(target: HTMLElement): FocusSnapshot | undefined {
 	const activeElement = document.activeElement;
@@ -23,6 +29,7 @@ export function captureFocusSnapshot(target: HTMLElement): FocusSnapshot | undef
 	}
 
 	return {
+		element: activeElement,
 		path: getNodePath(target, activeElement),
 		selectionDirection: isSelectableInput(activeElement) ? activeElement.selectionDirection : undefined,
 		selectionEnd: isSelectableInput(activeElement) ? activeElement.selectionEnd : undefined,
@@ -36,7 +43,13 @@ export function restoreFocusSnapshot(target: HTMLElement, snapshot: FocusSnapsho
 		return;
 	}
 
-	const nextFocusedNode = getNodeAtPath(target, snapshot.path);
+	// The element survived and never lost focus, so there is nothing to restore.
+	// Re-applying the selection here would clobber a caret the user has since moved.
+	if (document.activeElement === snapshot.element) {
+		return;
+	}
+
+	const nextFocusedNode = target.contains(snapshot.element) ? snapshot.element : getNodeAtPath(target, snapshot.path);
 
 	if (!(nextFocusedNode instanceof HTMLElement)) {
 		return;

--- a/packages/jsx/src/dom-render/mounted-disposal.ts
+++ b/packages/jsx/src/dom-render/mounted-disposal.ts
@@ -10,18 +10,14 @@ import type {
 /**
  * Releases runtime state associated with a root-level mounted tree.
  *
- * Template roots additionally tear down their live parts; every root releases the
- * host's delegated listeners, since flat and iterable hydration attach those too.
+ * Range disposal already detaches each binding's listeners individually; clearing
+ * the delegation root additionally drops any handler the range no longer tracks,
+ * such as those attached in place by flat or iterable hydration.
  *
  * @param root Mounted root descriptor stored in the root render state.
  */
 export function disposeMountedRoot(root: MountedRoot): void {
-	if (root.kind === 'template') {
-		disposeTemplateInstance(root.instance);
-		clearDelegationRoot(root.instance.rootTarget);
-		return;
-	}
-
+	disposeMountedRangeContent(root.mounted);
 	clearDelegationRoot(root.rootTarget);
 }
 

--- a/packages/jsx/src/dom-render/types.ts
+++ b/packages/jsx/src/dom-render/types.ts
@@ -254,16 +254,11 @@ export type MountedRangeContent =
 /**
  * Mounted representation for the current render root.
  *
- * Both variants carry the host element so disposal can release root-scoped
- * delegated listeners, which are registered on the host regardless of whether the
- * root mounted as a template instance or as loose nodes.
+ * A root is a {@link MountedRangeRecord} that spans its whole host, plus the host
+ * itself so disposal can release root-scoped delegated listeners. Modelling it as a
+ * range is what lets every value shape — templates, keyed lists, text, and reactive
+ * sources — behave the same at the root as inside a template.
  */
-export type MountedRoot =
-	| {
-			instance: TemplateInstance;
-			kind: 'template';
-	  }
-	| {
-			kind: 'value';
-			rootTarget: HTMLElement;
-	  };
+export type MountedRoot = MountedRangeRecord & {
+	rootTarget: HTMLElement;
+};

--- a/packages/jsx/test/dom-render-reconciliation.e2e.test.tsx
+++ b/packages/jsx/test/dom-render-reconciliation.e2e.test.tsx
@@ -1465,6 +1465,97 @@ describe('Radiant JSX DOM reconciliation behavior', () => {
 		expect((container.querySelector('input') as HTMLInputElement | null)?.checked).toBe(true);
 	});
 
+	test('a reactive value rendered at the root stays subscribed and patches in place', async () => {
+		const [{ createSubscribableJsxValue }, { createRoot }] = await Promise.all([loadJsxRuntime(), loadJsxModule()]);
+		const container = document.createElement('div');
+		const root = createRoot(container);
+		const subscribers = new Set<(value: string) => void>();
+		let label = 'first';
+		const boundLabel = createSubscribableJsxValue({
+			getValue: () => label,
+			subscribe: (notify) => {
+				subscribers.add(notify);
+				return () => {
+					subscribers.delete(notify);
+				};
+			},
+		});
+
+		root.render(boundLabel);
+
+		expect(container.textContent).toBe('first');
+		expect(subscribers.size).toBe(1);
+
+		label = 'second';
+
+		for (const subscriber of subscribers) {
+			subscriber(label);
+		}
+
+		expect(container.textContent).toBe('second');
+
+		root.unmount();
+
+		expect(subscribers.size).toBe(0);
+	});
+
+	test('a reactive template rendered at the root drives updates without a wrapping element', async () => {
+		const [{ createSubscribableJsxValue, jsxs }, { createRoot }] = await Promise.all([
+			loadJsxRuntime(),
+			loadJsxModule(),
+		]);
+		const container = document.createElement('div');
+		const root = createRoot(container);
+		const subscribers = new Set<(value: number) => void>();
+		let count = 1;
+		const boundView = createSubscribableJsxValue({
+			getValue: () => count,
+			subscribe: (notify) => {
+				subscribers.add(notify);
+				return () => {
+					subscribers.delete(notify);
+				};
+			},
+		}).map((value) => jsxs('p', { class: 'count', children: ['Count: ', value] }));
+
+		root.render(boundView);
+
+		expect(container.innerHTML).toBe('<p class="count">Count: 1</p>');
+
+		const mountedParagraph = container.querySelector('p');
+		count = 2;
+
+		for (const subscriber of subscribers) {
+			subscriber(count);
+		}
+
+		expect(container.innerHTML).toBe('<p class="count">Count: 2</p>');
+		// The template shape is stable, so the root patches the existing element
+		// rather than replacing the subtree.
+		expect(container.querySelector('p')).toBe(mountedParagraph);
+	});
+
+	test('root renders reconcile keyed lists in place instead of rebuilding them', async () => {
+		const [{ jsx }, { createRoot }] = await Promise.all([loadJsxRuntime(), loadJsxModule()]);
+		const container = document.createElement('div');
+		const root = createRoot(container);
+		const renderList = (keys: readonly string[]) => keys.map((key) => jsx('li', { children: key }, key));
+
+		root.render(renderList(['a', 'b', 'c']));
+
+		const initialItems = new Map(
+			Array.from(container.querySelectorAll('li'), (item) => [item.textContent, item] as const),
+		);
+
+		root.render(renderList(['c', 'a', 'b']));
+
+		expect(Array.from(container.querySelectorAll('li'), (item) => item.textContent)).toEqual(['c', 'a', 'b']);
+
+		for (const [key, item] of initialItems) {
+			expect(container.querySelector('li:nth-child(' + (['c', 'a', 'b'].indexOf(key!) + 1) + ')')).toBe(item);
+		}
+	});
+
 	test('map derives a record lookup and patches only the text node without rerendering', async () => {
 		const [{ createSubscribableJsxValue, jsxs }, { createRoot }] = await Promise.all([
 			loadJsxRuntime(),


### PR DESCRIPTION
A reactive value passed to render() was silently not reactive. createNodesFromValue
read getValue() once and never subscribed, so render(signal, target) mounted a
static snapshot — while the same value inside a template mounted fully live. The
root also had no way to reconcile: every non-template render replaced all children,
and MountedRoot's 'value' variant carried nothing, so nothing could be disposed.

The root is now a MountedRangeRecord spanning the host, reconciled by
updateRangeContent — the same engine used for every nested dynamic slot. Root
values gain the behavior they already had one level down:

- reactive sources subscribe, update in place, and unsubscribe on unmount
- keyed lists preserve node identity across reorders
- stable templates patch instead of remounting
- text updates mutate node data

This deletes the template-vs-value fork in render(), the manual replaceChildren
paths, and the MountedRoot union along with it. disposeMountedRoot loses its
branch too: disposing the range already detaches each binding's listeners, and
clearing the delegation root covers handlers attached in place by hydration.

Hydrated roots are bracketed with boundary markers after reconnection completes,
so a later render reconciles SSR DOM through the same path. Markers are added
last because hydration resolves blueprint paths against the host's original
child indexes.

Focus restore is now identity-first with the child-index path as fallback.
Identity is the accurate signal once reconciliation patches in place, it survives
reorders that shift paths, and it is unaffected by the root markers. Restore is
skipped entirely when the element never lost focus, so hydration no longer resets
a caret the user has since moved.

Adds tests for root-level reactive values, reactive templates at the root, and
keyed reordering at the root. The first two fail against the previous renderer
with zero subscriptions and no updates.
