### PR TITLE
refactor(jsx)!: carry binding metadata on template results

### DIFF
--- a/packages/jsx/README.md
+++ b/packages/jsx/README.md
@@ -699,16 +699,16 @@ That object is an internal contract between the JSX runtime and the Radiant rend
 
 These surfaces emit or parse raw HTML by design. Pass only content you already trust.
 
-| Surface                                                   | Contract                                                                                             |
-| --------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| Compiled JSX / template `strings[]`                       | Static author HTML; emitted raw                                                                      |
-| Transported `{ strings, values }`                         | `strings` are trusted author HTML; dynamic `values` are still escaped                                |
-| `unsafeHtml(...)` / `createMarkupNodeLike(...)`           | Branded markup; `outerHTML` emitted and parsed raw                                                   |
-| Live `Node` instances                                     | `outerHTML` emitted raw (slot projection / host passthrough)                                         |
-| Custom-element `renderHostToString` / server render hooks | Host HTML is trusted; return branded markup via `createMarkupNodeLike(...)`                          |
-| `<script>` children                                       | Raw element text; only the `</script` closing sequence is escaped, so executable content stays valid |
-| `prop:*` (including `prop:innerHTML`)                     | Live property assignment; no sanitization                                                            |
-| `href` / `src` / `style`                                  | Escaped as attribute text only — no URL-scheme or CSS sanitization                                   |
+| Surface                                                   | Contract                                                                                                    |
+| --------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| Compiled JSX / template `strings[]`                       | Static author HTML; emitted raw                                                                             |
+| Transported `{ strings, values }`                         | Only via `toTemplateResultLike(...)`; `strings` are trusted author HTML, dynamic `values` are still escaped |
+| `unsafeHtml(...)` / `createMarkupNodeLike(...)`           | Branded markup; `outerHTML` emitted and parsed raw                                                          |
+| Live `Node` instances                                     | `outerHTML` emitted raw (slot projection / host passthrough)                                                |
+| Custom-element `renderHostToString` / server render hooks | Host HTML is trusted; return branded markup via `createMarkupNodeLike(...)`                                 |
+| `<script>` children                                       | Raw element text; only the `</script` closing sequence is escaped, so executable content stays valid        |
+| `prop:*` (including `prop:innerHTML`)                     | Live property assignment; no sanitization                                                                   |
+| `href` / `src` / `style`                                  | Escaped as attribute text only — no URL-scheme or CSS sanitization                                          |
 
 ### Trusted markup API
 

--- a/packages/jsx/README.md
+++ b/packages/jsx/README.md
@@ -421,6 +421,22 @@ Iterable fragment hydration supports flat lists of intrinsic template children (
 
 Global SSR marker indexes are shared across all three paths via the binding collection helpers in `hydration-bindings.ts`, so fragment children resolve `data-radiant-jsx-bind-*` attributes against the same namespace used by `renderToString(..., { mode: 'hydrate' })`.
 
+Within a hydrated child range, a list child is reconnected in place only when its template consists purely of attribute bindings. A child that also carries dynamic content — `<li>{item.name}</li>` — cannot currently be reconnected, so its SSR subtree is discarded and rebuilt. Hydration still succeeds and the surrounding tree is reused, but that range pays full client-render cost. `pnpm run bench:hydrate` measures both shapes side by side.
+
+### Benchmarks
+
+| Command                    | Measures                                                                |
+| -------------------------- | ----------------------------------------------------------------------- |
+| `pnpm run bench:server`    | `renderToString` throughput in Node and Bun                             |
+| `pnpm run bench:hydrate`   | Client `hydrate(...)` in Chromium, per root shape                       |
+| `pnpm run profile:hydrate` | Per-binding SSR emission cost (this is an SSR profile despite the name) |
+
+`bench:hydrate` renders fixtures in Node, bundles the measurement code for the browser, and runs each scenario in its own browser context so a leaking shape cannot inflate the next one. It reports:
+
+- `medianMs` / `minMs` — time inside `hydrate(...)` only; parsing and teardown are outside the timer.
+- `drift` — median of the later rounds over the earlier ones. Rounds are identical and each is unmounted, so a value meaningfully above `1` means hydration left state behind.
+- `reconnected` — whether SSR nodes survived. Each scenario declares what it expects and the run **fails** on a mismatch, because a shape that silently falls back to a full client render still produces plausible-looking numbers.
+
 ### SSR Marker Lifecycle
 
 Hydration markers are not ad hoc attributes. They are one shared index namespace that connects server serialization to client recovery.

--- a/packages/jsx/benchmarks/hydrate-client-entry.ts
+++ b/packages/jsx/benchmarks/hydrate-client-entry.ts
@@ -1,0 +1,97 @@
+import { createRoot } from '../src/dom-render.ts';
+import { HYDRATE_SCENARIOS } from './hydrate-scenarios.tsx';
+
+export type HydrateScenarioResult = {
+	drift: number;
+	medianMs: number;
+	minMs: number;
+	name: string;
+	reconnected: boolean;
+	rounds: number[];
+};
+
+type RunOptions = {
+	measuredRounds: number;
+	warmupRounds: number;
+};
+
+function median(values: readonly number[]): number {
+	const sorted = [...values].sort((left, right) => left - right);
+	const middle = Math.floor(sorted.length / 2);
+
+	return sorted.length % 2 === 0 ? ((sorted[middle - 1] ?? 0) + (sorted[middle] ?? 0)) / 2 : (sorted[middle] ?? 0);
+}
+
+/**
+ * Times one `hydrate(...)` call per round against a freshly parsed copy of the
+ * SSR markup.
+ *
+ * Only the hydrate call is measured; parsing and teardown sit outside the timer.
+ * Each round gets its own container and is unmounted afterwards, so state that
+ * survives teardown shows up as a rising series rather than being averaged away.
+ */
+function measureScenario(html: string, build: () => unknown, options: RunOptions): Omit<HydrateScenarioResult, 'name'> {
+	const samples: number[] = [];
+	let reconnected = false;
+
+	for (let round = 0; round < options.warmupRounds + options.measuredRounds; round += 1) {
+		const container = document.createElement('div');
+		document.body.append(container);
+		container.innerHTML = html;
+
+		const probe = container.querySelector('.card, .row');
+		const root = createRoot(container);
+		const startedAt = performance.now();
+
+		root.hydrate(build() as never);
+
+		const elapsed = performance.now() - startedAt;
+
+		if (round === 0) {
+			reconnected = probe !== null && probe.isConnected;
+		}
+
+		if (round >= options.warmupRounds) {
+			samples.push(elapsed);
+		}
+
+		root.unmount();
+		container.remove();
+	}
+
+	// Half-vs-half medians rather than last-vs-first: a single unlucky round would
+	// otherwise dominate the ratio.
+	const midpoint = Math.floor(samples.length / 2);
+	const earlyMedian = median(samples.slice(0, midpoint));
+	const lateMedian = median(samples.slice(midpoint));
+
+	return {
+		// Rising cost across identical rounds means hydration left something behind.
+		drift: earlyMedian === 0 ? 0 : Number((lateMedian / earlyMedian).toFixed(2)),
+		medianMs: Number(median(samples).toFixed(3)),
+		minMs: Number(Math.min(...samples).toFixed(3)),
+		reconnected,
+		rounds: samples.map((sample) => Number(sample.toFixed(1))),
+	};
+}
+
+declare global {
+	// eslint-disable-next-line no-var
+	var __runHydrateBench: (name: string, html: string, options: RunOptions) => HydrateScenarioResult;
+}
+
+/**
+ * Measures a single scenario.
+ *
+ * One scenario per page load, because a shape that leaks leaves memory pressure
+ * behind and would otherwise be charged to whichever scenario ran after it.
+ */
+globalThis.__runHydrateBench = (name, html, options) => {
+	const scenario = HYDRATE_SCENARIOS.find((candidate) => candidate.name === name);
+
+	if (!scenario) {
+		throw new Error(`Unknown hydration scenario: ${name}`);
+	}
+
+	return { name, ...measureScenario(html, scenario.build, options) };
+};

--- a/packages/jsx/benchmarks/hydrate-client.ts
+++ b/packages/jsx/benchmarks/hydrate-client.ts
@@ -1,0 +1,109 @@
+import { writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import * as esbuild from 'esbuild';
+import { chromium } from 'playwright';
+import { renderToString } from '../src/ssr/server-render.ts';
+import { HYDRATE_SCENARIOS } from './hydrate-scenarios.tsx';
+import type { HydrateScenarioResult } from './hydrate-client-entry.ts';
+
+/**
+ * Client hydration benchmark.
+ *
+ * SSR needs Node and hydration needs a real DOM, so the run is split: fixtures are
+ * rendered here, the measurement code is bundled for the browser, and Chromium
+ * executes it. Numbers come back as structured results rather than console output.
+ *
+ * Run with `pnpm run bench:hydrate`.
+ */
+
+const packageRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const measuredRounds = Number(process.env.BENCH_ROUNDS ?? '15');
+const warmupRounds = Number(process.env.BENCH_WARMUP ?? '5');
+
+const fixtures = Object.fromEntries(
+	HYDRATE_SCENARIOS.map((scenario) => [scenario.name, renderToString(scenario.build(), { mode: 'hydrate' })]),
+);
+
+const bundle = await esbuild.build({
+	bundle: true,
+	entryPoints: [join(packageRoot, 'benchmarks/hydrate-client-entry.ts')],
+	format: 'iife',
+	platform: 'browser',
+	target: 'es2022',
+	write: false,
+});
+
+const bundledCode = bundle.outputFiles[0]?.text;
+
+if (!bundledCode) {
+	throw new Error('Failed to bundle the hydration benchmark client entry.');
+}
+
+const browser = await chromium.launch();
+const results: HydrateScenarioResult[] = [];
+
+try {
+	// A fresh context per scenario: a shape that leaks would otherwise leave memory
+	// pressure behind and inflate whichever scenario ran next.
+	for (const scenario of HYDRATE_SCENARIOS) {
+		const context = await browser.newContext();
+		const page = await context.newPage();
+
+		await page.setContent('<!doctype html><html><body></body></html>');
+		await page.addScriptTag({ content: bundledCode });
+
+		results.push(
+			await page.evaluate(
+				([name, html, options]) =>
+					globalThis.__runHydrateBench(
+						name as string,
+						html as string,
+						options as { measuredRounds: number; warmupRounds: number },
+					),
+				[scenario.name, fixtures[scenario.name] ?? '', { measuredRounds, warmupRounds }] as const,
+			),
+		);
+
+		await context.close();
+	}
+} finally {
+	await browser.close();
+}
+
+const mismatched = HYDRATE_SCENARIOS.filter(
+	(scenario) => scenario.reconnects !== results.find((result) => result.name === scenario.name)?.reconnected,
+);
+
+console.log(`Hydration profile: Chromium via Playwright (${measuredRounds} rounds, ${warmupRounds} warmup)\n`);
+console.table(
+	results.map((result) => ({
+		name: result.name,
+		medianMs: result.medianMs,
+		minMs: result.minMs,
+		drift: result.drift,
+		reconnected: result.reconnected,
+		sizeKiB: Number(((fixtures[result.name]?.length ?? 0) / 1024).toFixed(1)),
+	})),
+);
+
+console.log(
+	'\ndrift = median of the later rounds / median of the earlier rounds. Values meaningfully above 1 mean hydration left state behind.',
+);
+
+for (const scenario of HYDRATE_SCENARIOS) {
+	console.log(`  ${scenario.name}: ${scenario.description}`);
+}
+
+if (process.env.BENCH_JSON_OUT) {
+	writeFileSync(process.env.BENCH_JSON_OUT, JSON.stringify({ measuredRounds, results, warmupRounds }, null, 2));
+}
+
+if (mismatched.length > 0) {
+	// A scenario that stops reconnecting still yields numbers, they just describe a
+	// full client render instead of hydration. Fail rather than report them as-is.
+	throw new Error(
+		`Hydration expectation mismatch for: ${mismatched.map((scenario) => scenario.name).join(', ')}. ` +
+			"Either the shape regressed, or the scenario's `reconnects` flag needs updating.",
+	);
+}

--- a/packages/jsx/benchmarks/hydrate-scenarios.tsx
+++ b/packages/jsx/benchmarks/hydrate-scenarios.tsx
@@ -1,0 +1,101 @@
+/** @jsxImportSource ../src */
+import type { JsxRenderable } from '../src/types/index.ts';
+
+export type HydrateScenario = {
+	/** Stable id used as the fixture key and in the report. */
+	name: string;
+	/** What this shape is meant to expose. */
+	description: string;
+	/**
+	 * Whether hydration is expected to reconnect the SSR nodes in place.
+	 *
+	 * The runner asserts this: a scenario that silently starts falling back to a
+	 * full client render would otherwise still produce plausible-looking numbers.
+	 */
+	reconnects: boolean;
+	build: () => JsxRenderable;
+};
+
+type Item = {
+	id: number;
+	name: string;
+	price: number;
+};
+
+const ITEM_COUNT = 500;
+
+const items: Item[] = Array.from({ length: ITEM_COUNT }, (_, index) => ({
+	id: index,
+	name: `Purchase number ${index + 1}`,
+	price: index,
+}));
+
+/**
+ * Hydration benchmark shapes.
+ *
+ * Each entry is one structural case, not one page: the interesting differences
+ * live in how a child range reconnects, so the shapes are deliberately minimal
+ * apart from the property under test.
+ */
+export const HYDRATE_SCENARIOS: HydrateScenario[] = [
+	{
+		name: 'list-reconnect',
+		description: 'Attribute-only list children; the static-range hydrator reconnects them in place.',
+		reconnects: true,
+		build: () => (
+			<div class="list">
+				{items.map((item) => (
+					<article class="card" data-id={String(item.id)} title={item.name} lang="en" />
+				))}
+			</div>
+		),
+	},
+	{
+		name: 'list-rebuild',
+		description:
+			'List children carrying dynamic text. Hydration cannot reconnect these today, so the SSR subtree is discarded and rebuilt — the gap against list-reconnect is the cost of that fallback.',
+		reconnects: false,
+		build: () => (
+			<div class="list">
+				{items.map((item) => (
+					<article class="card" data-id={String(item.id)}>
+						<h3 class="card__title">{item.name}</h3>
+						<p class="card__price">{item.price}</p>
+					</article>
+				))}
+			</div>
+		),
+	},
+	{
+		name: 'list-keyed',
+		description: 'Keyed attribute-only children, exercising the keyed range hydrator.',
+		reconnects: true,
+		build: () => (
+			<div class="list">
+				{items.map((item) => (
+					<article key={item.id} class="card" data-id={String(item.id)} title={item.name} lang="en" />
+				))}
+			</div>
+		),
+	},
+	{
+		name: 'wide-attributes',
+		description: 'One template with many attribute bindings, isolating per-binding reconnection cost.',
+		reconnects: true,
+		build: () => (
+			<section class="panel" hidden title="ready" aria-label="demo" lang="en" dir="ltr">
+				{items.slice(0, 200).map((item) => (
+					<div
+						class="row"
+						title={item.name}
+						lang="en"
+						dir="ltr"
+						data-a={String(item.id)}
+						data-b={String(item.price)}
+						data-c="c"
+					/>
+				))}
+			</section>
+		),
+	},
+];

--- a/packages/jsx/package.json
+++ b/packages/jsx/package.json
@@ -40,6 +40,7 @@
 		"build:lib": "pnpm run clean && pnpm run build:files && pnpm run build:types",
 		"build:files": "node --import tsx ./build.ts",
 		"build:types": "tsc -p tsconfig.build.json && node --import tsx ./rewrite-dts-imports.ts",
+		"bench:hydrate": "node --import tsx benchmarks/hydrate-client.ts",
 		"bench:server": "node --import tsx benchmarks/run-all.ts",
 		"bench:server:bun": "bun run benchmarks/ssr.ts",
 		"bench:server:compare": "node --import tsx benchmarks/run.ts",

--- a/packages/jsx/src/dom-render/template-compiler.ts
+++ b/packages/jsx/src/dom-render/template-compiler.ts
@@ -1,5 +1,4 @@
 import { ATTRIBUTE_BINDING_PREFIX } from '../hydration/hydration-bindings.ts';
-import { getTemplateCacheKey, getTemplateInterpolationParts } from '../factory/template-shape.ts';
 import { createBoundaryMarker } from './dom-operations.ts';
 import { getElementNamespace, HTML_NAMESPACE_URI, setElementAttributeValue } from './namespaces.ts';
 import { getNodeAtPath, getNodePath } from './path-utils.ts';
@@ -13,50 +12,38 @@ import type {
 	TemplatePart,
 } from './types.ts';
 
-const TEMPLATE_CACHE = new WeakMap<readonly string[], CompiledTemplate>();
-const TEMPLATE_CACHE_BY_KEY = new Map<string, CompiledTemplate>();
+/**
+ * Compiled blueprints keyed by template shape.
+ *
+ * Every `jsx(...)` call allocates a fresh `strings` array, so identity-based caching
+ * would never hit across calls — the shape key is what makes reuse possible. The key
+ * is computed once by the factory and carried on the result.
+ */
+const TEMPLATE_CACHE_BY_SHAPE = new Map<string, CompiledTemplate>();
 
 /** Returns compiled metadata for a template shape, compiling and caching on first use. */
 export function getCompiledTemplate(template: TemplateResultLike): CompiledTemplate {
-	const templateStrings = template.strings as unknown as readonly string[];
-	const cachedTemplate = TEMPLATE_CACHE.get(templateStrings);
+	const cachedTemplate = TEMPLATE_CACHE_BY_SHAPE.get(template.shapeKey);
 
 	if (cachedTemplate) {
 		return cachedTemplate;
 	}
 
-	const cacheKey = getTemplateCacheKey(template.strings);
-	const cachedTemplateByKey = TEMPLATE_CACHE_BY_KEY.get(cacheKey);
-
-	if (cachedTemplateByKey) {
-		TEMPLATE_CACHE.set(templateStrings, cachedTemplateByKey);
-		return cachedTemplateByKey;
-	}
-
 	const htmlParts: string[] = [];
 	const bindings = new Map<number, BindingDescriptor>();
-	const interpolationParts = getTemplateInterpolationParts(template.strings);
 
 	for (let index = 0; index < template.values.length; index += 1) {
-		const interpolationPart = interpolationParts[index];
+		const part = template.parts[index];
 
-		if (interpolationPart?.type === 'attribute') {
-			htmlParts.push(
-				interpolationPart.leading,
-				interpolationPart.whitespace,
-				`${ATTRIBUTE_BINDING_PREFIX}${index}="${interpolationPart.kind}:${interpolationPart.name}"`,
-			);
-			bindings.set(index, { kind: interpolationPart.kind, name: interpolationPart.name });
+		htmlParts.push(template.strings[index] ?? '');
+
+		if (part?.type === 'attribute') {
+			htmlParts.push(` ${ATTRIBUTE_BINDING_PREFIX}${index}="${part.kind}:${part.name}"`);
+			bindings.set(index, { kind: part.kind, name: part.name });
 			continue;
 		}
 
-		htmlParts.push(
-			interpolationPart && interpolationPart.type === 'child'
-				? interpolationPart.string
-				: (template.strings[index] ?? ''),
-			`<!--${CHILD_BINDING_START_PREFIX}${index}-->`,
-			`<!--${CHILD_BINDING_END_PREFIX}${index}-->`,
-		);
+		htmlParts.push(`<!--${CHILD_BINDING_START_PREFIX}${index}-->`, `<!--${CHILD_BINDING_END_PREFIX}${index}-->`);
 		bindings.set(index, { kind: 'child' });
 	}
 
@@ -70,8 +57,7 @@ export function getCompiledTemplate(template: TemplateResultLike): CompiledTempl
 		parts: collectTemplateParts(blueprint.content, bindings),
 	};
 
-	TEMPLATE_CACHE.set(templateStrings, compiledTemplate);
-	TEMPLATE_CACHE_BY_KEY.set(cacheKey, compiledTemplate);
+	TEMPLATE_CACHE_BY_SHAPE.set(template.shapeKey, compiledTemplate);
 	return compiledTemplate;
 }
 

--- a/packages/jsx/src/factory/jsx-factory.ts
+++ b/packages/jsx/src/factory/jsx-factory.ts
@@ -79,22 +79,14 @@ export function createJsxElement<Props extends object>(
 		appendBinding(strings, values, type, name, value);
 	});
 
-	if (voidElementNames.has(type)) {
-		strings[strings.length - 1] += '>';
-		return wrapKeyedValue(
-			createTemplateResult(
-				strings,
-				values,
-				type,
-				type.includes('-') ? (props as Record<string, unknown>) : undefined,
-			),
-			keyedValue,
-		);
-	}
-
 	strings[strings.length - 1] += '>';
-	appendElementChildren(strings, values, type, children, childSlotMode);
-	strings[strings.length - 1] += `</${type}>`;
+
+	// Void elements take neither children nor a closing tag; everything else is
+	// otherwise assembled identically.
+	if (!voidElementNames.has(type)) {
+		appendElementChildren(strings, values, type, children, childSlotMode);
+		strings[strings.length - 1] += `</${type}>`;
+	}
 
 	return wrapKeyedValue(
 		createTemplateResult(
@@ -179,124 +171,137 @@ function appendBinding(strings: string[], values: unknown[], elementName: string
 		return;
 	}
 
-	const bindingShapeValue = resolveReactiveSnapshot(value);
-	const normalizedName = name.startsWith('attr:') ? name.slice(5) : name;
+	const { sigil, attributeName } = resolveBindingSigil(elementName, name, value);
 
-	if (name.startsWith('on-native:')) {
-		strings[strings.length - 1] += ` @${name.slice('on-native:'.length)}=`;
-		values.push(value);
-		strings.push('');
-		return;
-	}
-
-	if (name.startsWith('on:')) {
-		const eventName = name.slice(3);
-		strings[strings.length - 1] += shouldDelegateEventBinding(eventName) ? ` !${eventName}=` : ` @${eventName}=`;
-		values.push(value);
-		strings.push('');
-		return;
-	}
-
-	if (name.startsWith('prop:')) {
-		strings[strings.length - 1] += ` .${name.slice(5)}=`;
-		values.push(value);
-		strings.push('');
-		return;
-	}
-
-	if (name.startsWith('attr:')) {
-		strings[strings.length - 1] += ` ${normalizedName}=`;
-		values.push(value);
-		strings.push('');
-		return;
-	}
-
-	if (typeof bindingShapeValue === 'boolean' && shouldUseBooleanAttributeBinding(normalizedName)) {
-		strings[strings.length - 1] += ` ?${normalizedName}=`;
-		values.push(value);
-		strings.push('');
-		return;
-	}
-
-	if (!shouldUseAttributeBindingByDefaultForElement(elementName, normalizedName)) {
-		strings[strings.length - 1] += ` .${normalizedName}=`;
-		values.push(value);
-		strings.push('');
-		return;
-	}
-
-	strings[strings.length - 1] += ` ${normalizedName}=`;
+	strings[strings.length - 1] += ` ${sigil}${attributeName}=`;
 	values.push(value);
 	strings.push('');
 }
 
+/**
+ * Resolves the authored prop name to the template sigil and attribute name that
+ * encode its binding kind.
+ *
+ * Explicit prefixes (`on-native:`, `on:`, `prop:`, `attr:`) select a kind directly.
+ * Unprefixed names fall back to per-element defaults: boolean attributes bind by
+ * presence, custom elements bind by property unless the name is a known attribute.
+ *
+ * @param elementName Lowercase tag name, including custom-element names with `-`.
+ * @param name Authored prop name, possibly carrying an explicit prefix.
+ * @param value Bound value, resolved through reactive wrappers to pick the shape.
+ */
+function resolveBindingSigil(
+	elementName: string,
+	name: string,
+	value: unknown,
+): { sigil: string; attributeName: string } {
+	if (name.startsWith('on-native:')) {
+		return { sigil: '@', attributeName: name.slice('on-native:'.length) };
+	}
+
+	if (name.startsWith('on:')) {
+		const eventName = name.slice(3);
+		return { sigil: shouldDelegateEventBinding(eventName) ? '!' : '@', attributeName: eventName };
+	}
+
+	if (name.startsWith('prop:')) {
+		return { sigil: '.', attributeName: name.slice(5) };
+	}
+
+	if (name.startsWith('attr:')) {
+		return { sigil: '', attributeName: name.slice(5) };
+	}
+
+	if (typeof resolveReactiveSnapshot(value) === 'boolean' && shouldUseBooleanAttributeBinding(name)) {
+		return { sigil: '?', attributeName: name };
+	}
+
+	if (!shouldUseAttributeBindingByDefaultForElement(elementName, name)) {
+		return { sigil: '.', attributeName: name };
+	}
+
+	return { sigil: '', attributeName: name };
+}
+
+/**
+ * Emits `children` into the template's value slots.
+ *
+ * `multiple` mode (from `jsxs`) gives each sibling its own slot so the renderer can
+ * reconcile them positionally; `single` mode collapses the whole subtree into one
+ * slot. Empty slots are dropped entirely rather than emitted as blanks.
+ */
 function appendChildren(
 	strings: string[],
 	values: unknown[],
 	children: JsxRenderable | undefined,
 	childSlotMode: ChildSlotMode,
 ): void {
-	if (children === undefined || children === null || children === false) {
-		return;
-	}
-
-	if (!isIterableJsxChild(children)) {
-		values.push(normalizeChildren(children));
+	for (const slot of toChildSlots(children, childSlotMode)) {
+		values.push(slot);
 		strings.push('');
-		return;
 	}
-
-	if (childSlotMode === 'multiple') {
-		for (const child of children) {
-			const normalizedChild = normalizeChildSlot(child as JsxRenderable);
-
-			if (normalizedChild === undefined) {
-				continue;
-			}
-
-			values.push(normalizedChild);
-			strings.push('');
-		}
-		return;
-	}
-
-	const flattenedChildren = flattenChildren(children);
-
-	if (flattenedChildren.length === 0) {
-		return;
-	}
-
-	values.push(flattenedChildren as JsxRenderable);
-	strings.push('');
 }
 
+/**
+ * Resolves `children` to the value a fragment should render as.
+ *
+ * Unlike {@link appendChildren}, a fragment has no element to hang slots on, so a
+ * lone surviving child renders as itself. That collapse deliberately does not apply
+ * to element children: an element keeps a one-entry list as a list so the renderer
+ * reconciles it positionally instead of treating it as a single child.
+ */
 function normalizeChildrenWithMode(children: JsxRenderable | undefined, childSlotMode: ChildSlotMode): JsxRenderable {
 	if (childSlotMode === 'multiple' && isIterableJsxChild(children)) {
-		const slots: JsxRenderable[] = [];
-
-		for (const child of children) {
-			const normalizedChild = normalizeChildSlot(child as JsxRenderable);
-
-			if (normalizedChild !== undefined) {
-				slots.push(normalizedChild);
-			}
-		}
+		const slots = toChildSlots(children, childSlotMode);
 
 		if (slots.length === 0) {
 			return '';
 		}
 
-		if (slots.length === 1) {
-			return slots[0];
+		return (slots.length === 1 ? slots[0] : slots) as JsxRenderable;
+	}
+
+	const slot = toChildSlot(children);
+
+	if (slot === undefined) {
+		return '';
+	}
+
+	return (Array.isArray(slot) && slot.length === 1 ? slot[0] : slot) as JsxRenderable;
+}
+
+/**
+ * Splits `children` into the discrete slot values for the given slot mode.
+ *
+ * `multiple` keeps siblings in separate slots; `single` folds the whole subtree into
+ * one. Both drop `undefined`, `null`, and `false`.
+ */
+function toChildSlots(children: JsxRenderable | undefined, childSlotMode: ChildSlotMode): unknown[] {
+	if (childSlotMode === 'multiple' && isIterableJsxChild(children)) {
+		const slots: unknown[] = [];
+
+		for (const child of children) {
+			const slot = toChildSlot(child as JsxRenderable);
+
+			if (slot !== undefined) {
+				slots.push(slot);
+			}
 		}
 
 		return slots;
 	}
 
-	return normalizeChildren(children);
+	const slot = toChildSlot(children);
+	return slot === undefined ? [] : [slot];
 }
 
-function normalizeChildSlot(child: JsxRenderable | undefined): JsxRenderable | undefined {
+/**
+ * Flattens one child into its slot value, or `undefined` when it renders nothing.
+ *
+ * Iterables stay arrays even when they hold a single entry, so the renderer keeps
+ * treating them as lists.
+ */
+function toChildSlot(child: JsxRenderable | undefined): unknown {
 	if (child === undefined || child === null || child === false) {
 		return undefined;
 	}
@@ -306,7 +311,7 @@ function normalizeChildSlot(child: JsxRenderable | undefined): JsxRenderable | u
 	}
 
 	const flattenedChildren = flattenChildren(child);
-	return flattenedChildren.length === 0 ? undefined : (flattenedChildren as JsxRenderable);
+	return flattenedChildren.length === 0 ? undefined : flattenedChildren;
 }
 
 function flattenChildren(children: JsxRenderable | undefined): unknown[] {
@@ -328,28 +333,6 @@ function appendFlattenedChildren(flattenedChildren: unknown[], children: JsxRend
 	}
 
 	flattenedChildren.push(children);
-}
-
-function normalizeChildren(children: JsxRenderable | undefined): JsxRenderable {
-	if (children === undefined || children === null || children === false) {
-		return '';
-	}
-
-	if (!isIterableJsxChild(children)) {
-		return children;
-	}
-
-	const flattenedChildren = flattenChildren(children);
-
-	if (flattenedChildren.length === 0) {
-		return '';
-	}
-
-	if (flattenedChildren.length === 1) {
-		return flattenedChildren[0] as JsxRenderable;
-	}
-
-	return flattenedChildren as JsxRenderable;
 }
 
 function createTemplateResult(

--- a/packages/jsx/src/factory/jsx-factory.ts
+++ b/packages/jsx/src/factory/jsx-factory.ts
@@ -1,4 +1,5 @@
 import { shouldDelegateEventBinding } from './event-binding-policy.ts';
+import { getTemplateShapeKey } from './template-shape.ts';
 import { forEachNormalizedAttribute } from './attribute-normalize.ts';
 import { shouldUseAttributeBindingByDefaultForElement, shouldUseBooleanAttributeBinding } from './binding-defaults.ts';
 import { isIterableJsxChild, resolveReactiveSnapshot } from '../types/renderable-guards.ts';
@@ -15,6 +16,7 @@ import type {
 	JsxPropsWithChildren,
 	JsxRenderable,
 	SlotJsxValue,
+	TemplatePartDescriptor,
 	TemplateResultLike,
 } from '../types/index.ts';
 
@@ -74,9 +76,10 @@ export function createJsxElement<Props extends object>(
 
 	const strings = [`<${type}`];
 	const values: unknown[] = [];
+	const parts: TemplatePartDescriptor[] = [];
 	const { children, key: _key, ...rawAttributes } = props as JsxPropsWithChildren & Record<string, unknown>;
 	forEachNormalizedAttribute(rawAttributes, (name, value) => {
-		appendBinding(strings, values, type, name, value);
+		appendBinding(strings, values, parts, type, name, value);
 	});
 
 	strings[strings.length - 1] += '>';
@@ -84,7 +87,7 @@ export function createJsxElement<Props extends object>(
 	// Void elements take neither children nor a closing tag; everything else is
 	// otherwise assembled identically.
 	if (!voidElementNames.has(type)) {
-		appendElementChildren(strings, values, type, children, childSlotMode);
+		appendElementChildren(strings, values, parts, type, children, childSlotMode);
 		strings[strings.length - 1] += `</${type}>`;
 	}
 
@@ -92,6 +95,7 @@ export function createJsxElement<Props extends object>(
 		createTemplateResult(
 			strings,
 			values,
+			parts,
 			type,
 			type.includes('-') ? (props as Record<string, unknown>) : undefined,
 		),
@@ -110,6 +114,7 @@ export function createMarkupNodeLike(outerHTML: string): JsxNodeLike {
 function appendElementChildren(
 	strings: string[],
 	values: unknown[],
+	parts: TemplatePartDescriptor[],
 	type: string,
 	children: JsxRenderable | undefined,
 	childSlotMode: ChildSlotMode,
@@ -122,11 +127,12 @@ function appendElementChildren(
 		}
 
 		values.push(createMarkupNodeLike(rawTextContent));
+		parts.push({ type: 'child' });
 		strings.push('');
 		return;
 	}
 
-	appendChildren(strings, values, children, childSlotMode);
+	appendChildren(strings, values, parts, children, childSlotMode);
 }
 
 function renderJsxRenderableToRawText(value: JsxRenderable | undefined): string {
@@ -166,21 +172,25 @@ function escapeRawTextElementText(value: string): string {
 	return value.replace(/<\/(?=script[\s/>])/gi, '<\\/');
 }
 
-function appendBinding(strings: string[], values: unknown[], elementName: string, name: string, value: unknown): void {
+function appendBinding(
+	strings: string[],
+	values: unknown[],
+	parts: TemplatePartDescriptor[],
+	elementName: string,
+	name: string,
+	value: unknown,
+): void {
 	if (value === undefined) {
 		return;
 	}
 
-	const { sigil, attributeName } = resolveBindingSigil(elementName, name, value);
-
-	strings[strings.length - 1] += ` ${sigil}${attributeName}=`;
+	parts.push(resolveBindingPart(elementName, name, value));
 	values.push(value);
 	strings.push('');
 }
 
 /**
- * Resolves the authored prop name to the template sigil and attribute name that
- * encode its binding kind.
+ * Resolves an authored prop name to the binding kind and attribute name it denotes.
  *
  * Explicit prefixes (`on-native:`, `on:`, `prop:`, `attr:`) select a kind directly.
  * Unprefixed names fall back to per-element defaults: boolean attributes bind by
@@ -190,37 +200,41 @@ function appendBinding(strings: string[], values: unknown[], elementName: string
  * @param name Authored prop name, possibly carrying an explicit prefix.
  * @param value Bound value, resolved through reactive wrappers to pick the shape.
  */
-function resolveBindingSigil(
+function resolveBindingPart(
 	elementName: string,
 	name: string,
 	value: unknown,
-): { sigil: string; attributeName: string } {
+): Extract<TemplatePartDescriptor, { type: 'attribute' }> {
 	if (name.startsWith('on-native:')) {
-		return { sigil: '@', attributeName: name.slice('on-native:'.length) };
+		return { kind: 'native-event', name: name.slice('on-native:'.length), type: 'attribute' };
 	}
 
 	if (name.startsWith('on:')) {
 		const eventName = name.slice(3);
-		return { sigil: shouldDelegateEventBinding(eventName) ? '!' : '@', attributeName: eventName };
+		return {
+			kind: shouldDelegateEventBinding(eventName) ? 'event' : 'native-event',
+			name: eventName,
+			type: 'attribute',
+		};
 	}
 
 	if (name.startsWith('prop:')) {
-		return { sigil: '.', attributeName: name.slice(5) };
+		return { kind: 'prop', name: name.slice(5), type: 'attribute' };
 	}
 
 	if (name.startsWith('attr:')) {
-		return { sigil: '', attributeName: name.slice(5) };
+		return { kind: 'attr', name: name.slice(5), type: 'attribute' };
 	}
 
 	if (typeof resolveReactiveSnapshot(value) === 'boolean' && shouldUseBooleanAttributeBinding(name)) {
-		return { sigil: '?', attributeName: name };
+		return { kind: 'bool', name, type: 'attribute' };
 	}
 
 	if (!shouldUseAttributeBindingByDefaultForElement(elementName, name)) {
-		return { sigil: '.', attributeName: name };
+		return { kind: 'prop', name, type: 'attribute' };
 	}
 
-	return { sigil: '', attributeName: name };
+	return { kind: 'attr', name, type: 'attribute' };
 }
 
 /**
@@ -233,11 +247,13 @@ function resolveBindingSigil(
 function appendChildren(
 	strings: string[],
 	values: unknown[],
+	parts: TemplatePartDescriptor[],
 	children: JsxRenderable | undefined,
 	childSlotMode: ChildSlotMode,
 ): void {
 	for (const slot of toChildSlots(children, childSlotMode)) {
 		values.push(slot);
+		parts.push({ type: 'child' });
 		strings.push('');
 	}
 }
@@ -338,14 +354,17 @@ function appendFlattenedChildren(flattenedChildren: unknown[], children: JsxRend
 function createTemplateResult(
 	strings: string[],
 	values: unknown[],
+	parts: TemplatePartDescriptor[],
 	rootLocalName: string,
 	ssrIntrinsicProps?: Readonly<Record<string, unknown>>,
 ): TemplateResultLike {
 	return {
 		[RADIANT_TEMPLATE_RESULT_FIELD]: RADIANT_TEMPLATE_RESULT,
+		parts,
 		rootLocalName,
+		shapeKey: getTemplateShapeKey(strings, parts),
 		ssrIntrinsicProps,
-		strings: toTemplateStrings(strings),
+		strings,
 		values,
 	};
 }
@@ -368,13 +387,4 @@ function createSlotJsxValue(props: JsxPropsWithChildren & { name?: unknown }): S
 		name: typeof props.name === 'string' && props.name !== '' ? props.name : undefined,
 		[SLOT_JSX_VALUE_SYMBOL]: true,
 	};
-}
-
-function toTemplateStrings(strings: string[]): TemplateStringsArray {
-	const templateStrings = [...strings] as unknown as TemplateStringsArray;
-	Object.defineProperty(templateStrings, 'raw', {
-		value: [...strings],
-		writable: false,
-	});
-	return templateStrings;
 }

--- a/packages/jsx/src/factory/template-shape.ts
+++ b/packages/jsx/src/factory/template-shape.ts
@@ -1,39 +1,26 @@
-/** Kinds of dynamic bindings that the JSX runtime can encode into templates. */
-export type BindingKind = 'attr' | 'bool' | 'event' | 'native-event' | 'prop';
+import type { BindingKind, TemplatePartDescriptor } from '../types/renderable-types.ts';
 
-/**
- * Cached metadata describing how one interpolation slot should be interpreted
- * during SSR, hydration binding collection, or DOM template compilation.
- */
-export type TemplateInterpolationPart =
-	| {
-			string: string;
-			type: 'child';
-	  }
-	| {
-			kind: BindingKind;
-			leading: string;
-			name: string;
-			prefix: string;
-			whitespace: string;
-			type: 'attribute';
-	  };
+export type { BindingKind, TemplatePartDescriptor };
 
 /**
  * Matches a static template segment that ends with an attribute-like binding
  * placeholder such as ` class=`, ` ?hidden=`, ` @focus=`, ` !click=`, or ` .value=`.
+ *
+ * @remarks Only the transported wire format still embeds binding syntax in its
+ * strings. Templates built by the JSX factory carry their parts explicitly, so this
+ * pattern is not on any render path — it runs once per payload in
+ * {@link deriveLegacyTemplateShape}.
  */
 export const ATTRIBUTE_BINDING_PATTERN = /^(.*?)(\s+)([@.?!]?)([^\s"'<>/=`]+)=$/s;
 
-export type TemplateShape = {
-	/** Parsed interpolation slots for one tagged-template literal shape. */
-	interpolationParts: readonly TemplateInterpolationPart[];
+/** Static template shape recovered from a transported payload. */
+export type LegacyTemplateShape = {
+	parts: TemplatePartDescriptor[];
+	strings: string[];
 };
 
-const TEMPLATE_SHAPE_CACHE = new WeakMap<readonly string[], TemplateShape>();
-const TEMPLATE_SHAPE_CACHE_BY_KEY = new Map<string, TemplateShape>();
-
-/** Resolves the logical binding kind from the runtime prefix used in JSX template strings.
+/**
+ * Resolves the logical binding kind from the sigil used in transported template strings.
  *
  * @param prefix One of `''`, `'?'`, `'!'`, `'@'`, or `'.'`.
  * @returns The binding kind used by serializers, hydration, and DOM compilation.
@@ -53,65 +40,45 @@ export function getBindingKind(prefix: string): BindingKind {
 	}
 }
 
-/** Derives a stable string cache key from a `TemplateStringsArray`. */
-export function getTemplateCacheKey(strings: readonly string[]): string {
-	return strings.map((part) => `${part.length}:${part}`).join('|');
+/** Derives a stable identity for a template shape from its strings and parts. */
+export function getTemplateShapeKey(strings: readonly string[], parts: readonly TemplatePartDescriptor[]): string {
+	// Length-prefixing keeps the key unambiguous for strings containing the separator.
+	const stringKey = strings.map((part) => `${part.length}:${part}`).join('|');
+	const partKey = parts.map((part) => (part.type === 'child' ? 'c' : `${part.kind}:${part.name}`)).join(',');
+
+	return `${stringKey}${partKey}`;
 }
 
-/** Returns cached interpolation metadata for a template shape, parsing on first use. */
-export function getTemplateShape(strings: readonly string[]): TemplateShape {
-	const cachedShape = TEMPLATE_SHAPE_CACHE.get(strings);
-
-	if (cachedShape) {
-		return cachedShape;
-	}
-
-	const cacheKey = getTemplateCacheKey(strings);
-	const cachedShapeByKey = TEMPLATE_SHAPE_CACHE_BY_KEY.get(cacheKey);
-
-	if (cachedShapeByKey) {
-		TEMPLATE_SHAPE_CACHE.set(strings, cachedShapeByKey);
-		return cachedShapeByKey;
-	}
-
-	const interpolationParts = parseTemplateInterpolationParts(strings);
-	const shape: TemplateShape = { interpolationParts };
-
-	TEMPLATE_SHAPE_CACHE.set(strings, shape);
-	TEMPLATE_SHAPE_CACHE_BY_KEY.set(cacheKey, shape);
-	return shape;
-}
-
-/** Convenience accessor for interpolation parts on a template shape. */
-export function getTemplateInterpolationParts(strings: readonly string[]): readonly TemplateInterpolationPart[] {
-	return getTemplateShape(strings).interpolationParts;
-}
-
-function parseTemplateInterpolationParts(strings: readonly string[]): readonly TemplateInterpolationPart[] {
-	const parts: TemplateInterpolationPart[] = [];
+/**
+ * Splits a transported template's sigil-bearing strings into plain static chunks
+ * plus explicit part descriptors.
+ *
+ * This is the compatibility bridge for the wire format: it produces exactly what
+ * the JSX factory would have emitted directly, so everything downstream sees one
+ * representation.
+ *
+ * @param strings Wire-format strings, where an attribute slot's chunk ends in `name=`.
+ */
+export function deriveLegacyTemplateShape(strings: readonly string[]): LegacyTemplateShape {
+	const staticStrings: string[] = [];
+	const parts: TemplatePartDescriptor[] = [];
 
 	for (let index = 0; index < strings.length - 1; index += 1) {
 		const stringPart = strings[index] ?? '';
 		const attributeBinding = ATTRIBUTE_BINDING_PATTERN.exec(stringPart);
 
 		if (!attributeBinding) {
-			parts.push({
-				string: stringPart,
-				type: 'child',
-			});
+			staticStrings.push(stringPart);
+			parts.push({ type: 'child' });
 			continue;
 		}
 
-		const [, leading = '', whitespace = ' ', prefix = '', name = ''] = attributeBinding;
-		parts.push({
-			kind: getBindingKind(prefix),
-			leading,
-			name,
-			prefix,
-			whitespace,
-			type: 'attribute',
-		});
+		const [, leading = '', , prefix = '', name = ''] = attributeBinding;
+		staticStrings.push(leading);
+		parts.push({ kind: getBindingKind(prefix), name, type: 'attribute' });
 	}
 
-	return parts;
+	staticStrings.push(strings[strings.length - 1] ?? '');
+
+	return { parts, strings: staticStrings };
 }

--- a/packages/jsx/src/hydration/hydration-bindings.ts
+++ b/packages/jsx/src/hydration/hydration-bindings.ts
@@ -14,7 +14,7 @@
 import { isIterableRenderable, isTemplateResultLike } from '../types/renderable-guards.ts';
 import type { JsxRenderable, TemplateResultLike } from '../types/index.ts';
 import { shouldSkipHydrationSubtree } from './hydration-subtree-policy.ts';
-import { getTemplateInterpolationParts, type BindingKind } from '../factory/template-shape.ts';
+import type { BindingKind } from '../types/renderable-types.ts';
 
 /** Attribute prefix used for emitted SSR hydration markers. */
 export const ATTRIBUTE_BINDING_PREFIX = 'data-radiant-jsx-bind-';
@@ -74,13 +74,10 @@ export function collectTemplateAttributeMarkerIndices(
 	startIndex: number,
 ): TemplateAttributeMarkerIndices {
 	const indices = new Map<number, number>();
-	const interpolationParts = getTemplateInterpolationParts(template.strings);
 	const state = { nextBindingIndex: startIndex };
 
 	for (let index = 0; index < template.values.length; index += 1) {
-		const interpolationPart = interpolationParts[index];
-
-		if (interpolationPart?.type === 'attribute') {
+		if (template.parts[index]?.type === 'attribute') {
 			indices.set(index, takeNextHydrationMarkerIndex(state));
 		}
 	}
@@ -218,24 +215,23 @@ function collectTemplateBindings(
 		return;
 	}
 
-	const interpolationParts = getTemplateInterpolationParts(template.strings);
 	const markerIndices = collectTemplateAttributeMarkerIndices(template, state.nextIndex);
 	state.nextIndex = markerIndices.nextIndex;
 
 	for (const [valueIndex, globalIndex] of markerIndices.indices) {
-		const interpolationPart = interpolationParts[valueIndex];
+		const part = template.parts[valueIndex];
 
-		if (interpolationPart?.type === 'attribute') {
+		if (part?.type === 'attribute') {
 			bindings.set(globalIndex, {
-				kind: interpolationPart.kind,
-				name: interpolationPart.name,
+				kind: part.kind,
+				name: part.name,
 				value: template.values[valueIndex],
 			});
 		}
 	}
 
 	for (let index = 0; index < template.values.length; index += 1) {
-		if (interpolationParts[index]?.type !== 'attribute') {
+		if (template.parts[index]?.type !== 'attribute') {
 			collectValueBindings(template.values[index] as JsxRenderable, bindings, state, options);
 		}
 	}

--- a/packages/jsx/src/ssr/serialize-renderable.ts
+++ b/packages/jsx/src/ssr/serialize-renderable.ts
@@ -2,20 +2,17 @@ import {
 	isIterableRenderable,
 	isJsxNodeLike,
 	isKeyedJsxValue,
-	isSerializableTemplateResultLike,
 	isSignalLikeValue,
 	isSubscribableJsxValue,
 	isTemplateResultLike,
 	mayEmitOrParseRawOuterHtml,
 	resolveReactiveSnapshot,
-	toTemplateResultLike,
 } from '../types/renderable-guards.ts';
 import {
 	resolveHydrationMarkerAttributeName,
 	serializeBindingDescriptor,
 	takeNextHydrationMarkerIndex,
 } from '../hydration/hydration-bindings.ts';
-import { getTemplateInterpolationParts } from '../factory/template-shape.ts';
 import { isClientOnlyBinding } from '../hydration/hydration-marker-policy.ts';
 import { serializeStyleSnapshot } from '../factory/attribute-normalize.ts';
 import { escapeAttribute, escapeHtml } from './html-escape.ts';
@@ -67,8 +64,8 @@ export function serializeRenderable(value: JsxRenderable | undefined, options: S
 		return '';
 	}
 
-	if (isTemplateResultLike(value) || isSerializableTemplateResultLike(value)) {
-		return serializeTemplateResult(toTemplateResultLike(value), options);
+	if (isTemplateResultLike(value)) {
+		return serializeTemplateResult(value, options);
 	}
 
 	if (isJsxNodeLike(value)) {
@@ -97,38 +94,33 @@ function serializeTemplateResult(template: TemplateResultLike, options: Serializ
 		}
 	}
 
-	const interpolationParts = getTemplateInterpolationParts(template.strings);
 	const hydrationState = options.hydrationBindingState;
 	let html = '';
 
 	for (let index = 0; index < template.values.length; index += 1) {
-		const interpolationPart = interpolationParts[index];
+		const part = template.parts[index];
 		const childValue = resolveReactiveSnapshot(template.values[index]);
 
-		if (!interpolationPart || interpolationPart.type === 'child') {
-			html +=
-				interpolationPart && interpolationPart.type === 'child'
-					? interpolationPart.string
-					: (template.strings[index] ?? '');
+		html += template.strings[index] ?? '';
+
+		if (!part || part.type === 'child') {
 			html += serializeRenderable(childValue as JsxRenderable, options);
 			continue;
 		}
 
-		const bindingKind = interpolationPart.kind;
 		const bindingIndex = hydrationState ? takeNextHydrationMarkerIndex(hydrationState) : 0;
-		html += interpolationPart.leading;
 
 		if (options.mode === 'hydrate' && hydrationState) {
-			html += `${interpolationPart.whitespace}${resolveHydrationMarkerAttributeName(bindingIndex)}="${serializeBindingDescriptor(bindingKind, interpolationPart.name)}"`;
+			html += ` ${resolveHydrationMarkerAttributeName(bindingIndex)}="${serializeBindingDescriptor(part.kind, part.name)}"`;
 		}
 
-		if (isClientOnlyBinding(bindingKind)) {
+		if (isClientOnlyBinding(part.kind)) {
 			continue;
 		}
 
-		if (interpolationPart.prefix === '?') {
+		if (part.kind === 'bool') {
 			if (childValue) {
-				html += `${interpolationPart.whitespace}${interpolationPart.name}`;
+				html += ` ${part.name}`;
 			}
 			continue;
 		}
@@ -138,8 +130,8 @@ function serializeTemplateResult(template: TemplateResultLike, options: Serializ
 		}
 
 		const attributeValue =
-			interpolationPart.name.toLowerCase() === 'style' ? serializeStyleSnapshot(childValue) : String(childValue);
-		html += `${interpolationPart.whitespace}${interpolationPart.name}="${escapeAttribute(attributeValue)}"`;
+			part.name.toLowerCase() === 'style' ? serializeStyleSnapshot(childValue) : String(childValue);
+		html += ` ${part.name}="${escapeAttribute(attributeValue)}"`;
 	}
 
 	html += template.strings[template.strings.length - 1] ?? '';

--- a/packages/jsx/src/types/renderable-guards.ts
+++ b/packages/jsx/src/types/renderable-guards.ts
@@ -1,3 +1,4 @@
+import { deriveLegacyTemplateShape, getTemplateShapeKey } from '../factory/template-shape.ts';
 import {
 	KEYED_VALUE_SYMBOL,
 	RADIANT_MARKUP_NODE_SYMBOL,
@@ -18,9 +19,13 @@ import type {
 /**
  * Type guard that narrows `value` to {@link TemplateResultLike}.
  *
+ * @remarks Checks `parts` as well as `strings` and `values`, so a partially-formed
+ * object is rejected here and rendered as text rather than reaching the template
+ * compiler, which would fault on the missing metadata. Build transported payloads
+ * with {@link toTemplateResultLike} to satisfy the full contract.
+ *
  * @param value Value to inspect.
- * @returns `true` when `value` is a branded Radiant template result with array
- *   `strings` and `values` fields.
+ * @returns `true` when `value` is a branded Radiant template result.
  */
 export function isTemplateResultLike(value: unknown): value is TemplateResultLike {
 	return (
@@ -28,7 +33,8 @@ export function isTemplateResultLike(value: unknown): value is TemplateResultLik
 		value !== null &&
 		(value as { ['_$rType$']?: unknown })['_$rType$'] === RADIANT_TEMPLATE_RESULT &&
 		Array.isArray((value as Partial<TemplateResultLike>).strings) &&
-		Array.isArray((value as Partial<TemplateResultLike>).values)
+		Array.isArray((value as Partial<TemplateResultLike>).values) &&
+		Array.isArray((value as Partial<TemplateResultLike>).parts)
 	);
 }
 
@@ -146,21 +152,30 @@ export function isSerializableTemplateResultLike(value: unknown): value is Seria
 }
 
 /**
- * Normalizes transported template payloads into the canonical runtime template result shape.
+ * Normalizes a transported template payload into the canonical runtime shape.
+ *
+ * This is the only place that accepts binding syntax inside `strings`. Nothing
+ * renders a bare `{ strings, values }` object implicitly — call this at the wire
+ * boundary to brand it first. Requiring the explicit step is what keeps an ordinary
+ * application object that happens to have a `strings` array off the raw-HTML path.
  *
  * @param value Template payload to normalize.
- * @returns A branded {@link TemplateResultLike} with a concrete `values` array.
+ * @returns A branded {@link TemplateResultLike} with explicit parts and a shape key.
  */
 export function toTemplateResultLike(value: SerializableTemplateResultLike | TemplateResultLike): TemplateResultLike {
 	if (isTemplateResultLike(value)) {
 		return value;
 	}
 
+	const { parts, strings } = deriveLegacyTemplateShape(value.strings);
+
 	return {
 		[RADIANT_TEMPLATE_RESULT_FIELD]: RADIANT_TEMPLATE_RESULT,
+		parts,
 		rootLocalName: value.rootLocalName,
+		shapeKey: getTemplateShapeKey(strings, parts),
 		ssrIntrinsicProps: value.ssrIntrinsicProps,
-		strings: value.strings as TemplateStringsArray,
+		strings,
 		values: value.values ?? [],
 	};
 }

--- a/packages/jsx/src/types/renderable-types.ts
+++ b/packages/jsx/src/types/renderable-types.ts
@@ -51,20 +51,50 @@ export interface JsxNodeLike {
 	readonly [RADIANT_MARKUP_NODE_SYMBOL]?: true;
 }
 
+/** Kinds of dynamic bindings that the JSX runtime can encode into templates. */
+export type BindingKind = 'attr' | 'bool' | 'event' | 'native-event' | 'prop';
+
+/**
+ * Describes what one interpolation slot binds to.
+ *
+ * The factory knows each slot's kind at construction time and records it here, so
+ * the DOM compiler, the SSR serializer, and hydration all read the same structured
+ * metadata instead of re-deriving it from the surrounding markup.
+ */
+export type TemplatePartDescriptor =
+	| { readonly type: 'child' }
+	| {
+			readonly type: 'attribute';
+			readonly kind: BindingKind;
+			readonly name: string;
+	  };
+
 /**
  * Radiant template result produced by the JSX runtime.
+ *
+ * `strings` holds plain static HTML chunks and carries no binding syntax: every
+ * slot's kind and name lives in the parallel `parts` array, where `parts[i]`
+ * describes `values[i]` and `strings[i]` is the markup preceding it.
  */
 export interface TemplateResultLike {
 	readonly ['_$rType$']: typeof RADIANT_TEMPLATE_RESULT;
 	readonly rootLocalName?: string;
 	readonly ssrIntrinsicProps?: Readonly<Record<string, unknown>>;
-	readonly strings: TemplateStringsArray;
+	readonly parts: readonly TemplatePartDescriptor[];
+	/** Identity of the static template shape, used to reuse compiled blueprints. */
+	readonly shapeKey: string;
+	readonly strings: readonly string[];
 	readonly values: readonly unknown[];
 }
 
 /**
  * Template payload shape that can be transported across process or integration
  * boundaries and later rehydrated into a standard template result.
+ *
+ * This is the wire format, and it is deliberately the *only* place that still
+ * accepts binding syntax inside `strings` (` class=`, ` ?hidden=`, ` .value=`,
+ * ` @focus=`, ` !click=`). Pass it through `toTemplateResultLike(...)` to convert
+ * it into a branded {@link TemplateResultLike}; nothing renders it implicitly.
  */
 export interface SerializableTemplateResultLike {
 	readonly rootLocalName?: string;
@@ -166,7 +196,6 @@ export type JsxRenderable =
 	| SignalLike
 	| SlotJsxValue
 	| SubscribableJsxValue
-	| SerializableTemplateResultLike
 	| TemplateResultLike
 	| Iterable<JsxRenderable>;
 

--- a/packages/jsx/test/dom-render-reconciliation.e2e.test.tsx
+++ b/packages/jsx/test/dom-render-reconciliation.e2e.test.tsx
@@ -30,15 +30,6 @@ class BooleanPropertyElement extends HTMLElement {
 
 customElements.define(booleanPropertyTagName, BooleanPropertyElement);
 
-function toTemplateStrings(strings: string[]): TemplateStringsArray {
-	const templateStrings = [...strings] as unknown as TemplateStringsArray;
-	Object.defineProperty(templateStrings, 'raw', {
-		value: [...strings],
-		writable: false,
-	});
-	return templateStrings;
-}
-
 describe('Radiant JSX DOM reconciliation behavior', () => {
 	beforeEach(() => {
 		document.body.innerHTML = '';
@@ -432,16 +423,17 @@ describe('Radiant JSX DOM reconciliation behavior', () => {
 	});
 
 	test('manual template results without root metadata do not poison later intrinsic SVG mounts', async () => {
-		const [{ jsx }, { createRoot }] = await Promise.all([loadJsxRuntime(), loadJsxModule()]);
+		const [{ jsx, toTemplateResultLike }, { createRoot }] = await Promise.all([loadJsxRuntime(), loadJsxModule()]);
 		const primeContainer = document.createElement('div');
 		const primeRoot = createRoot(primeContainer);
 		const verifyContainer = document.createElement('div');
 		const verifyRoot = createRoot(verifyContainer);
-		const manualTemplate = {
-			['_$rType$']: 1 as const,
-			strings: toTemplateStrings(['<linearGradient id=', '></linearGradient>']),
+		// Built through the wire-format adapter: no rootLocalName, so the renderer
+		// has to infer the namespace from context rather than from root metadata.
+		const manualTemplate = toTemplateResultLike({
+			strings: ['<linearGradient id=', '></linearGradient>'],
 			values: ['gradient'],
-		};
+		});
 
 		primeRoot.render(
 			jsx('svg', {

--- a/packages/jsx/test/renderable-guards.test.tsx
+++ b/packages/jsx/test/renderable-guards.test.tsx
@@ -18,7 +18,9 @@ import {
 function createTemplateResult(): import('../src/types/index.ts').TemplateResultLike {
 	return {
 		[RADIANT_TEMPLATE_RESULT_FIELD]: RADIANT_TEMPLATE_RESULT,
-		strings: ['<p>', '</p>'] as unknown as TemplateStringsArray,
+		parts: [{ type: 'child' }],
+		shapeKey: '3:<p>|4:</p>c',
+		strings: ['<p>', '</p>'],
 		values: ['hello'],
 	};
 }

--- a/packages/jsx/test/runtime.test.tsx
+++ b/packages/jsx/test/runtime.test.tsx
@@ -68,7 +68,8 @@ describe('Radiant JSX runtime', () => {
 		});
 
 		expectTemplateResultLike(result);
-		expect(Array.from(result.strings)).toEqual(['<div class=', '>', '</div>']);
+		expect(Array.from(result.strings)).toEqual(['<div', '>', '</div>']);
+		expect(result.parts).toEqual([{ kind: 'attr', name: 'class', type: 'attribute' }, { type: 'child' }]);
 		expect(result.values).toEqual(['counter', 'Hello JSX']);
 	});
 
@@ -155,7 +156,12 @@ describe('Radiant JSX runtime', () => {
 		const result = jsx(Card, { title: 'Overview', children: jsx('p', { children: 'Body copy' }) });
 
 		expectTemplateResultLike(result);
-		expect(Array.from(result.strings)).toEqual(['<article class=', '>', '', '</article>']);
+		expect(Array.from(result.strings)).toEqual(['<article', '>', '', '</article>']);
+		expect(result.parts).toEqual([
+			{ kind: 'attr', name: 'class', type: 'attribute' },
+			{ type: 'child' },
+			{ type: 'child' },
+		]);
 		expect(result.values[0]).toBe('card');
 		expectTemplateResultLike(result.values[1]);
 		expectTemplateResultLike(result.values[2]);
@@ -183,7 +189,7 @@ describe('Radiant JSX runtime', () => {
 		expectTemplateResultLike(result);
 		expect(Array.from(result.strings)).toEqual(['<section>', '</section>']);
 		expectTemplateResultLike(result.values[0]);
-		expect(Array.from(result.values[0].strings)).toEqual(['<label class=', '>', '', '</label>']);
+		expect(Array.from(result.values[0].strings)).toEqual(['<label', '>', '', '</label>']);
 		expect(result.values[0].values[0]).toBe('field');
 		expectTemplateResultLike(result.values[0].values[1]);
 		expectTemplateResultLike(result.values[0].values[2]);
@@ -198,7 +204,8 @@ describe('Radiant JSX runtime', () => {
 		});
 
 		expectTemplateResultLike(result);
-		expect(Array.from(result.strings)).toEqual(['<div class=', '>', '</div>']);
+		expect(Array.from(result.strings)).toEqual(['<div', '>', '</div>']);
+		expect(result.parts).toEqual([{ kind: 'attr', name: 'class', type: 'attribute' }, { type: 'child' }]);
 		expect(result.values).toEqual(['panel stack wide surface active nested 2 0', 'Ready']);
 	});
 
@@ -211,7 +218,8 @@ describe('Radiant JSX runtime', () => {
 		});
 
 		expectTemplateResultLike(result);
-		expect(Array.from(result.strings)).toEqual(['<button !click=', '>', '</button>']);
+		expect(Array.from(result.strings)).toEqual(['<button', '>', '</button>']);
+		expect(result.parts[0]).toEqual({ kind: 'event', name: 'click', type: 'attribute' });
 		expect(result.values).toEqual([handleClick, 'Increment']);
 	});
 
@@ -224,7 +232,8 @@ describe('Radiant JSX runtime', () => {
 		});
 
 		expectTemplateResultLike(result);
-		expect(Array.from(result.strings)).toEqual(['<button @change=', '>', '</button>']);
+		expect(Array.from(result.strings)).toEqual(['<button', '>', '</button>']);
+		expect(result.parts[0]).toEqual({ kind: 'native-event', name: 'change', type: 'attribute' });
 		expect(result.values).toEqual([handleChange, 'Save']);
 	});
 
@@ -237,7 +246,8 @@ describe('Radiant JSX runtime', () => {
 		});
 
 		expectTemplateResultLike(result);
-		expect(Array.from(result.strings)).toEqual(['<button @click=', '>', '</button>']);
+		expect(Array.from(result.strings)).toEqual(['<button', '>', '</button>']);
+		expect(result.parts[0]).toEqual({ kind: 'native-event', name: 'click', type: 'attribute' });
 		expect(result.values).toEqual([handleClick, 'Increment']);
 	});
 
@@ -249,7 +259,8 @@ describe('Radiant JSX runtime', () => {
 		});
 
 		expectTemplateResultLike(result);
-		expect(Array.from(result.strings)).toEqual(['<property-receiver .payload=', '></property-receiver>']);
+		expect(Array.from(result.strings)).toEqual(['<property-receiver', '></property-receiver>']);
+		expect(result.parts).toEqual([{ kind: 'prop', name: 'payload', type: 'attribute' }]);
 		expect(result.values).toEqual([payload]);
 	});
 
@@ -262,7 +273,11 @@ describe('Radiant JSX runtime', () => {
 		});
 
 		expectTemplateResultLike(result);
-		expect(Array.from(result.strings)).toEqual(['<property-receiver .items=', ' id=', '></property-receiver>']);
+		expect(Array.from(result.strings)).toEqual(['<property-receiver', '', '></property-receiver>']);
+		expect(result.parts).toEqual([
+			{ kind: 'prop', name: 'items', type: 'attribute' },
+			{ kind: 'attr', name: 'id', type: 'attribute' },
+		]);
 		expect(result.values).toEqual([items, 'receiver']);
 	});
 
@@ -273,7 +288,8 @@ describe('Radiant JSX runtime', () => {
 		});
 
 		expectTemplateResultLike(result);
-		expect(Array.from(result.strings)).toEqual(['<property-receiver value=', '></property-receiver>']);
+		expect(Array.from(result.strings)).toEqual(['<property-receiver', '></property-receiver>']);
+		expect(result.parts).toEqual([{ kind: 'attr', name: 'value', type: 'attribute' }]);
 		expect(result.values).toEqual(['draft']);
 	});
 
@@ -285,11 +301,12 @@ describe('Radiant JSX runtime', () => {
 		});
 
 		expectTemplateResultLike(result);
-		expect(Array.from(result.strings)).toEqual(['<button type=', '>', '</button>']);
+		expect(Array.from(result.strings)).toEqual(['<button', '>', '</button>']);
+		expect(result.parts).toEqual([{ kind: 'attr', name: 'type', type: 'attribute' }, { type: 'child' }]);
 		expect(result.values).toEqual(['button', 'Save']);
 	});
 
-	test('boolean, data, and aria bindings encode the expected template syntax', async () => {
+	test('boolean, data, and aria bindings resolve to the expected binding kinds', async () => {
 		const [{ jsx }] = await Promise.all([loadJsxRuntime()]);
 		const result = jsx('button', {
 			hidden: true,
@@ -299,12 +316,12 @@ describe('Radiant JSX runtime', () => {
 		});
 
 		expectTemplateResultLike(result);
-		expect(Array.from(result.strings)).toEqual([
-			'<button ?hidden=',
-			' data-tid=',
-			' aria-label=',
-			'>',
-			'</button>',
+		expect(Array.from(result.strings)).toEqual(['<button', '', '', '>', '</button>']);
+		expect(result.parts).toEqual([
+			{ kind: 'bool', name: 'hidden', type: 'attribute' },
+			{ kind: 'attr', name: 'data-tid', type: 'attribute' },
+			{ kind: 'attr', name: 'aria-label', type: 'attribute' },
+			{ type: 'child' },
 		]);
 		expect(result.values).toEqual([true, 'counter', 'Decrement', '-']);
 	});

--- a/packages/jsx/test/runtime.test.tsx
+++ b/packages/jsx/test/runtime.test.tsx
@@ -114,6 +114,19 @@ describe('Radiant JSX runtime', () => {
 		expect(result.values[0] as unknown[]).toHaveLength(1);
 	});
 
+	test('jsx collapses a singleton iterable inside a fragment to its only child', async () => {
+		const [{ Fragment, jsx }] = await Promise.all([loadJsxRuntime()]);
+		const single = jsx(Fragment, { children: ['alpha'] });
+
+		// A fragment has no element to hang slots on, so a lone child renders as
+		// itself — the opposite of the element case above, which keeps the list.
+		expect(single).toBe('alpha');
+
+		const many = jsx(Fragment, { children: ['alpha', 'beta'] });
+
+		expect(many).toEqual(['alpha', 'beta']);
+	});
+
 	test('jsx drops true children the same way SSR does', async () => {
 		const [{ jsx }] = await Promise.all([loadJsxRuntime()]);
 		const result = jsx('div', {

--- a/packages/jsx/test/server-render.test.tsx
+++ b/packages/jsx/test/server-render.test.tsx
@@ -85,27 +85,43 @@ describe('Radiant JSX server render', () => {
 	});
 
 	test('serializes transported template payloads without leaking object coercions', async () => {
-		const [{ jsx }, { renderToString }] = await Promise.all([loadJsxRuntime(), loadServerRender()]);
+		const [{ jsx, toTemplateResultLike }, { renderToString }] = await Promise.all([
+			loadJsxRuntime(),
+			loadServerRender(),
+		]);
 		const deferredTemplate = {
 			strings: ['<div class=', ' ?data-ready=', '>', '</div>'],
 			values: ['shell-stack', true, ['Hello ', jsx('strong', { children: 'transport' })]],
 		} as const;
 
-		expect(renderToString(deferredTemplate as unknown as import('../src/jsx-runtime.ts').JsxRenderable)).toBe(
+		expect(renderToString(toTemplateResultLike(deferredTemplate))).toBe(
 			'<div class="shell-stack" data-ready>Hello <strong>transport</strong></div>',
 		);
 	});
 
 	test('escapes dynamic values in transported templates while treating strings as trusted HTML', async () => {
-		const { renderToString } = await loadServerRender();
+		const [{ toTemplateResultLike }, { renderToString }] = await Promise.all([
+			loadJsxRuntime(),
+			loadServerRender(),
+		]);
 		const deferredTemplate = {
 			strings: ['<div>', '</div><img src=x onerror=alert(1)//'],
 			values: ['Hello <script>'],
 		} as const;
 
-		expect(renderToString(deferredTemplate as unknown as import('../src/jsx-runtime.ts').JsxRenderable)).toBe(
+		expect(renderToString(toTemplateResultLike(deferredTemplate))).toBe(
 			'<div>Hello &lt;script&gt;</div><img src=x onerror=alert(1)//',
 		);
+	});
+
+	test('does not treat an unbranded object with a strings array as a template', async () => {
+		const [{ jsx }, { renderToString }] = await Promise.all([loadJsxRuntime(), loadServerRender()]);
+
+		// An application object that merely happens to carry `strings` must never
+		// reach the raw-HTML path; branding via toTemplateResultLike is required.
+		const lookalike = { strings: ['<img src=x onerror=alert(1)//'], values: [] };
+
+		expect(renderToString(jsx('div', { children: lookalike }))).not.toContain('<img');
 	});
 
 	test('escapes unbranded outerHTML node-like objects as text', async () => {

--- a/packages/radiant/src/core/slot-projection-runtime.ts
+++ b/packages/radiant/src/core/slot-projection-runtime.ts
@@ -104,11 +104,10 @@ export function resolveSlotProjection(
 		}
 
 		if (isTemplateResultLike(currentValue)) {
+			// Spread rather than enumerate: only `values` is rewritten here, and the
+			// template result carries compile metadata that must survive untouched.
 			return {
-				_$rType$: 1,
-				rootLocalName: currentValue.rootLocalName,
-				ssrIntrinsicProps: currentValue.ssrIntrinsicProps,
-				strings: currentValue.strings,
+				...currentValue,
 				values: currentValue.values.map((entry) => resolveValue(entry as JsxRenderable)),
 			} satisfies TemplateResultLike;
 		}


### PR DESCRIPTION
## Summary

Stack PR #5 of 6. **Breaking change** — deserves the most scrutiny in this series.

Three commits:

1. **refactor(jsx): collapse repeated branches in the element factory** — Deduplicate `appendBinding`, `createJsxElement`, and child-normalization helpers. Element vs fragment single-child collapse rules are now explicit and tested.

2. **refactor(jsx)!: carry binding metadata on template results** — Template results now carry `parts` descriptors instead of encoding binding kinds as sigils inside static strings (` .value=`, ` ?hidden=`, ` !click=`). Removes the WeakMap/content-keyed parsing cache; DOM compiler, SSR serializer, and hydration all read descriptors directly.

   **BREAKING:** bare `{ strings, values }` payloads are no longer auto-detected as templates. Pass them through `toTemplateResultLike(...)` at the wire boundary. `isTemplateResultLike` additionally checks `parts`.

3. **test(jsx): add a client hydration benchmark** — Playwright-based harness measuring client hydration (not SSR). Covers attribute-only, dynamic-text, keyed, and wide-attribute scenarios with isolation, reconnect assertions, and drift detection for leaks.

## Reviewer notes

- This is where the breaking template-format change lands (`refactor(jsx)!`).
- The benchmark documents the list-reconnect vs list-rebuild gap that PR #6 closes.

## Test plan

- [x] jsx 96 + 98, radiant 452 (green on tip)