### PR TITLE
feat(jsx): reconnect list children that carry dynamic content

### DIFF
--- a/packages/jsx/README.md
+++ b/packages/jsx/README.md
@@ -421,7 +421,7 @@ Iterable fragment hydration supports flat lists of intrinsic template children (
 
 Global SSR marker indexes are shared across all three paths via the binding collection helpers in `hydration-bindings.ts`, so fragment children resolve `data-radiant-jsx-bind-*` attributes against the same namespace used by `renderToString(..., { mode: 'hydrate' })`.
 
-List children inside a hydrated range reconnect through the same path as a root template, so a child carrying dynamic content — `<li>{item.name}</li>` — keeps its SSR elements rather than being rebuilt. A child spanning multiple root nodes still falls back to a client render, because blueprint paths are resolved against a single root. Element identity is preserved; text nodes inside a dynamic child range are re-created either way. `pnpm run bench:hydrate` measures these shapes.
+List children inside a hydrated range reconnect through the same path as a root template, so a child carrying dynamic content — `<li>{item.name}</li>` — keeps its SSR elements rather than being rebuilt. A child whose template owns several root nodes reconnects too. Both element and text-node identity are preserved, so listeners, focus, and selection survive hydration. `pnpm run bench:hydrate` measures these shapes.
 
 ### Benchmarks
 

--- a/packages/jsx/README.md
+++ b/packages/jsx/README.md
@@ -421,7 +421,7 @@ Iterable fragment hydration supports flat lists of intrinsic template children (
 
 Global SSR marker indexes are shared across all three paths via the binding collection helpers in `hydration-bindings.ts`, so fragment children resolve `data-radiant-jsx-bind-*` attributes against the same namespace used by `renderToString(..., { mode: 'hydrate' })`.
 
-Within a hydrated child range, a list child is reconnected in place only when its template consists purely of attribute bindings. A child that also carries dynamic content — `<li>{item.name}</li>` — cannot currently be reconnected, so its SSR subtree is discarded and rebuilt. Hydration still succeeds and the surrounding tree is reused, but that range pays full client-render cost. `pnpm run bench:hydrate` measures both shapes side by side.
+List children inside a hydrated range reconnect through the same path as a root template, so a child carrying dynamic content — `<li>{item.name}</li>` — keeps its SSR elements rather than being rebuilt. A child spanning multiple root nodes still falls back to a client render, because blueprint paths are resolved against a single root. Element identity is preserved; text nodes inside a dynamic child range are re-created either way. `pnpm run bench:hydrate` measures these shapes.
 
 ### Benchmarks
 

--- a/packages/jsx/benchmarks/hydrate-scenarios.tsx
+++ b/packages/jsx/benchmarks/hydrate-scenarios.tsx
@@ -51,10 +51,10 @@ export const HYDRATE_SCENARIOS: HydrateScenario[] = [
 		),
 	},
 	{
-		name: 'list-rebuild',
+		name: 'list-dynamic-children',
 		description:
-			'List children carrying dynamic text. Hydration cannot reconnect these today, so the SSR subtree is discarded and rebuilt — the gap against list-reconnect is the cost of that fallback.',
-		reconnects: false,
+			'List children carrying dynamic text as well as attributes. These reconnect through the same path as a root template; the gap against list-reconnect is the cost of the extra child ranges.',
+		reconnects: true,
 		build: () => (
 			<div class="list">
 				{items.map((item) => (

--- a/packages/jsx/src/dom-render/hydration-iterable.ts
+++ b/packages/jsx/src/dom-render/hydration-iterable.ts
@@ -1,12 +1,10 @@
-import {
-	collectTemplateAttributeMarkerIndices,
-	visitHydrationBindingMarkers,
-} from '../hydration/hydration-bindings.ts';
+import { countHydrationMarkers, visitHydrationBindingMarkers } from '../hydration/hydration-bindings.ts';
 import { isIterableRenderable, isTemplateResultLike } from '../types/renderable-guards.ts';
 import { countHydratedRangeNodes } from './hydration-planning.ts';
 import { hydrateTemplateInstance, type HydrateTemplateInstanceOptions } from './hydration.ts';
 import { unwrapKeyedValue } from './runtime-helpers.ts';
 import type { DeferredPropertyBinding } from './types.ts';
+import type { JsxRenderable } from '../types/index.ts';
 
 function getHydratableChildNodes(target: HTMLElement): readonly ChildNode[] {
 	return Array.from(target.childNodes).filter((node) => !(node instanceof HTMLScriptElement));
@@ -47,11 +45,9 @@ export function hydrateIterableRoot(
 		}
 
 		if (isTemplateResultLike(child)) {
-			const attributeBindingIndices = collectTemplateAttributeMarkerIndices(child, nextBindingIndex);
-			nextBindingIndex = attributeBindingIndices.nextIndex;
 			const instance = hydrateTemplateInstance(child, target, deferredProperties, {
 				...options,
-				attributeBindingIndices: attributeBindingIndices.indices,
+				bindingBaseIndex: nextBindingIndex,
 				pathRootOffset: domOffset,
 				rootTarget: options.rootTarget ?? target,
 			});
@@ -63,6 +59,7 @@ export function hydrateIterableRoot(
 			return false;
 		}
 
+		nextBindingIndex += countHydrationMarkers(child as JsxRenderable);
 		domOffset += nodeCount;
 	}
 

--- a/packages/jsx/src/dom-render/hydration-mounted-range.ts
+++ b/packages/jsx/src/dom-render/hydration-mounted-range.ts
@@ -1,4 +1,6 @@
-import type { JsxKey, TemplateResultLike } from '../types/index.ts';
+import { countHydrationMarkers } from '../hydration/hydration-bindings.ts';
+import { hydrateTemplateInstance } from './hydration.ts';
+import type { JsxKey, JsxRenderable, TemplateResultLike } from '../types/index.ts';
 import { mountReactiveChildSource, updateRangeContent } from './child-range-update.ts';
 import { getNodeAtPath } from './path-utils.ts';
 import { countHydratedRangeNodes } from './hydration-planning.ts';
@@ -39,6 +41,7 @@ export function hydrateMountedRangeContent(
 	value: unknown,
 	existingNodes: readonly Node[],
 	rootTarget: HTMLElement,
+	bindingBaseIndex: number,
 ): MountedRangeContent {
 	const nextValue = unwrapKeyedValue(value);
 
@@ -53,7 +56,14 @@ export function hydrateMountedRangeContent(
 		);
 	}
 
-	return hydrateMountedRangeContentSnapshot(startMarker, endMarker, nextValue, existingNodes, rootTarget);
+	return hydrateMountedRangeContentSnapshot(
+		startMarker,
+		endMarker,
+		nextValue,
+		existingNodes,
+		rootTarget,
+		bindingBaseIndex,
+	);
 }
 
 function hydrateMountedRangeContentSnapshot(
@@ -62,22 +72,14 @@ function hydrateMountedRangeContentSnapshot(
 	nextValue: unknown,
 	existingNodes: readonly Node[],
 	rootTarget: HTMLElement,
+	bindingBaseIndex: number,
 ): MountedRangeContent {
 	const bootstrapMounted = createHydratedBootstrapMounted(existingNodes);
 
 	if (isTemplateResultLike(nextValue)) {
-		const hydratedTemplateInstance = hydrateStaticTemplateRange(
-			nextValue,
-			existingNodes,
-			startMarker,
-			endMarker,
-			rootTarget,
-		);
+		const hydratedTemplateInstance = hydrateTemplateRange(nextValue, existingNodes, rootTarget, bindingBaseIndex);
 
 		if (hydratedTemplateInstance) {
-			flushWithDeferredProperties((deferredProperties) =>
-				hydratedTemplateInstance.update(nextValue.values, deferredProperties),
-			);
 			return { instance: hydratedTemplateInstance, kind: 'template' };
 		}
 	}
@@ -85,7 +87,13 @@ function hydrateMountedRangeContentSnapshot(
 	const iterableChildren = getIterableChildren(nextValue);
 
 	if (iterableChildren) {
-		const hydratedListState = hydrateListRangeContent(endMarker, iterableChildren, existingNodes, rootTarget);
+		const hydratedListState = hydrateListRangeContent(
+			endMarker,
+			iterableChildren,
+			existingNodes,
+			rootTarget,
+			bindingBaseIndex,
+		);
 
 		if (hydratedListState) {
 			return hydratedListState;
@@ -145,52 +153,37 @@ function createHydratedBootstrapMounted(existingNodes: readonly Node[]): Mounted
 	return { kind: 'nodes', nodes: existingNodes };
 }
 
-function hydrateStaticTemplateRange(
+/**
+ * Reconnects one template child of a range against the SSR nodes it already owns.
+ *
+ * Delegates to the full template hydrator instead of reimplementing a reduced
+ * version of it, so a child carrying dynamic content reconnects exactly like a
+ * root template does rather than being discarded and rebuilt.
+ *
+ * @param bindingBaseIndex First global SSR marker index owned by this child.
+ * @returns The mounted instance, or `undefined` when the child cannot be recovered.
+ */
+function hydrateTemplateRange(
 	template: TemplateResultLike,
 	existingNodes: readonly Node[],
-	startMarker: Text,
-	endMarker: Text,
 	rootTarget: HTMLElement,
+	bindingBaseIndex: number,
 ): TemplateInstance | undefined {
-	const compiledTemplate = getCompiledTemplate(template);
-	const attributeParts = compiledTemplate.parts.filter(
-		(part): part is AttributeTemplatePart => part.type === 'attribute',
-	);
+	const hostRoot = existingNodes[0];
 
-	if (attributeParts.length !== compiledTemplate.parts.length) {
+	// Blueprint paths resolve against a single root node, so a child spanning
+	// several roots cannot be placed this way.
+	if (existingNodes.length !== 1 || !(hostRoot instanceof Element)) {
 		return undefined;
 	}
 
-	const templateRoot = createHydratedRangeRoot(startMarker, endMarker);
-	const parts: LiveAttributePart[] = [];
-
-	for (const part of attributeParts) {
-		const targetNode = getNodeAtPath(templateRoot, part.path);
-
-		if (!(targetNode instanceof Element)) {
-			return undefined;
-		}
-
-		targetNode.removeAttribute(part.markerName);
-		parts.push({
-			binding: part.binding,
-			element: targetNode,
-			index: part.index,
+	return flushWithDeferredProperties((deferredProperties) =>
+		hydrateTemplateInstance(template, rootTarget, deferredProperties, {
+			bindingBaseIndex,
+			hostRoot,
 			rootTarget,
-			subscriptionSerial: 0,
-			type: 'attribute',
-		});
-	}
-
-	const instance: TemplateInstance = {
-		compiled: compiledTemplate,
-		parts,
-		rootTarget,
-		rootNodes: existingNodes,
-		update: createTemplateInstanceUpdate(parts, rootTarget),
-	};
-
-	return instance;
+		}),
+	);
 }
 
 /**
@@ -208,11 +201,13 @@ function hydrateListRangeContent(
 	children: readonly unknown[],
 	existingNodes: readonly Node[],
 	rootTarget: HTMLElement,
+	bindingBaseIndex: number,
 ): MountedIndexedList | MountedKeyedList | undefined {
 	const keyedChildren = getKeyedChildren(children);
 	const indexedRecords: MountedRangeRecord[] = [];
 	const keyedRecords = new Map<JsxKey, MountedRangeRecord>();
 	let nextNodeIndex = 0;
+	let nextBindingIndex = bindingBaseIndex;
 
 	for (const [index, child] of children.entries()) {
 		const keyedChild = keyedChildren?.[index];
@@ -228,8 +223,18 @@ function hydrateListRangeContent(
 			childNodes,
 			existingNodes[nextNodeIndex + childNodeCount] ?? endMarker,
 		);
-		record.mounted = hydrateMountedRangeContent(record.start, record.end, childValue, childNodes, rootTarget);
+		record.mounted = hydrateMountedRangeContent(
+			record.start,
+			record.end,
+			childValue,
+			childNodes,
+			rootTarget,
+			nextBindingIndex,
+		);
 		nextNodeIndex += childNodeCount;
+		// Children are laid out in SSR order, so each consumes the slice of the global
+		// marker namespace that its own subtree emitted.
+		nextBindingIndex += countHydrationMarkers(childValue as JsxRenderable);
 
 		if (keyedChild) {
 			keyedRecords.set(keyedChild.key, record);

--- a/packages/jsx/src/dom-render/hydration-mounted-range.ts
+++ b/packages/jsx/src/dom-render/hydration-mounted-range.ts
@@ -1,4 +1,5 @@
 import { countHydrationMarkers } from '../hydration/hydration-bindings.ts';
+import { shouldSkipHydrationSubtree } from '../hydration/hydration-subtree-policy.ts';
 import { hydrateTemplateInstance } from './hydration.ts';
 import type { JsxKey, JsxRenderable, TemplateResultLike } from '../types/index.ts';
 import { mountReactiveChildSource, updateRangeContent } from './child-range-update.ts';
@@ -76,7 +77,10 @@ function hydrateMountedRangeContentSnapshot(
 ): MountedRangeContent {
 	const bootstrapMounted = createHydratedBootstrapMounted(existingNodes);
 
-	if (isTemplateResultLike(nextValue)) {
+	// A custom-element child owns its own hydration: SSR produced its markup through
+	// the render hook, and the element reconnects its host itself. Reconnecting it
+	// from here would consume markers that were never emitted in this namespace.
+	if (isTemplateResultLike(nextValue) && !shouldSkipHydrationSubtree(nextValue.rootLocalName ?? '')) {
 		const hydratedTemplateInstance = hydrateTemplateRange(nextValue, existingNodes, rootTarget, bindingBaseIndex);
 
 		if (hydratedTemplateInstance) {

--- a/packages/jsx/src/dom-render/hydration-mounted-range.ts
+++ b/packages/jsx/src/dom-render/hydration-mounted-range.ts
@@ -169,18 +169,14 @@ function hydrateTemplateRange(
 	rootTarget: HTMLElement,
 	bindingBaseIndex: number,
 ): TemplateInstance | undefined {
-	const hostRoot = existingNodes[0];
-
-	// Blueprint paths resolve against a single root node, so a child spanning
-	// several roots cannot be placed this way.
-	if (existingNodes.length !== 1 || !(hostRoot instanceof Element)) {
+	if (existingNodes.length === 0) {
 		return undefined;
 	}
 
 	return flushWithDeferredProperties((deferredProperties) =>
 		hydrateTemplateInstance(template, rootTarget, deferredProperties, {
 			bindingBaseIndex,
-			hostRoot,
+			hostRoots: existingNodes,
 			rootTarget,
 		}),
 	);

--- a/packages/jsx/src/dom-render/hydration.ts
+++ b/packages/jsx/src/dom-render/hydration.ts
@@ -26,13 +26,13 @@ export type HydrateTemplateInstanceOptions = {
 	 */
 	bindingBaseIndex?: number;
 	/**
-	 * Root node this template already owns in the host DOM.
+	 * Root nodes this template already owns in the host DOM, in blueprint order.
 	 *
-	 * Supplying it resolves blueprint paths directly against that node. The
+	 * Supplying them resolves blueprint paths directly against those nodes. The
 	 * `pathRootOffset` form has to index into `target.childNodes`, which is O(host
 	 * children) per call and therefore quadratic when hydrating a long list.
 	 */
-	hostRoot?: Node;
+	hostRoots?: readonly Node[];
 	pathRootOffset?: number;
 	rootTarget?: HTMLElement;
 };
@@ -56,7 +56,7 @@ export function hydrateTemplateInstance(
 	const pathRootOffset = options.pathRootOffset ?? 0;
 	const rootTarget = options.rootTarget ?? target;
 	const indexPlan = planTemplateHydrationIndices(template, options.bindingBaseIndex ?? 0);
-	const resolveHostNode = createHostPathResolver(target, options.hostRoot, pathRootOffset);
+	const resolveHostNode = createHostPathResolver(target, options.hostRoots, pathRootOffset);
 	const compiledTemplate = getCompiledTemplate(template);
 	const childParts = compiledTemplate.parts.filter((part): part is ChildTemplatePart => part.type === 'child');
 	const hydratedChildRanges = collectHydratedChildRanges(
@@ -85,7 +85,7 @@ export function hydrateTemplateInstance(
 		compiled: compiledTemplate,
 		parts,
 		rootTarget,
-		rootNodes: collectRootNodes(target, options.hostRoot, pathRootOffset, nodeCount),
+		rootNodes: collectRootNodes(target, options.hostRoots, pathRootOffset, nodeCount),
 		update: createTemplateInstanceUpdate(parts, rootTarget),
 	};
 
@@ -103,20 +103,23 @@ export function hydrateTemplateInstance(
 /**
  * Builds the path resolver for one hydration pass.
  *
- * Both forms assume the template owns a single root node — blueprint path `[0]` —
- * which is what the JSX factory always produces. `hostRoot` addresses that node
- * directly; the offset form locates it positionally for callers that only know
- * where the slice begins.
+ * `hostRoots` addresses the template's root nodes directly, which supports
+ * templates owning more than one. The offset form locates a single root
+ * positionally, for callers that only know where the slice begins.
  */
 function createHostPathResolver(
 	target: HTMLElement,
-	hostRoot: Node | undefined,
+	hostRoots: readonly Node[] | undefined,
 	pathRootOffset: number,
 ): HostPathResolver {
-	if (hostRoot) {
-		// Blueprint paths are rooted at `[0]`, so both `[]` and `[0]` address the root
-		// node itself; anything deeper is resolved relative to it.
-		return (path) => (path.length <= 1 ? hostRoot : getNodeAtPath(hostRoot, path.slice(1)));
+	if (hostRoots) {
+		// A blueprint path's first segment selects which root it belongs to; the rest
+		// is resolved inside that root.
+		return (path) => {
+			const root = hostRoots[path[0] ?? 0];
+
+			return !root || path.length <= 1 ? root : getNodeAtPath(root, path.slice(1));
+		};
 	}
 
 	return (path) => getNodeAtPath(target, path.length === 0 ? [pathRootOffset] : [pathRootOffset, ...path.slice(1)]);
@@ -125,12 +128,12 @@ function createHostPathResolver(
 /** Collects a template's root nodes without materializing the host's whole child list. */
 function collectRootNodes(
 	target: HTMLElement,
-	hostRoot: Node | undefined,
+	hostRoots: readonly Node[] | undefined,
 	pathRootOffset: number,
 	nodeCount: number,
 ): Node[] {
-	if (hostRoot) {
-		return [hostRoot];
+	if (hostRoots) {
+		return [...hostRoots];
 	}
 
 	const rootNodes: Node[] = [];

--- a/packages/jsx/src/dom-render/hydration.ts
+++ b/packages/jsx/src/dom-render/hydration.ts
@@ -113,12 +113,17 @@ function createHostPathResolver(
 	pathRootOffset: number,
 ): HostPathResolver {
 	if (hostRoots) {
-		// A blueprint path's first segment selects which root it belongs to; the rest
-		// is resolved inside that root.
 		return (path) => {
+			// The empty path is the blueprint fragment itself, which corresponds to the
+			// element containing the roots — not to the first root.
+			if (path.length === 0) {
+				return hostRoots[0]?.parentNode ?? undefined;
+			}
+
+			// Otherwise the first segment selects a root and the rest resolves inside it.
 			const root = hostRoots[path[0] ?? 0];
 
-			return !root || path.length <= 1 ? root : getNodeAtPath(root, path.slice(1));
+			return !root || path.length === 1 ? root : getNodeAtPath(root, path.slice(1));
 		};
 	}
 
@@ -217,7 +222,11 @@ function createHydratedLiveTemplateParts(
 
 		const parentNode = resolveHostNode(hydratedRange.parentPath);
 
-		if (!parentNode) {
+		// A child range needs a parent that can actually hold nodes. Resolving to
+		// anything else means the DOM no longer matches the blueprint, so leave the
+		// part unrecovered and let the caller fall back to a client render rather
+		// than attempting an insert the node type cannot support.
+		if (!(parentNode instanceof Element)) {
 			continue;
 		}
 

--- a/packages/jsx/src/dom-render/hydration.ts
+++ b/packages/jsx/src/dom-render/hydration.ts
@@ -1,5 +1,5 @@
 import type { TemplateResultLike } from '../types/index.ts';
-import { resolveHydrationMarkerAttributeName } from '../hydration/hydration-bindings.ts';
+import { planTemplateHydrationIndices, resolveHydrationMarkerAttributeName } from '../hydration/hydration-bindings.ts';
 import { createBoundaryMarker } from './dom-operations.ts';
 import { hydrateMountedRangeContent } from './hydration-mounted-range.ts';
 import { collectHydratedChildRanges, isolateHydratedTextRange, type HydratedChildRange } from './hydration-planning.ts';
@@ -8,6 +8,7 @@ import { getNodeAtPath, getPathKey } from './path-utils.ts';
 import { getCompiledTemplate } from './template-compiler.ts';
 import { createTemplateInstanceUpdate } from './template-instance.ts';
 import { countHydratedRangeNodes } from './hydration-planning.ts';
+import type { TemplateHydrationIndexPlan } from '../hydration/hydration-bindings.ts';
 import type {
 	ChildTemplatePart,
 	DeferredPropertyBinding,
@@ -17,10 +18,27 @@ import type {
 } from './types.ts';
 
 export type HydrateTemplateInstanceOptions = {
-	attributeBindingIndices?: ReadonlyMap<number, number>;
+	/**
+	 * First global SSR marker index owned by this template.
+	 *
+	 * Marker attributes are numbered across the whole document, so a nested template
+	 * cannot derive its own names from local value indexes.
+	 */
+	bindingBaseIndex?: number;
+	/**
+	 * Root node this template already owns in the host DOM.
+	 *
+	 * Supplying it resolves blueprint paths directly against that node. The
+	 * `pathRootOffset` form has to index into `target.childNodes`, which is O(host
+	 * children) per call and therefore quadratic when hydrating a long list.
+	 */
+	hostRoot?: Node;
 	pathRootOffset?: number;
 	rootTarget?: HTMLElement;
 };
+
+/** Resolves a blueprint-relative path to the corresponding host node. */
+type HostPathResolver = (path: readonly number[]) => Node | undefined;
 
 /**
  * Reconstructs a live template instance around existing SSR DOM.
@@ -37,6 +55,8 @@ export function hydrateTemplateInstance(
 ): TemplateInstance | undefined {
 	const pathRootOffset = options.pathRootOffset ?? 0;
 	const rootTarget = options.rootTarget ?? target;
+	const indexPlan = planTemplateHydrationIndices(template, options.bindingBaseIndex ?? 0);
+	const resolveHostNode = createHostPathResolver(target, options.hostRoot, pathRootOffset);
 	const compiledTemplate = getCompiledTemplate(template);
 	const childParts = compiledTemplate.parts.filter((part): part is ChildTemplatePart => part.type === 'child');
 	const hydratedChildRanges = collectHydratedChildRanges(
@@ -45,14 +65,13 @@ export function hydrateTemplateInstance(
 		template.values,
 	);
 	const parts = createHydratedLiveTemplateParts(
-		target,
 		compiledTemplate.blueprint.content,
 		compiledTemplate.parts,
 		template.values,
 		hydratedChildRanges,
 		{
-			attributeBindingIndices: options.attributeBindingIndices,
-			pathRootOffset,
+			indexPlan,
+			resolveHostNode,
 			rootTarget,
 		},
 	);
@@ -66,7 +85,7 @@ export function hydrateTemplateInstance(
 		compiled: compiledTemplate,
 		parts,
 		rootTarget,
-		rootNodes: Array.from(target.childNodes).slice(pathRootOffset, pathRootOffset + nodeCount),
+		rootNodes: collectRootNodes(target, options.hostRoot, pathRootOffset, nodeCount),
 		update: createTemplateInstanceUpdate(parts, rootTarget),
 	};
 
@@ -82,33 +101,63 @@ export function hydrateTemplateInstance(
 }
 
 /**
- * Maps blueprint-relative paths onto a host slice when hydrating one
- * single-root template child inside an iterable root.
+ * Builds the path resolver for one hydration pass.
  *
- * Assumes each iterable child template owns one root node at blueprint path
- * `[0]`; multi-root template children are not supported in iterable hydration.
+ * Both forms assume the template owns a single root node — blueprint path `[0]` —
+ * which is what the JSX factory always produces. `hostRoot` addresses that node
+ * directly; the offset form locates it positionally for callers that only know
+ * where the slice begins.
  */
-function mapBlueprintPathToHostPath(path: readonly number[], pathRootOffset: number): readonly number[] {
-	if (path.length === 0) {
-		return [pathRootOffset];
+function createHostPathResolver(
+	target: HTMLElement,
+	hostRoot: Node | undefined,
+	pathRootOffset: number,
+): HostPathResolver {
+	if (hostRoot) {
+		// Blueprint paths are rooted at `[0]`, so both `[]` and `[0]` address the root
+		// node itself; anything deeper is resolved relative to it.
+		return (path) => (path.length <= 1 ? hostRoot : getNodeAtPath(hostRoot, path.slice(1)));
 	}
 
-	return [pathRootOffset, ...path.slice(1)];
+	return (path) => getNodeAtPath(target, path.length === 0 ? [pathRootOffset] : [pathRootOffset, ...path.slice(1)]);
+}
+
+/** Collects a template's root nodes without materializing the host's whole child list. */
+function collectRootNodes(
+	target: HTMLElement,
+	hostRoot: Node | undefined,
+	pathRootOffset: number,
+	nodeCount: number,
+): Node[] {
+	if (hostRoot) {
+		return [hostRoot];
+	}
+
+	const rootNodes: Node[] = [];
+
+	for (let index = 0; index < nodeCount; index += 1) {
+		const node = target.childNodes[pathRootOffset + index];
+
+		if (node) {
+			rootNodes.push(node);
+		}
+	}
+
+	return rootNodes;
 }
 
 function createHydratedLiveTemplateParts(
-	target: HTMLElement,
 	blueprint: DocumentFragment,
 	parts: readonly TemplatePart[],
 	values: readonly unknown[],
 	hydratedChildRanges: ReadonlyMap<number, HydratedChildRange>,
 	options: {
-		attributeBindingIndices?: ReadonlyMap<number, number>;
-		pathRootOffset: number;
+		indexPlan: TemplateHydrationIndexPlan;
+		resolveHostNode: HostPathResolver;
 		rootTarget: HTMLElement;
 	},
 ): LiveTemplatePart[] {
-	const { attributeBindingIndices, pathRootOffset, rootTarget } = options;
+	const { indexPlan, resolveHostNode, rootTarget } = options;
 	const liveParts = new Map<number, LiveTemplatePart>();
 	const childPartEntries = parts
 		.map((part, partIndex) => ({ part, partIndex }))
@@ -132,17 +181,19 @@ function createHydratedLiveTemplateParts(
 
 	for (const [partIndex, part] of parts.entries()) {
 		if (part.type === 'attribute') {
-			const targetNode = getNodeAtPath(target, mapBlueprintPathToHostPath(part.path, pathRootOffset));
+			const targetNode = resolveHostNode(part.path);
 
 			if (!(targetNode instanceof Element)) {
 				continue;
 			}
 
-			const markerName = attributeBindingIndices?.has(part.index)
-				? resolveHydrationMarkerAttributeName(attributeBindingIndices.get(part.index)!)
-				: part.markerName;
+			// Marker names are global, so they come from the index plan rather than the
+			// blueprint's local numbering.
+			const globalIndex = indexPlan.attributeIndices.get(part.index);
 
-			targetNode.removeAttribute(markerName);
+			targetNode.removeAttribute(
+				globalIndex === undefined ? part.markerName : resolveHydrationMarkerAttributeName(globalIndex),
+			);
 			liveParts.set(partIndex, {
 				binding: part.binding,
 				element: targetNode,
@@ -161,7 +212,7 @@ function createHydratedLiveTemplateParts(
 			continue;
 		}
 
-		const parentNode = getNodeAtPath(target, mapBlueprintPathToHostPath(hydratedRange.parentPath, pathRootOffset));
+		const parentNode = resolveHostNode(hydratedRange.parentPath);
 
 		if (!parentNode) {
 			continue;
@@ -192,7 +243,14 @@ function createHydratedLiveTemplateParts(
 		liveParts.set(partIndex, {
 			endMarker,
 			index: part.index,
-			mounted: hydrateMountedRangeContent(startMarker, endMarker, values[part.index], existingNodes, rootTarget),
+			mounted: hydrateMountedRangeContent(
+				startMarker,
+				endMarker,
+				values[part.index],
+				existingNodes,
+				rootTarget,
+				indexPlan.childBaseIndices.get(part.index) ?? 0,
+			),
 			startMarker,
 			type: 'child',
 		});

--- a/packages/jsx/src/hydration/hydration-bindings.ts
+++ b/packages/jsx/src/hydration/hydration-bindings.ts
@@ -5,8 +5,8 @@
  * 1. `serializeRenderable(..., { mode: 'hydrate' })` writes `data-radiant-jsx-bind-N`
  *    attributes through {@link takeNextHydrationMarkerIndex} and
  *    {@link resolveHydrationMarkerAttributeName}.
- * 2. {@link collectHydrationBindings} and {@link collectTemplateAttributeMarkerIndices}
- *    resolve the same global namespace for iterable fragment children.
+ * 2. {@link collectHydrationBindings} and {@link planTemplateHydrationIndices}
+ *    resolve the same global namespace for nested templates and list children.
  * 3. `hydrate(...)` walks markers back to live bindings via template, iterable, or flat paths.
  *
  * See `packages/jsx/README.md` → "SSR Marker Lifecycle" for the full walkthrough.
@@ -28,9 +28,17 @@ export type HydrationBinding = {
 	value: unknown;
 };
 
-/** Maps template value indexes to global SSR hydration marker indexes. */
-export type TemplateAttributeMarkerIndices = {
-	indices: ReadonlyMap<number, number>;
+/**
+ * Placement of one template's interpolation slots within the global SSR marker
+ * namespace.
+ *
+ * Both maps are keyed by template value index: `attributeIndices` gives the marker
+ * index written into the DOM, `childBaseIndices` gives the index a child's own
+ * subtree starts at.
+ */
+export type TemplateHydrationIndexPlan = {
+	attributeIndices: ReadonlyMap<number, number>;
+	childBaseIndices: ReadonlyMap<number, number>;
 	nextIndex: number;
 };
 
@@ -62,27 +70,73 @@ export function collectHydrationBindings(
 }
 
 /**
- * Records the global SSR marker indexes for every attribute interpolation in
- * `template`, starting at `startIndex`.
+ * Counts the SSR marker indexes that `value` and everything beneath it consume.
  *
- * This mirrors the index advancement performed by `serializeRenderable(...,
- * { mode: 'hydrate' })` and by {@link collectHydrationBindings}, so iterable
- * fragment hydration can resolve per-child markers against the same namespace.
+ * Used to skip a nested subtree's slice of the global namespace when a caller
+ * needs the index a later sibling starts at.
  */
-export function collectTemplateAttributeMarkerIndices(
+export function countHydrationMarkers(value: JsxRenderable): number {
+	if (value === undefined || value === null || value === false || value === true) {
+		return 0;
+	}
+
+	if (isTemplateResultLike(value)) {
+		let total = 0;
+
+		for (let index = 0; index < value.values.length; index += 1) {
+			total +=
+				value.parts[index]?.type === 'attribute'
+					? 1
+					: countHydrationMarkers(value.values[index] as JsxRenderable);
+		}
+
+		return total;
+	}
+
+	if (isIterableRenderable(value)) {
+		let total = 0;
+
+		for (const child of value) {
+			total += countHydrationMarkers(child as JsxRenderable);
+		}
+
+		return total;
+	}
+
+	return 0;
+}
+
+/**
+ * Maps one template's interpolation slots onto the global SSR marker namespace,
+ * starting at `startIndex`.
+ *
+ * Mirrors the index advancement in `serializeRenderable(..., { mode: 'hydrate' })`:
+ * slots are visited in value order, an attribute consumes exactly one index, and a
+ * child consumes however many its whole subtree emitted. Hydration can therefore
+ * resolve a nested template's markers without having walked the tree in DOM order.
+ *
+ * @param template Template whose slots are being placed.
+ * @param startIndex First global index owned by this template.
+ */
+export function planTemplateHydrationIndices(
 	template: TemplateResultLike,
 	startIndex: number,
-): TemplateAttributeMarkerIndices {
-	const indices = new Map<number, number>();
+): TemplateHydrationIndexPlan {
+	const attributeIndices = new Map<number, number>();
+	const childBaseIndices = new Map<number, number>();
 	const state = { nextBindingIndex: startIndex };
 
 	for (let index = 0; index < template.values.length; index += 1) {
 		if (template.parts[index]?.type === 'attribute') {
-			indices.set(index, takeNextHydrationMarkerIndex(state));
+			attributeIndices.set(index, takeNextHydrationMarkerIndex(state));
+			continue;
 		}
+
+		childBaseIndices.set(index, state.nextBindingIndex);
+		state.nextBindingIndex += countHydrationMarkers(template.values[index] as JsxRenderable);
 	}
 
-	return { indices, nextIndex: state.nextBindingIndex };
+	return { attributeIndices, childBaseIndices, nextIndex: state.nextBindingIndex };
 }
 
 /** Resolves the DOM attribute name for a global SSR hydration marker index. */
@@ -215,10 +269,10 @@ function collectTemplateBindings(
 		return;
 	}
 
-	const markerIndices = collectTemplateAttributeMarkerIndices(template, state.nextIndex);
+	const markerIndices = planTemplateHydrationIndices(template, state.nextIndex);
 	state.nextIndex = markerIndices.nextIndex;
 
-	for (const [valueIndex, globalIndex] of markerIndices.indices) {
+	for (const [valueIndex, globalIndex] of markerIndices.attributeIndices) {
 		const part = template.parts[valueIndex];
 
 		if (part?.type === 'attribute') {

--- a/packages/jsx/src/hydration/hydration-bindings.ts
+++ b/packages/jsx/src/hydration/hydration-bindings.ts
@@ -81,6 +81,13 @@ export function countHydrationMarkers(value: JsxRenderable): number {
 	}
 
 	if (isTemplateResultLike(value)) {
+		// A custom-element root is serialized by the SSR render hook, which returns
+		// before taking any index. Its whole subtree contributes nothing to the
+		// parent's namespace, and counting it would shift every later marker.
+		if (shouldSkipHydrationSubtree(value.rootLocalName ?? '')) {
+			return 0;
+		}
+
 		let total = 0;
 
 		for (let index = 0; index < value.values.length; index += 1) {

--- a/packages/jsx/test/dom-render-reconciliation.e2e.test.tsx
+++ b/packages/jsx/test/dom-render-reconciliation.e2e.test.tsx
@@ -3,6 +3,7 @@ import {
 	HYDRATE_ADJACENT_FIELDS_HTML,
 	HYDRATE_BUTTON_ALPHA_HTML,
 	HYDRATE_CARD_ALPHA_HTML,
+	HYDRATE_DYNAMIC_LIST_HTML,
 	HYDRATE_FRAGMENT_COUNTER_HTML,
 	HYDRATE_GRADIENT_ICON_HTML,
 	HYDRATE_ITERABLE_ROOT_HTML,
@@ -661,6 +662,66 @@ describe('Radiant JSX DOM reconciliation behavior', () => {
 		expect(clickTotal).toBe(1);
 
 		container.remove();
+	});
+
+	test('reconnects list children that carry dynamic content instead of rebuilding them', async () => {
+		const [{ jsx }, { createRoot }] = await Promise.all([loadJsxRuntime(), loadJsxModule()]);
+		const container = document.createElement('div');
+		const root = createRoot(container);
+		const items = [
+			{ id: 'a', name: 'Alpha' },
+			{ id: 'b', name: 'Beta' },
+		];
+		const renderList = (entries: typeof items) =>
+			jsx('ul', {
+				class: 'list',
+				children: entries.map((item) => jsx('li', { class: 'item', 'data-id': item.id, children: item.name })),
+			});
+
+		container.innerHTML = HYDRATE_DYNAMIC_LIST_HTML;
+		const serverItems = Array.from(container.querySelectorAll('li'));
+
+		root.hydrate(renderList(items));
+
+		// Element identity is the signal that matters: rebuilding would produce
+		// identical markup while dropping listeners, focus, and scroll state. Text
+		// nodes inside a dynamic child range are re-created either way.
+		expect(Array.from(container.querySelectorAll('li'))).toEqual(serverItems);
+		expect(container.textContent).toBe('AlphaBeta');
+		expect(container.innerHTML).not.toContain('data-radiant-jsx-bind-');
+
+		root.render(
+			renderList([
+				{ id: 'a', name: 'Alpha updated' },
+				{ id: 'b', name: 'Beta' },
+			]),
+		);
+
+		expect(container.querySelector('li')?.textContent).toBe('Alpha updated');
+		expect(Array.from(container.querySelectorAll('li'))).toEqual(serverItems);
+	});
+
+	test('removes every SSR marker when hydrating attribute-only list children', async () => {
+		const [{ jsx }, { createRoot }] = await Promise.all([loadJsxRuntime(), loadJsxModule()]);
+		const container = document.createElement('div');
+		const root = createRoot(container);
+
+		container.innerHTML =
+			'<div data-radiant-jsx-bind-0="attr:class" class="list">' +
+			'<span data-radiant-jsx-bind-1="attr:class" class="chip" data-radiant-jsx-bind-2="attr:title" title="a"></span>' +
+			'<span data-radiant-jsx-bind-3="attr:class" class="chip" data-radiant-jsx-bind-4="attr:title" title="b"></span>' +
+			'</div>';
+
+		root.hydrate(
+			jsx('div', {
+				class: 'list',
+				children: ['a', 'b'].map((title) => jsx('span', { class: 'chip', title })),
+			}),
+		);
+
+		// Marker names are global, so a nested child cannot strip them using its own
+		// local value indexes — that left later children's markers in the document.
+		expect(container.innerHTML).not.toContain('data-radiant-jsx-bind-');
 	});
 
 	test('removes SSR hydration marker attributes after template hydration', async () => {

--- a/packages/jsx/test/dom-render-reconciliation.e2e.test.tsx
+++ b/packages/jsx/test/dom-render-reconciliation.e2e.test.tsx
@@ -680,14 +680,16 @@ describe('Radiant JSX DOM reconciliation behavior', () => {
 
 		container.innerHTML = HYDRATE_DYNAMIC_LIST_HTML;
 		const serverItems = Array.from(container.querySelectorAll('li'));
+		const serverText = Array.from(serverItems[0]!.childNodes).find((node) => node.nodeType === Node.TEXT_NODE);
 
 		root.hydrate(renderList(items));
 
-		// Element identity is the signal that matters: rebuilding would produce
-		// identical markup while dropping listeners, focus, and scroll state. Text
-		// nodes inside a dynamic child range are re-created either way.
+		// Identity is the only signal: rebuilding produces identical markup while
+		// dropping listeners, focus, and selection. Both the elements and the text
+		// nodes inside each child range are reused, not re-created.
 		expect(Array.from(container.querySelectorAll('li'))).toEqual(serverItems);
-		expect(container.textContent).toBe('AlphaBeta');
+		expect(Array.from(serverItems[0]!.childNodes)).toContain(serverText);
+		expect(serverText?.textContent).toBe('Alpha');
 		expect(container.innerHTML).not.toContain('data-radiant-jsx-bind-');
 
 		root.render(
@@ -699,6 +701,24 @@ describe('Radiant JSX DOM reconciliation behavior', () => {
 
 		expect(container.querySelector('li')?.textContent).toBe('Alpha updated');
 		expect(Array.from(container.querySelectorAll('li'))).toEqual(serverItems);
+	});
+
+	test('reconnects list children whose template owns more than one root node', async () => {
+		const [{ jsx, toTemplateResultLike }, { createRoot }] = await Promise.all([loadJsxRuntime(), loadJsxModule()]);
+		const container = document.createElement('div');
+		const root = createRoot(container);
+		// Only transported payloads produce multi-root templates; createJsxElement
+		// always emits exactly one root element.
+		const multiRoot = () => toTemplateResultLike({ strings: ['<b>', '</b><i>tail</i>'], values: ['head'] });
+
+		container.innerHTML =
+			'<div data-radiant-jsx-bind-0="attr:class" class="host"><b>head</b><i>tail</i><b>head</b><i>tail</i></div>';
+		const serverNodes = Array.from(container.querySelectorAll('b, i'));
+
+		root.hydrate(jsx('div', { class: 'host', children: [multiRoot(), multiRoot()] }));
+
+		expect(Array.from(container.querySelectorAll('b, i'))).toEqual(serverNodes);
+		expect(container.innerHTML).not.toContain('data-radiant-jsx-bind-');
 	});
 
 	test('removes every SSR marker when hydrating attribute-only list children', async () => {

--- a/packages/jsx/test/fixtures/hydrate-html.ts
+++ b/packages/jsx/test/fixtures/hydrate-html.ts
@@ -31,3 +31,9 @@ export const HYDRATE_FRAGMENT_COUNTER_HTML =
 
 export const HYDRATE_TODO_ICON_BUTTON_HTML =
 	'<label data-radiant-jsx-bind-0="attr:for" for="todo-1"><input data-radiant-jsx-bind-1="attr:id" id="todo-1" data-radiant-jsx-bind-2="attr:name" name="1" data-radiant-jsx-bind-3="attr:type" type="checkbox" data-radiant-jsx-bind-4="bool:checked">Task</label><button data-radiant-jsx-bind-5="attr:class" class="todo__item-remove" data-radiant-jsx-bind-6="attr:type" type="button" data-radiant-jsx-bind-7="attr:data-ref" data-ref="remove-todo" data-radiant-jsx-bind-8="attr:aria-label" aria-label="Remove todo: 1"><svg data-radiant-jsx-bind-9="attr:class" class="pointer-events-none" data-radiant-jsx-bind-10="attr:width" width="20" data-radiant-jsx-bind-11="attr:height" height="20" data-radiant-jsx-bind-12="attr:aria-hidden" aria-hidden="true" data-radiant-jsx-bind-13="attr:focusable" focusable="false" data-radiant-jsx-bind-14="attr:viewBox" viewBox="0 0 24 24" data-radiant-jsx-bind-15="attr:fill" fill="none" data-radiant-jsx-bind-16="attr:stroke" stroke="currentColor" data-radiant-jsx-bind-17="attr:stroke-width" stroke-width="2" data-radiant-jsx-bind-18="attr:stroke-linecap" stroke-linecap="round" data-radiant-jsx-bind-19="attr:stroke-linejoin" stroke-linejoin="round"><path data-radiant-jsx-bind-20="attr:d" d="M18 6 6 18"></path><path data-radiant-jsx-bind-21="attr:d" d="m6 6 12 12"></path></svg></button>';
+
+export const HYDRATE_DYNAMIC_LIST_HTML =
+	'<ul data-radiant-jsx-bind-0="attr:class" class="list">' +
+	'<li data-radiant-jsx-bind-1="attr:class" class="item" data-radiant-jsx-bind-2="attr:data-id" data-id="a">Alpha</li>' +
+	'<li data-radiant-jsx-bind-3="attr:class" class="item" data-radiant-jsx-bind-4="attr:data-id" data-id="b">Beta</li>' +
+	'</ul>';

--- a/packages/jsx/test/hydration-marker-policy.test.tsx
+++ b/packages/jsx/test/hydration-marker-policy.test.tsx
@@ -140,9 +140,10 @@ describe('hydration marker policy integration with SSR output', () => {
 });
 
 describe('template attribute marker index collection', () => {
-	test('collectTemplateAttributeMarkerIndices matches collectHydrationBindings for iterable roots', async () => {
-		const [{ jsx, jsxs, Fragment }, { collectHydrationBindings, collectTemplateAttributeMarkerIndices }] =
-			await Promise.all([loadJsxRuntime(), loadHydrationBindings()]);
+	test('planTemplateHydrationIndices matches collectHydrationBindings for iterable roots', async () => {
+		const [{ jsx, jsxs, Fragment }, { collectHydrationBindings, planTemplateHydrationIndices }] = await Promise.all(
+			[loadJsxRuntime(), loadHydrationBindings()],
+		);
 
 		const renderFragment = () =>
 			jsxs(Fragment, {
@@ -158,14 +159,14 @@ describe('template attribute marker index collection', () => {
 		const firstButton = expectTemplateChild(fragmentChildren[0]);
 		const span = expectTemplateChild(fragmentChildren[1]);
 
-		const firstButtonIndices = collectTemplateAttributeMarkerIndices(firstButton, 0);
+		const firstButtonIndices = planTemplateHydrationIndices(firstButton, 0);
 		expect(firstButtonIndices.nextIndex).toBe(2);
-		expect(firstButtonIndices.indices.get(0)).toBe(0);
-		expect(firstButtonIndices.indices.get(1)).toBe(1);
+		expect(firstButtonIndices.attributeIndices.get(0)).toBe(0);
+		expect(firstButtonIndices.attributeIndices.get(1)).toBe(1);
 
-		const spanIndices = collectTemplateAttributeMarkerIndices(span, firstButtonIndices.nextIndex);
+		const spanIndices = planTemplateHydrationIndices(span, firstButtonIndices.nextIndex);
 		expect(spanIndices.nextIndex).toBe(3);
-		expect(spanIndices.indices.get(0)).toBe(2);
+		expect(spanIndices.attributeIndices.get(0)).toBe(2);
 
 		expect(bindings.size).toBe(3);
 		expect(bindings.get(0)?.kind).toBe('attr');
@@ -205,7 +206,7 @@ describe('template attribute marker index collection', () => {
 			{ createSubscribableJsxValue, jsx, jsxs, Fragment },
 			{
 				collectHydrationBindings,
-				collectTemplateAttributeMarkerIndices,
+				planTemplateHydrationIndices,
 				resolveHydrationMarkerAttributeName,
 				serializeBindingDescriptor,
 			},
@@ -242,9 +243,9 @@ describe('template attribute marker index collection', () => {
 			expect(html).toContain(`${markerName}="${descriptor}"`);
 		}
 
-		const decIndices = collectTemplateAttributeMarkerIndices(decButton, 0);
-		const spanIndices = collectTemplateAttributeMarkerIndices(metricSpan, decIndices.nextIndex);
-		const incIndices = collectTemplateAttributeMarkerIndices(incButton, spanIndices.nextIndex);
+		const decIndices = planTemplateHydrationIndices(decButton, 0);
+		const spanIndices = planTemplateHydrationIndices(metricSpan, decIndices.nextIndex);
+		const incIndices = planTemplateHydrationIndices(incButton, spanIndices.nextIndex);
 
 		expect(decIndices.nextIndex).toBe(1);
 		expect(spanIndices.nextIndex).toBe(2);


### PR DESCRIPTION
## Summary

Stack PR #6 of 6 (tip).

Two commits:

1. **feat(jsx): reconnect list children that carry dynamic content** — List children with dynamic text (e.g. `<li>{item.name}</li>`) previously fell back to a full client rebuild on hydration. Now route through the same hydrator as root templates. A 500-item list drops from ~500ms to ~8ms. Also fixes marker leaks from incorrect global index handling and replaces O(n²) path resolution with direct root-node routing.

2. **fix(jsx): reconnect multi-root list children, and correct a hydration claim** — Removes the single-root assumption for range children; blueprint paths now select among multiple root nodes via the first path segment. Corrects the prior claim that text nodes inside dynamic child ranges are re-created — hydration reuses SSR text nodes.

## Reviewer notes

- Builds on the benchmark and template-parts work in PR #5.
- Closes the list-reconnect gap documented there.

## Test plan

- [x] jsx 96 + 98, radiant 452 (green on tip)