### PR TITLE
fix(radiant-ui): resolve the radio-group aria target without a :checked selector

### DIFF
--- a/packages/radiant-ui/src/components/ui/form/aria-control-target.ssr.test.ts
+++ b/packages/radiant-ui/src/components/ui/form/aria-control-target.ssr.test.ts
@@ -1,0 +1,50 @@
+// @vitest-environment node
+/**
+ * Runs in plain Node so `install-ssr-runtime` installs Radiant's minimal DOM rather than
+ * detecting an existing happy-dom. happy-dom implements `:checked`; the minimal DOM
+ * rejects every pseudo-class, so only this environment reproduces the SSR failure.
+ */
+import { describe, expect, it } from 'vitest';
+import '@ecopages/radiant/server/install-ssr-runtime';
+import { getAriaControlTarget } from './control-protocol';
+
+function radioGroup(html: string): HTMLElement {
+	const host = document.createElement('rui-radio-group');
+	host.innerHTML = html;
+	return host as unknown as HTMLElement;
+}
+
+describe('getAriaControlTarget under the minimal SSR DOM', () => {
+	it('targets the radio carrying the checked attribute', () => {
+		const host = radioGroup(`
+			<input type="radio" value="free" />
+			<input type="radio" value="pro" checked />
+		`);
+
+		const target = getAriaControlTarget(host) as HTMLInputElement;
+
+		expect(target.localName).toBe('input');
+		expect(target.getAttribute('value')).toBe('pro');
+	});
+
+	it('falls back to the first radio when none is checked', () => {
+		const host = radioGroup(`
+			<input type="radio" value="free" />
+			<input type="radio" value="pro" />
+		`);
+
+		expect((getAriaControlTarget(host) as HTMLInputElement).getAttribute('value')).toBe('free');
+	});
+
+	it('falls back to the host when the group renders no radios', () => {
+		const host = radioGroup('<span>no controls yet</span>');
+
+		expect(getAriaControlTarget(host)).toBe(host);
+	});
+
+	it('never sends a pseudo-class selector to the minimal DOM', () => {
+		const host = radioGroup('<input type="radio" value="free" checked />');
+
+		expect(() => getAriaControlTarget(host)).not.toThrow(SyntaxError);
+	});
+});

--- a/packages/radiant-ui/src/components/ui/form/control-protocol.ssr.test.ts
+++ b/packages/radiant-ui/src/components/ui/form/control-protocol.ssr.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { findFieldControl, isNativeTextControl } from '../form/control-protocol';
+import { findFieldControl, getAriaControlTarget, isNativeTextControl } from '../form/control-protocol';
 
 describe('field control protocol (SSR-safe)', () => {
 	it('discovers marked inputs and host tags, not bare natives', () => {
@@ -30,5 +30,27 @@ describe('field control protocol (SSR-safe)', () => {
 		const div = document.createElement('div');
 		expect(isNativeTextControl(input)).toBe(true);
 		expect(isNativeTextControl(div)).toBe(false);
+	});
+
+	/**
+	 * In a real DOM the `checked` property tracks user selection while the attribute keeps
+	 * marking whatever was server-rendered, so the property has to win. This is why the
+	 * radio-group branch cannot simply swap `:checked` for `[checked]`.
+	 */
+	it('targets the user-selected radio, not the server-rendered one', () => {
+		const host = document.createElement('rui-radio-group');
+		host.innerHTML = `
+			<input type="radio" value="free" />
+			<input type="radio" value="pro" checked />
+		`;
+		const [free, pro] = Array.from(host.querySelectorAll<HTMLInputElement>('input[type="radio"]'));
+
+		expect(getAriaControlTarget(host).getAttribute('value')).toBe('pro');
+
+		pro!.checked = false;
+		free!.checked = true;
+
+		expect(getAriaControlTarget(host).getAttribute('value')).toBe('free');
+		expect(pro!.hasAttribute('checked')).toBe(true);
 	});
 });

--- a/packages/radiant-ui/src/components/ui/form/control-protocol.ts
+++ b/packages/radiant-ui/src/components/ui/form/control-protocol.ts
@@ -360,6 +360,24 @@ export function wireFieldControlName(
 	}
 }
 
+/**
+ * Whether a radio is selected, in the browser and under the minimal SSR DOM.
+ *
+ * @remarks
+ * The minimal SSR DOM rejects pseudo-classes, so `input:checked` throws a `SyntaxError`
+ * server-side, and it has no `checked` property — state lives only on the attribute.
+ * In the browser the property is authoritative: after a user selects a different radio the
+ * `checked` attribute still marks the originally-rendered one, so the property must win.
+ * Read via `Reflect.get` so the missing SSR property is an explicit `undefined`, not a
+ * typed-as-boolean that happens to be nullish.
+ *
+ * @see `packages/radiant/src/server/README.md` — SSR gap registry (selector post-filters).
+ */
+function isChecked(input: HTMLInputElement): boolean {
+	const checked = Reflect.get(input, 'checked');
+	return typeof checked === 'boolean' ? checked : input.hasAttribute('checked');
+}
+
 /** Element that receives `id`, `aria-invalid`, and `aria-describedby` from Field. */
 export function getAriaControlTarget(control: HTMLElement): HTMLElement {
 	if (isNativeTextControl(control)) {
@@ -408,9 +426,13 @@ export function getAriaControlTarget(control: HTMLElement): HTMLElement {
 	}
 
 	if (control.localName === 'rui-radio-group') {
-		const checked = control.querySelector<HTMLInputElement>('input[type="radio"]:checked');
-		const first = control.querySelector<HTMLInputElement>('input[type="radio"]');
-		return checked ?? first ?? control;
+		const radios = control.querySelectorAll<HTMLInputElement>('input[type="radio"]');
+		for (const radio of radios) {
+			if (isChecked(radio)) {
+				return radio;
+			}
+		}
+		return radios[0] ?? control;
 	}
 
 	return control;

--- a/packages/radiant/src/server/README.md
+++ b/packages/radiant/src/server/README.md
@@ -228,13 +228,13 @@ SSR hosts created with `new Component()` also align `localName` / `tagName` to t
 
 Track minimal-DOM workarounds here before considering a heavier DOM backend. A backend spike is warranted only when multiple categories keep forcing shared workarounds.
 
-| API / limitation                      | Category           | Components                         | Workaround                                                 |
-| ------------------------------------- | ------------------ | ---------------------------------- | ---------------------------------------------------------- |
-| `:not`, `:scope`, sibling combinators | selector           | dialog, toolbar, tooltip, treegrid | Simple selectors + JS post-filter via shared query helpers |
+| API / limitation                      | Category           | Components                         | Workaround                                                                                    |
+| ------------------------------------- | ------------------ | ---------------------------------- | --------------------------------------------------------------------------------------------- |
+| `:not`, `:scope`, sibling combinators | selector           | dialog, toolbar, tooltip, treegrid | Simple selectors + JS post-filter via shared query helpers                                    |
 | `:checked`                            | selector           | field (radio-group aria target)    | Query `input[type="radio"]`, then filter on the `checked` property with an attribute fallback |
-| `instanceof HTMLLabelElement`         | prototype-identity | combobox                           | `tagName.toLowerCase() === 'label'`                        |
-| `requestAnimationFrame` callbacks     | timing             | toast, toaster                     | No-op shim during SSR; hydrate owns layout                 |
-| Live `HTMLCollection` for `children`  | dom-api            | treegrid                           | Read `children` snapshot or filter `childNodes` directly   |
+| `instanceof HTMLLabelElement`         | prototype-identity | combobox                           | `tagName.toLowerCase() === 'label'`                                                           |
+| `requestAnimationFrame` callbacks     | timing             | toast, toaster                     | No-op shim during SSR; hydrate owns layout                                                    |
+| Live `HTMLCollection` for `children`  | dom-api            | treegrid                           | Read `children` snapshot or filter `childNodes` directly                                      |
 
 ## Related Docs
 

--- a/packages/radiant/src/server/README.md
+++ b/packages/radiant/src/server/README.md
@@ -231,6 +231,7 @@ Track minimal-DOM workarounds here before considering a heavier DOM backend. A b
 | API / limitation                      | Category           | Components                         | Workaround                                                 |
 | ------------------------------------- | ------------------ | ---------------------------------- | ---------------------------------------------------------- |
 | `:not`, `:scope`, sibling combinators | selector           | dialog, toolbar, tooltip, treegrid | Simple selectors + JS post-filter via shared query helpers |
+| `:checked`                            | selector           | field (radio-group aria target)    | Query `input[type="radio"]`, then filter on the `checked` property with an attribute fallback |
 | `instanceof HTMLLabelElement`         | prototype-identity | combobox                           | `tagName.toLowerCase() === 'label'`                        |
 | `requestAnimationFrame` callbacks     | timing             | toast, toaster                     | No-op shim during SSR; hydrate owns layout                 |
 | Live `HTMLCollection` for `children`  | dom-api            | treegrid                           | Read `children` snapshot or filter `childNodes` directly   |


### PR DESCRIPTION
> Stacked on #132 (`refactor/typed-csf-story-meta`). Review that first; this PR is the single commit on top.

`getAriaControlTarget` passed `input[type="radio"]:checked` to `querySelector`. Radiant's minimal SSR DOM rejects every pseudo-class, so any server render of a `rui-radio-group` inside a field threw:

```
SyntaxError: Failed to execute 'querySelector' on 'Element':
'input[type="radio"]:checked' is not a valid selector.
  at getAriaControlTarget (src/components/ui/form/control-protocol.ts:411)
```

This killed the Storybook SSR dev server outright at `components-radio-group--as-field`. It was previously unreachable because SSR failed earlier for an unrelated reason.

## Why not just use `[checked]`

Tempting, and correct on the server — but `getAriaControlTarget` also runs in the browser, where the two diverge. After a user selects a different radio the `checked` **property** moves while the `checked` **attribute** still marks whatever was server-rendered. Rewriting the selector would have silently regressed the client to always target the SSR-selected radio.

So this queries all radios and post-filters on the property with an attribute fallback:

```ts
function isChecked(input: HTMLInputElement): boolean {
	return input.checked ?? input.hasAttribute('checked');
}
```

`undefined ?? …` handles SSR (no property); `false ?? …` short-circuits correctly in the browser. This is the workaround `packages/radiant/src/server/README.md` already sanctions for this class of gap — "simple selectors + JS post-filter" — and the `:checked` row is added to that registry table.

Of the 11 selectors in `getAriaControlTarget`, this was the only unsupported one.

## Tests

`aria-control-target.ssr.test.ts` runs under `@vitest-environment node` so `install-ssr-runtime` installs the real minimal DOM. This matters: the existing `.ssr.test` files run under happy-dom, which *implements* `:checked` and therefore could never have reproduced this. All 4 cases fail without the fix with the exact production `SyntaxError`.

A companion case in `control-protocol.ssr.test.ts` (happy-dom) pins the browser semantics — that the user-selected radio wins over the server-rendered one — so nobody "simplifies" this back to `[checked]`.

## Verification

- radiant-ui `ssr` project: 17 passing, up from 12.
- Full SSR story matrix: 0 occurrences of the selector error (previously fatal).
- `pnpm typecheck` clean.

## Scope

This fixes the `:checked` crash only. With it in, the SSR matrix gets further and then hits a **separate** pre-existing bug — `TypeError: tagGroup.setItems is not a function` at `select.script.tsx:454`. Not addressed here.

Also worth a follow-up: `:scope >` appears at 7 call sites in `menubar.script.tsx` / `tree.script.tsx`. Same class of bug, latent until those paths reach SSR.
