### PR TITLE
fix(radiant): stop hydration capturing a host's own SSR output as slot content

### DIFF
--- a/packages/jsx/src/dom-render/dom-operations.ts
+++ b/packages/jsx/src/dom-render/dom-operations.ts
@@ -107,6 +107,19 @@ export function insertNodesBefore(referenceNode: Node, nodes: readonly Node[]): 
 		return;
 	}
 
+	// A node that already contains the reference node cannot be inserted before it. The DOM
+	// answers that with a HierarchyRequestError, which escapes hydration as an uncaught
+	// exception; degrade to the same drift warning the detached case uses so the caller can
+	// fall back instead of tearing down the page.
+	for (const node of nodes) {
+		if (node.contains(referenceNode)) {
+			warnRuntime(DETACHED_INSERTION_POINT_WARNING, undefined, {
+				code: 'dom-range-anchor-drift:insert',
+			});
+			return;
+		}
+	}
+
 	const fragment = document.createDocumentFragment();
 
 	for (const node of nodes) {

--- a/packages/jsx/src/dom-render/dom-operations.ts
+++ b/packages/jsx/src/dom-render/dom-operations.ts
@@ -92,6 +92,12 @@ export function createNodesFromJsxNodeLike(value: JsxNodeLike): Node[] {
  *
  * No-ops when `nodes` is empty.
  *
+ * @remarks
+ * Degrades to a runtime warning (instead of throwing) when the reference node has no
+ * parent, or when any inserted node already contains the reference — both are illegal
+ * `insertBefore` targets that otherwise surface as uncaught DOMExceptions during
+ * hydration. Callers can fall back after the warning.
+ *
  * @param referenceNode Node before which the new nodes are inserted.
  * @param nodes Nodes to insert.
  */
@@ -107,10 +113,6 @@ export function insertNodesBefore(referenceNode: Node, nodes: readonly Node[]): 
 		return;
 	}
 
-	// A node that already contains the reference node cannot be inserted before it. The DOM
-	// answers that with a HierarchyRequestError, which escapes hydration as an uncaught
-	// exception; degrade to the same drift warning the detached case uses so the caller can
-	// fall back instead of tearing down the page.
 	for (const node of nodes) {
 		if (node.contains(referenceNode)) {
 			warnRuntime(DETACHED_INSERTION_POINT_WARNING, undefined, {

--- a/packages/jsx/src/hydration/hydration-bindings.ts
+++ b/packages/jsx/src/hydration/hydration-bindings.ts
@@ -202,6 +202,10 @@ export function serializeBindingDescriptor(kind: BindingKind, name: string): str
  *
  * Attributes are iterated in reverse index order so that callers may safely call
  * `removeAttribute` inside `visit` without corrupting the live `NamedNodeMap`.
+ *
+ * @remarks
+ * Incomplete SSR DOM shims may omit `attributes` or expose a non-`NamedNodeMap`
+ * store. Those hosts have no Attr markers to recover, so the walk is a no-op.
  */
 export function visitHydrationBindingMarkers(
 	target: HTMLElement,
@@ -209,9 +213,7 @@ export function visitHydrationBindingMarkers(
 ): boolean {
 	let foundHydrationMarker = false;
 	const walk = (element: Element): void => {
-		const attributes = Array.from(element.attributes).filter((attribute) =>
-			attribute.name.startsWith(ATTRIBUTE_BINDING_PREFIX),
-		);
+		const attributes = listHydrationBindingAttributes(element);
 
 		for (let index = attributes.length - 1; index >= 0; index -= 1) {
 			const attribute = attributes[index];
@@ -242,6 +244,38 @@ export function visitHydrationBindingMarkers(
 	walk(target);
 
 	return foundHydrationMarker;
+}
+
+/**
+ * Collects Attr nodes that carry hydration markers on `element`.
+ *
+ * @remarks
+ * Requires a real `NamedNodeMap`-shaped `attributes` list. Map-backed SSR shims
+ * and missing attribute bags are treated as empty — calling `Array.from` on a
+ * `Map` would otherwise yield `[name, value]` tuples and crash on `.name`.
+ */
+function listHydrationBindingAttributes(element: Element): Attr[] {
+	const namedAttributes = element.attributes;
+
+	if (!namedAttributes || typeof namedAttributes.length !== 'number') {
+		return [];
+	}
+
+	const markers: Attr[] = [];
+
+	for (let index = 0; index < namedAttributes.length; index += 1) {
+		const attribute = namedAttributes.item(index) ?? namedAttributes[index];
+
+		if (
+			attribute &&
+			typeof attribute.name === 'string' &&
+			attribute.name.startsWith(ATTRIBUTE_BINDING_PREFIX)
+		) {
+			markers.push(attribute);
+		}
+	}
+
+	return markers;
 }
 
 function collectValueBindings(

--- a/packages/jsx/src/hydration/hydration-bindings.ts
+++ b/packages/jsx/src/hydration/hydration-bindings.ts
@@ -266,11 +266,7 @@ function listHydrationBindingAttributes(element: Element): Attr[] {
 	for (let index = 0; index < namedAttributes.length; index += 1) {
 		const attribute = namedAttributes.item(index) ?? namedAttributes[index];
 
-		if (
-			attribute &&
-			typeof attribute.name === 'string' &&
-			attribute.name.startsWith(ATTRIBUTE_BINDING_PREFIX)
-		) {
+		if (attribute && typeof attribute.name === 'string' && attribute.name.startsWith(ATTRIBUTE_BINDING_PREFIX)) {
 			markers.push(attribute);
 		}
 	}

--- a/packages/jsx/src/hydration/hydration-bindings.ts
+++ b/packages/jsx/src/hydration/hydration-bindings.ts
@@ -74,6 +74,12 @@ export function collectHydrationBindings(
  *
  * Used to skip a nested subtree's slice of the global namespace when a caller
  * needs the index a later sibling starts at.
+ *
+ * @remarks
+ * A custom-element root is serialized by the SSR render hook, which returns
+ * before taking any index. Its whole subtree contributes nothing to the parent's
+ * namespace, and counting it would shift every later marker — hence the
+ * {@link shouldSkipHydrationSubtree} early return.
  */
 export function countHydrationMarkers(value: JsxRenderable): number {
 	if (value === undefined || value === null || value === false || value === true) {
@@ -81,9 +87,6 @@ export function countHydrationMarkers(value: JsxRenderable): number {
 	}
 
 	if (isTemplateResultLike(value)) {
-		// A custom-element root is serialized by the SSR render hook, which returns
-		// before taking any index. Its whole subtree contributes nothing to the
-		// parent's namespace, and counting it would shift every later marker.
 		if (shouldSkipHydrationSubtree(value.rootLocalName ?? '')) {
 			return 0;
 		}

--- a/packages/jsx/src/hydration/hydration-bindings.ts
+++ b/packages/jsx/src/hydration/hydration-bindings.ts
@@ -204,13 +204,17 @@ export function serializeBindingDescriptor(kind: BindingKind, name: string): str
  * `removeAttribute` inside `visit` without corrupting the live `NamedNodeMap`.
  *
  * @remarks
- * Incomplete SSR DOM shims may omit `attributes` or expose a non-`NamedNodeMap`
- * store. Those hosts have no Attr markers to recover, so the walk is a no-op.
+ * Incomplete SSR DOM shims may omit a real `NamedNodeMap`/`HTMLCollection`. Those
+ * hosts have no Attr markers to recover, so the walk is a no-op.
  */
 export function visitHydrationBindingMarkers(
 	target: HTMLElement,
 	visit: (element: Element, attribute: Attr) => void,
 ): boolean {
+	if (!isNamedNodeMapLike(target.attributes)) {
+		return false;
+	}
+
 	let foundHydrationMarker = false;
 	const walk = (element: Element): void => {
 		const attributes = listHydrationBindingAttributes(element);
@@ -233,7 +237,7 @@ export function visitHydrationBindingMarkers(
 		const children = element.children;
 
 		for (let index = 0; index < children.length; index += 1) {
-			const child = children.item(index);
+			const child = getChildElementAt(children, index);
 
 			if (child) {
 				walk(child);
@@ -257,7 +261,7 @@ export function visitHydrationBindingMarkers(
 function listHydrationBindingAttributes(element: Element): Attr[] {
 	const namedAttributes = element.attributes;
 
-	if (!namedAttributes || typeof namedAttributes.length !== 'number') {
+	if (!isNamedNodeMapLike(namedAttributes)) {
 		return [];
 	}
 
@@ -272,6 +276,18 @@ function listHydrationBindingAttributes(element: Element): Attr[] {
 	}
 
 	return markers;
+}
+
+function isNamedNodeMapLike(value: NamedNodeMap | undefined | null): value is NamedNodeMap {
+	return Boolean(value && typeof value.length === 'number' && typeof value.item === 'function');
+}
+
+function getChildElementAt(children: HTMLCollection, index: number): Element | null {
+	if (typeof children.item === 'function') {
+		return children.item(index);
+	}
+
+	return (children as unknown as ArrayLike<Element | null | undefined>)[index] ?? null;
 }
 
 function collectValueBindings(

--- a/packages/jsx/src/warnings/jsx-dev-warnings.ts
+++ b/packages/jsx/src/warnings/jsx-dev-warnings.ts
@@ -32,7 +32,7 @@ const HYDRATION_MALFORMED_BINDING_DESCRIPTOR_WARNING_PREFIX = 'Ignored malformed
 const HYDRATION_MISSING_BINDING_WARNING_PREFIX = 'Ignored hydration marker without a matching binding value';
 const DOM_RANGE_ANCHOR_DRIFT_WARNING_PREFIX = 'A renderer-managed DOM range was mutated outside Radiant JSX control';
 const DETACHED_INSERTION_POINT_WARNING_MESSAGE =
-	'A renderer-managed insertion point was detached before insertNodesBefore ran.';
+	'insertNodesBefore skipped: the reference node is detached or would form a hierarchy cycle.';
 
 export function installDefaultDevWarningFormatter(): void {
 	installDevWarningFormatter((kind, detail) => {

--- a/packages/jsx/test/dom-operations.browser.test.ts
+++ b/packages/jsx/test/dom-operations.browser.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { insertNodesBefore } from '../src/dom-render/dom-operations.ts';
+import {
+	installDefaultDevWarningFormatter,
+	resetRuntimeWarningsForTests,
+	setDevWarningsEnabled,
+} from '../src/warnings/jsx-dev-warnings.ts';
+
+beforeEach(() => {
+	// Normally installed by `jsx-dev-runtime`; without it `warnRuntime` has no formatter.
+	installDefaultDevWarningFormatter();
+	setDevWarningsEnabled(true);
+	resetRuntimeWarningsForTests();
+});
+
+afterEach(() => {
+	resetRuntimeWarningsForTests();
+	setDevWarningsEnabled(undefined);
+});
+
+describe('insertNodesBefore', () => {
+	test('inserts nodes before the reference node', () => {
+		const parent = document.createElement('div');
+		const reference = document.createElement('span');
+		parent.append(reference);
+
+		const first = document.createElement('b');
+		const second = document.createElement('i');
+		insertNodesBefore(reference, [first, second]);
+
+		expect(Array.from(parent.children)).toEqual([first, second, reference]);
+	});
+
+	test('no-ops on an empty node list', () => {
+		const parent = document.createElement('div');
+		const reference = document.createElement('span');
+		parent.append(reference);
+
+		insertNodesBefore(reference, []);
+
+		expect(parent.children).toHaveLength(1);
+	});
+
+	/**
+	 * A stale range can hand back a node that already contains the anchor. The DOM answers
+	 * that with a HierarchyRequestError, which escapes hydration as an uncaught exception —
+	 * so this degrades to the drift warning instead, letting the caller fall back.
+	 */
+	test('warns instead of throwing when a node contains the reference node', () => {
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+		const ancestor = document.createElement('div');
+		const reference = document.createElement('span');
+		ancestor.append(reference);
+		document.body.append(ancestor);
+
+		expect(() => insertNodesBefore(reference, [ancestor])).not.toThrow();
+		expect(warn).toHaveBeenCalledOnce();
+		expect(ancestor.contains(reference)).toBe(true);
+
+		ancestor.remove();
+		warn.mockRestore();
+	});
+
+	test('rejects the whole batch when any node contains the reference node', () => {
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+		const ancestor = document.createElement('div');
+		const reference = document.createElement('span');
+		ancestor.append(reference);
+		document.body.append(ancestor);
+		const safe = document.createElement('b');
+
+		insertNodesBefore(reference, [safe, ancestor]);
+
+		expect(safe.parentNode).toBeNull();
+		expect(Array.from(ancestor.children)).toEqual([reference]);
+
+		ancestor.remove();
+		warn.mockRestore();
+	});
+});

--- a/packages/jsx/test/hydration-marker-policy.test.tsx
+++ b/packages/jsx/test/hydration-marker-policy.test.tsx
@@ -266,10 +266,17 @@ describe('visitHydrationBindingMarkers DOM compatibility', () => {
 		expect(visitHydrationBindingMarkers(host, () => undefined)).toBe(false);
 	});
 
-	test('skips hosts with a missing attributes bag', async () => {
+	test('skips hosts with a missing attributes bag without walking children', async () => {
 		const { visitHydrationBindingMarkers } = await loadHydrationBindings();
 		const host = {
-			children: { length: 0, item: () => null },
+			children: {
+				get length() {
+					throw new Error('children should not be walked without a NamedNodeMap');
+				},
+				item: () => {
+					throw new Error('children should not be walked without a NamedNodeMap');
+				},
+			},
 			localName: 'demo-host',
 		} as unknown as HTMLElement;
 
@@ -290,6 +297,36 @@ describe('visitHydrationBindingMarkers DOM compatibility', () => {
 		const host = {
 			attributes,
 			children: { length: 0, item: () => null },
+			localName: 'demo-host',
+		} as unknown as HTMLElement;
+
+		const visited: string[] = [];
+		expect(
+			visitHydrationBindingMarkers(host, (_element, attribute) => {
+				visited.push(attribute.name);
+			}),
+		).toBe(true);
+		expect(visited).toEqual([`${ATTRIBUTE_BINDING_PREFIX}0`]);
+	});
+
+	test('walks array-like children that omit item()', async () => {
+		const { ATTRIBUTE_BINDING_PREFIX, visitHydrationBindingMarkers } = await loadHydrationBindings();
+		const marker = {
+			name: `${ATTRIBUTE_BINDING_PREFIX}0`,
+			value: 'attr:title',
+		};
+		const child = {
+			attributes: {
+				0: marker,
+				length: 1,
+				item: (index: number) => (index === 0 ? marker : null),
+			},
+			children: [],
+			localName: 'span',
+		};
+		const host = {
+			attributes: { length: 0, item: () => null },
+			children: [child],
 			localName: 'demo-host',
 		} as unknown as HTMLElement;
 

--- a/packages/jsx/test/hydration-marker-policy.test.tsx
+++ b/packages/jsx/test/hydration-marker-policy.test.tsx
@@ -253,3 +253,52 @@ describe('template attribute marker index collection', () => {
 		expect(incIndices.nextIndex).toBe(bindings.size);
 	});
 });
+
+describe('visitHydrationBindingMarkers DOM compatibility', () => {
+	test('skips hosts whose attributes bag is a Map instead of a NamedNodeMap', async () => {
+		const { visitHydrationBindingMarkers } = await loadHydrationBindings();
+		const host = {
+			attributes: new Map([['data-radiant-jsx-bind-0', 'attr:title']]),
+			children: { length: 0, item: () => null },
+			localName: 'demo-host',
+		} as unknown as HTMLElement;
+
+		expect(visitHydrationBindingMarkers(host, () => undefined)).toBe(false);
+	});
+
+	test('skips hosts with a missing attributes bag', async () => {
+		const { visitHydrationBindingMarkers } = await loadHydrationBindings();
+		const host = {
+			children: { length: 0, item: () => null },
+			localName: 'demo-host',
+		} as unknown as HTMLElement;
+
+		expect(visitHydrationBindingMarkers(host, () => undefined)).toBe(false);
+	});
+
+	test('still finds Attr markers on a NamedNodeMap-shaped attributes list', async () => {
+		const { ATTRIBUTE_BINDING_PREFIX, visitHydrationBindingMarkers } = await loadHydrationBindings();
+		const marker = {
+			name: `${ATTRIBUTE_BINDING_PREFIX}0`,
+			value: 'attr:title',
+		};
+		const attributes = {
+			0: marker,
+			length: 1,
+			item: (index: number) => (index === 0 ? marker : null),
+		};
+		const host = {
+			attributes,
+			children: { length: 0, item: () => null },
+			localName: 'demo-host',
+		} as unknown as HTMLElement;
+
+		const visited: string[] = [];
+		expect(
+			visitHydrationBindingMarkers(host, (_element, attribute) => {
+				visited.push(attribute.name);
+			}),
+		).toBe(true);
+		expect(visited).toEqual([`${ATTRIBUTE_BINDING_PREFIX}0`]);
+	});
+});

--- a/packages/radiant-ui/src/components/ui/select/select.script.tsx
+++ b/packages/radiant-ui/src/components/ui/select/select.script.tsx
@@ -154,8 +154,21 @@ export class RuiSelect extends RadiantElement {
 		});
 	}
 
+	/**
+	 * Resolves the multi-select chip host inside the value slot.
+	 *
+	 * @remarks
+	 * During Storybook/SSR upgrade, `querySelector` can return the host before
+	 * `rui-tag-group` is defined — treat that as absent until `setItems` exists.
+	 */
 	private getTagGroup(): RuiTagGroup | null {
-		return this.querySelector<RuiTagGroup>('[data-select-value] rui-tag-group');
+		const tagGroup = this.querySelector<RuiTagGroup>('[data-select-value] rui-tag-group');
+
+		if (!tagGroup || typeof tagGroup.setItems !== 'function') {
+			return null;
+		}
+
+		return tagGroup;
 	}
 
 	private hasTagGroup(): boolean {

--- a/packages/radiant/src/core/render-runtime.ts
+++ b/packages/radiant/src/core/render-runtime.ts
@@ -154,6 +154,21 @@ export class RenderRuntime {
 		this.disconnectRenderWatcher();
 	}
 
+	/**
+	 * Capture authored light-DOM slot content once, before the host's own first render.
+	 *
+	 * @remarks
+	 * Prefer the `data-radiant-slot-projection` script when present. Otherwise treat
+	 * "host has children" as authored content only while `#hasMounted` is still false —
+	 * after the first pass those children are the host's own light-DOM output and must
+	 * not be fed back in as slot content.
+	 *
+	 * `#hasMounted` alone misses SSR hydration: the host already holds its server-rendered
+	 * markup while the flag is false. Client-side, {@link hasHydrationMarkers} is the
+	 * positive signal to skip capture (authored SSR content arrives via the script above).
+	 * Server-side the children *are* authored and there are no markers yet, so the marker
+	 * walk is skipped via {@link isServer} — the minimal SSR DOM cannot back it.
+	 */
 	private ensureSlotProjectionState(): void {
 		if (this.#projectedSlotContent.size > 0) {
 			return;
@@ -167,19 +182,6 @@ export class RenderRuntime {
 			return;
 		}
 
-		// Only trust "the host has children" as authored slot content before the host's
-		// own first render/hydrate pass has run. After that, any children present are the
-		// host's own previously-rendered output (light-DOM mode writes into `this.#host`),
-		// not user-authored content — capturing them here would feed a render's own output
-		// back into itself as "slot content" on the next pass.
-		//
-		// `#hasMounted` alone cannot see the SSR case: on first hydrate the host already
-		// holds its own server-rendered output while `#hasMounted` is still false. Hydration
-		// markers are the positive signal for that. Authored content that existed at SSR time
-		// arrives through the projection script above, so nothing is lost by skipping here.
-		//
-		// Server-side the children *are* the authored content and there are no markers yet,
-		// so the check is client-only — the minimal SSR DOM also cannot back the marker walk.
 		if (
 			!this.#hasMounted &&
 			this.#host.childNodes.length > 0 &&

--- a/packages/radiant/src/core/render-runtime.ts
+++ b/packages/radiant/src/core/render-runtime.ts
@@ -1,9 +1,4 @@
-import {
-	hasHydrationMarkers,
-	hydrate as hydrateJsx,
-	render as renderJsx,
-	type JsxRenderable,
-} from '@ecopages/jsx';
+import { hasHydrationMarkers, hydrate as hydrateJsx, render as renderJsx, type JsxRenderable } from '@ecopages/jsx';
 import { isServer } from '@ecopages/radiant/is-server';
 import {
 	createReactiveComputed,
@@ -182,11 +177,7 @@ export class RenderRuntime {
 			return;
 		}
 
-		if (
-			!this.#hasMounted &&
-			this.#host.childNodes.length > 0 &&
-			(isServer || !hasHydrationMarkers(this.#host))
-		) {
+		if (!this.#hasMounted && this.#host.childNodes.length > 0 && (isServer || !hasHydrationMarkers(this.#host))) {
 			this.#projectedSlotContent = captureProjectedSlotRenderables(this.#host);
 			this.#slotProjectionVersion += 1;
 		}

--- a/packages/radiant/src/core/render-runtime.ts
+++ b/packages/radiant/src/core/render-runtime.ts
@@ -1,4 +1,10 @@
-import { hydrate as hydrateJsx, render as renderJsx, type JsxRenderable } from '@ecopages/jsx';
+import {
+	hasHydrationMarkers,
+	hydrate as hydrateJsx,
+	render as renderJsx,
+	type JsxRenderable,
+} from '@ecopages/jsx';
+import { isServer } from '@ecopages/radiant/is-server';
 import {
 	createReactiveComputed,
 	createReactiveWatcher,
@@ -166,7 +172,19 @@ export class RenderRuntime {
 		// host's own previously-rendered output (light-DOM mode writes into `this.#host`),
 		// not user-authored content — capturing them here would feed a render's own output
 		// back into itself as "slot content" on the next pass.
-		if (!this.#hasMounted && this.#host.childNodes.length > 0) {
+		//
+		// `#hasMounted` alone cannot see the SSR case: on first hydrate the host already
+		// holds its own server-rendered output while `#hasMounted` is still false. Hydration
+		// markers are the positive signal for that. Authored content that existed at SSR time
+		// arrives through the projection script above, so nothing is lost by skipping here.
+		//
+		// Server-side the children *are* the authored content and there are no markers yet,
+		// so the check is client-only — the minimal SSR DOM also cannot back the marker walk.
+		if (
+			!this.#hasMounted &&
+			this.#host.childNodes.length > 0 &&
+			(isServer || !hasHydrationMarkers(this.#host))
+		) {
 			this.#projectedSlotContent = captureProjectedSlotRenderables(this.#host);
 			this.#slotProjectionVersion += 1;
 		}

--- a/packages/radiant/src/server/shim/minimal-dom/nodes.ts
+++ b/packages/radiant/src/server/shim/minimal-dom/nodes.ts
@@ -235,7 +235,14 @@ class MinimalClassList {
 }
 
 export class MinimalElement extends MinimalNode {
-	private attributes = new Map<string, string>();
+	/**
+	 * @remarks
+	 * Must not be named `attributes`: TypeScript `private` is erased at runtime, and
+	 * a field of that name would collide with the DOM `attributes` NamedNodeMap that
+	 * hydration marker walks expect. A `Map` there makes `Array.from(el.attributes)`
+	 * yield `[name, value]` tuples and crash on `.name.startsWith(...)`.
+	 */
+	#attributeStore = new Map<string, string>();
 	private classListValue?: MinimalClassList;
 	private datasetValue?: DOMStringMap;
 	private styleValue?: CSSStyleDeclaration;
@@ -335,20 +342,20 @@ export class MinimalElement extends MinimalNode {
 	}
 
 	hasAttribute(name: string): boolean {
-		return this.attributes.has(name);
+		return this.#attributeStore.has(name);
 	}
 
 	getAttribute(name: string): string | null {
-		return this.attributes.get(name) ?? null;
+		return this.#attributeStore.get(name) ?? null;
 	}
 
 	getAttributeNames(): string[] {
-		return Array.from(this.attributes.keys());
+		return Array.from(this.#attributeStore.keys());
 	}
 
 	setAttribute(name: string, value: unknown): void {
 		this.clearFragmentCache();
-		this.attributes.set(name, String(value));
+		this.#attributeStore.set(name, String(value));
 	}
 
 	toggleAttribute(name: string, force?: boolean): boolean {
@@ -365,7 +372,7 @@ export class MinimalElement extends MinimalNode {
 
 	removeAttribute(name: string): void {
 		this.clearFragmentCache();
-		this.attributes.delete(name);
+		this.#attributeStore.delete(name);
 	}
 
 	get parentElement(): MinimalElement | null {
@@ -419,7 +426,7 @@ export class MinimalElement extends MinimalNode {
 			return this.fragmentHtml;
 		}
 
-		const attributes = Array.from(this.attributes.entries())
+		const attributes = Array.from(this.#attributeStore.entries())
 			.map(([name, value]) => serializeHtmlAttribute(name, value))
 			.join('');
 
@@ -455,7 +462,7 @@ export class MinimalElement extends MinimalNode {
 		this.fragmentHtml = fragmentHtml;
 		this.fragmentInnerHtml = innerHtml;
 		this.fragmentText = fragmentText;
-		this.attributes = new Map(Object.entries(attributes));
+		this.#attributeStore = new Map(Object.entries(attributes));
 		this.replaceChildren();
 	}
 }

--- a/packages/radiant/src/server/shim/minimal-dom/nodes.ts
+++ b/packages/radiant/src/server/shim/minimal-dom/nodes.ts
@@ -38,6 +38,18 @@ function ensureHtmlParsers(): HtmlParsers {
 	return htmlParsers;
 }
 
+/**
+ * Builds an `HTMLCollection`-shaped view over element children.
+ *
+ * @remarks
+ * Plain arrays lack `.item()`, which hydration marker walks and other DOM code call.
+ */
+function createMinimalHtmlCollection(elements: MinimalHTMLElement[]): HTMLCollection {
+	const collection = elements as unknown as MinimalHTMLElement[] & HTMLCollection;
+	collection.item = (index: number): Element | null => (elements[index] as unknown as Element | undefined) ?? null;
+	return collection;
+}
+
 function createMinimalStyle(onChange: (value: string) => void): CSSStyleDeclaration {
 	const values = new Map<string, string>();
 	const commit = () => onChange([...values].map(([name, value]) => `${name}: ${value}`).join('; '));
@@ -380,10 +392,12 @@ export class MinimalElement extends MinimalNode {
 		return parent instanceof MinimalElement ? parent : null;
 	}
 
-	get children(): MinimalHTMLElement[] {
-		return Array.from(this.childNodes ?? []).filter(
+	get children(): HTMLCollection {
+		const elements = Array.from(this.childNodes ?? []).filter(
 			(node) => node.nodeType === MinimalNode.ELEMENT_NODE,
 		) as unknown as MinimalHTMLElement[];
+
+		return createMinimalHtmlCollection(elements);
 	}
 
 	materializeChildren(): void {

--- a/packages/radiant/test/core/render-runtime-slot-projection.browser.test.tsx
+++ b/packages/radiant/test/core/render-runtime-slot-projection.browser.test.tsx
@@ -23,7 +23,7 @@ const SSR_OUTPUT = '<div data-radiant-jsx-bind-0="attr:class" class="card"><div 
 const AUTHORED_LIGHT_DOM = '<span data-authored>authored</span>';
 
 describe('RenderRuntime slot projection', () => {
-	test('ignores the host’s own SSR output when hydration markers are present', () => {
+	test("ignores the host's own SSR output when hydration markers are present", () => {
 		const host = createHost(SSR_OUTPUT);
 		const runtime = new RenderRuntime(host);
 
@@ -43,5 +43,4 @@ describe('RenderRuntime slot projection', () => {
 		expect(runtime.slotProjectionVersion).toBe(1);
 		host.remove();
 	});
-
 });

--- a/packages/radiant/test/core/render-runtime-slot-projection.browser.test.tsx
+++ b/packages/radiant/test/core/render-runtime-slot-projection.browser.test.tsx
@@ -1,0 +1,47 @@
+import { describe, expect, test } from 'vitest';
+import { jsx } from '@ecopages/jsx';
+import { RenderRuntime, type RenderRuntimeHost } from '../../src/core/render-runtime';
+
+/**
+ * Regression coverage for hydration feeding a host's own SSR output back in as slot content.
+ *
+ * On first hydrate the host already holds its server-rendered markup while `hasMounted` is
+ * still false, so the "host has children ⇒ authored light DOM" heuristic used to capture
+ * that output as default-slot content. The slot value then became an ancestor of the very
+ * range it was inserted into, and `insertNodesBefore` threw a `HierarchyRequestError`.
+ */
+function createHost(innerHTML: string): RenderRuntimeHost {
+	const host = document.createElement('slot-projection-host') as RenderRuntimeHost;
+	host.innerHTML = innerHTML;
+	host.render = () => jsx('div', { children: jsx('slot', {}) });
+	host.requestUpdate = () => {};
+	document.body.appendChild(host);
+	return host;
+}
+
+const SSR_OUTPUT = '<div data-radiant-jsx-bind-0="attr:class" class="card"><div data-ref="pane"></div></div>';
+const AUTHORED_LIGHT_DOM = '<span data-authored>authored</span>';
+
+describe('RenderRuntime slot projection', () => {
+	test('ignores the host’s own SSR output when hydration markers are present', () => {
+		const host = createHost(SSR_OUTPUT);
+		const runtime = new RenderRuntime(host);
+
+		runtime.hydrate(host);
+
+		// Nothing was captured as slot content, so the version counter never advanced.
+		expect(runtime.slotProjectionVersion).toBe(0);
+		host.remove();
+	});
+
+	test('still captures authored light DOM that carries no hydration markers', () => {
+		const host = createHost(AUTHORED_LIGHT_DOM);
+		const runtime = new RenderRuntime(host);
+
+		runtime.render(host);
+
+		expect(runtime.slotProjectionVersion).toBe(1);
+		host.remove();
+	});
+
+});

--- a/packages/radiant/test/server/minimal-dom-install.test.ts
+++ b/packages/radiant/test/server/minimal-dom-install.test.ts
@@ -138,6 +138,21 @@ describe('minimal DOM installation boundary', () => {
 		expect(host.attributes instanceof Map).toBe(false);
 	});
 
+	test('exposes HTMLCollection-shaped children with item()', async () => {
+		clearDomGlobals();
+
+		const { installLightDomShim } = await import('../../src/server/shim/minimal-dom/install');
+		installLightDomShim();
+
+		const host = document.createElement('demo-host');
+		const child = document.createElement('span');
+		host.append(child);
+
+		expect(typeof host.children.item).toBe('function');
+		expect(host.children.item(0)).toBe(child);
+		expect(host.children.item(1)).toBeNull();
+	});
+
 	test('replaces a foreign DOM when a custom-element host fails the style probe', async () => {
 		const { ForeignHTMLElement, foreignDocument } = installForeignPartialDom();
 		const { installLightDomShim } = await import('../../src/server/shim/minimal-dom/install');

--- a/packages/radiant/test/server/minimal-dom-install.test.ts
+++ b/packages/radiant/test/server/minimal-dom-install.test.ts
@@ -124,6 +124,20 @@ describe('minimal DOM installation boundary', () => {
 		expect(globalThis.cancelAnimationFrame).toBeTypeOf('function');
 	});
 
+	test('does not expose the attribute store as element.attributes', async () => {
+		clearDomGlobals();
+
+		const { installLightDomShim } = await import('../../src/server/shim/minimal-dom/install');
+		installLightDomShim();
+
+		const host = document.createElement('demo-host');
+		host.setAttribute('title', 'ok');
+
+		expect(host.getAttribute('title')).toBe('ok');
+		expect(host.attributes).toBeUndefined();
+		expect(host.attributes instanceof Map).toBe(false);
+	});
+
 	test('replaces a foreign DOM when a custom-element host fails the style probe', async () => {
 		const { ForeignHTMLElement, foreignDocument } = installForeignPartialDom();
 		const { installLightDomShim } = await import('../../src/server/shim/minimal-dom/install');

--- a/packages/storybook-radiant-vite/src/apply-control-overrides.test.ts
+++ b/packages/storybook-radiant-vite/src/apply-control-overrides.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from 'vitest';
+import { applyControlOverrides } from './storybook-ssr.ts';
+
+describe('applyControlOverrides', () => {
+	test('replaces nested array args instead of spreading them into objects', () => {
+		const merged = applyControlOverrides(
+			{
+				rows: [
+					['Mon', 'Tue', 'Wed'],
+					['A', 'B', 'C'],
+				],
+			},
+			{
+				rows: [
+					['Mon', 'Tue', 'Wed'],
+					['A', 'B', 'C'],
+				],
+			},
+		);
+
+		expect(merged.rows).toEqual([
+			['Mon', 'Tue', 'Wed'],
+			['A', 'B', 'C'],
+		]);
+		expect(Array.isArray((merged.rows as unknown[])[0])).toBe(true);
+	});
+
+	test('still deep-merges arrays of plain objects by index', () => {
+		const merged = applyControlOverrides(
+			{
+				items: [
+					{ id: 'a', label: 'Alpha' },
+					{ id: 'b', label: 'Beta' },
+				],
+			},
+			{
+				items: [{ label: 'A1' }, { label: 'B1' }],
+			},
+		);
+
+		expect(merged.items).toEqual([
+			{ id: 'a', label: 'A1' },
+			{ id: 'b', label: 'B1' },
+		]);
+	});
+
+	test('replaces primitive array overrides wholesale', () => {
+		const merged = applyControlOverrides({ tags: ['one', 'two'] }, { tags: ['one', 'two', 'three'] });
+
+		expect(merged.tags).toEqual(['one', 'two', 'three']);
+	});
+});

--- a/packages/storybook-radiant-vite/src/apply-control-overrides.test.ts
+++ b/packages/storybook-radiant-vite/src/apply-control-overrides.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { applyControlOverrides } from './storybook-ssr.ts';
+import { applyControlOverrides } from './storybook-ssr';
 
 describe('applyControlOverrides', () => {
 	test('replaces nested array args instead of spreading them into objects', () => {

--- a/packages/storybook-radiant-vite/src/storybook-ssr.ts
+++ b/packages/storybook-radiant-vite/src/storybook-ssr.ts
@@ -98,9 +98,7 @@ export function applyControlOverrides(
 }
 
 function canDeepMergeArrayItems(baseItems: readonly unknown[], overrideItems: readonly unknown[]): boolean {
-	return (
-		baseItems.every(isPlainObject) && overrideItems.every((item) => item === undefined || isPlainObject(item))
-	);
+	return baseItems.every(isPlainObject) && overrideItems.every((item) => item === undefined || isPlainObject(item));
 }
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {

--- a/packages/storybook-radiant-vite/src/storybook-ssr.ts
+++ b/packages/storybook-radiant-vite/src/storybook-ssr.ts
@@ -53,7 +53,15 @@ export async function resolveStoryArgs(
 	return applyControlOverrides(base, overrides);
 }
 
-function applyControlOverrides(
+/**
+ * Merges Storybook control overrides onto CSF module args for SSR.
+ *
+ * @remarks
+ * Arrays of plain objects are deep-merged by index (option lists). Nested arrays
+ * and primitives replace wholesale — spreading an array into an object turns
+ * `['Mon','Tue']` into `{0:'Mon',1:'Tue'}`, which then breaks `.map`.
+ */
+export function applyControlOverrides(
 	base: Record<string, unknown>,
 	overrides: Record<string, unknown>,
 ): Record<string, unknown> {
@@ -65,10 +73,17 @@ function applyControlOverrides(
 		}
 
 		if (Array.isArray(value) && Array.isArray(merged[key])) {
-			merged[key] = (merged[key] as unknown[]).map((baseItem, index) => {
+			const baseItems = merged[key] as unknown[];
+
+			if (!canDeepMergeArrayItems(baseItems, value)) {
+				merged[key] = value;
+				continue;
+			}
+
+			merged[key] = baseItems.map((baseItem, index) => {
 				const overrideItem = value[index];
-				if (!overrideItem || typeof overrideItem !== 'object' || typeof baseItem !== 'object') {
-					return baseItem;
+				if (!overrideItem || typeof overrideItem !== 'object' || !baseItem || typeof baseItem !== 'object') {
+					return overrideItem === undefined ? baseItem : overrideItem;
 				}
 
 				return { ...(baseItem as Record<string, unknown>), ...(overrideItem as Record<string, unknown>) };
@@ -80,6 +95,16 @@ function applyControlOverrides(
 	}
 
 	return merged;
+}
+
+function canDeepMergeArrayItems(baseItems: readonly unknown[], overrideItems: readonly unknown[]): boolean {
+	return (
+		baseItems.every(isPlainObject) && overrideItems.every((item) => item === undefined || isPlainObject(item))
+	);
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
 }
 
 export async function renderViewAuthoredContent(


### PR DESCRIPTION
> Stacked on #133 (`fix/radio-group-aria-target-ssr`). Review that first; this PR is the single commit on top.

`vitest --project=ssr` in `packages/radiant-ui` exited 1 with an unhandled exception. All 12 tests passed, which is exactly why it survived — the throw escapes from a `queueMicrotask` in `connectedCallback`, so it never fails a specific test.

```
DOMException: Failed to execute 'insertBefore' on 'Node':
The new node is a parent of the node to insert to.
  ❯ insertNodesBefore          jsx/src/dom-render/dom-operations.ts:116
  ❯ replaceMountedRangeWithNodes  jsx/src/dom-render/child-range-update.ts:173
  ❯ hydrateTemplateInstance    jsx/src/dom-render/hydration.ts:98
```

## Root cause (in radiant, not jsx)

`RenderRuntime.ensureSlotProjectionState` decides whether the host's children are authored light DOM using `!hasMounted && childNodes.length > 0`.

That heuristic cannot see the SSR case. On first hydrate the host already holds its **own** server-rendered output while `hasMounted` is still `false`, so that output got captured as default-slot content. `resolveSlotValue` then substituted the live SSR root element as the child of a node *inside* it — and `insertNodesBefore` was asked to insert an ancestor before its own descendant.

The existing comment on that branch already names the hazard ("capturing them here would feed a render's own output back into itself"); it just had no signal for the hydration case. Authored content that existed at SSR time arrives through the `data-radiant-slot-projection` script, which is only emitted when there *is* authored content — so "host has children" is ambiguous precisely when it matters.

`hasHydrationMarkers(host)` is the positive signal, so the capture is now skipped when the children are marked SSR output.

## Two changes

1. **`packages/radiant`** — the fix above. Server-side the children genuinely *are* the authored content and there are no markers yet, so the check is client-only via `isServer`.
2. **`packages/jsx`** — `insertNodesBefore` guarded a detached reference node but not a containing one. It now degrades to the existing `dom-range-anchor-drift` warning instead of throwing, so this class of bug can't take down a page again.

## Review notes

- **I verified each change in isolation.** The radiant fix alone fixes it; the jsx guard alone also suppresses it. Both are kept deliberately — but only after confirming the guard is defence-in-depth rather than a mask over a broken root-cause fix.
- **My first attempt broke real SSR.** Gating on `hasHydrationMarkers` unconditionally throws in the minimal DOM (`children.item` doesn't exist there) — caught by tests, now gated on `isServer`, using the helper whose own docs say to prefer it over `typeof window`.
- **I discarded a synthetic regression test** that passed without the fix. It didn't reproduce the failure and would have given false confidence. The shipped test drives `RenderRuntime` directly and does fail without the fix (`expected 1 to be +0`), while its companion case guards against over-correcting so authored light DOM is still captured.

## Verification

- radiant-ui `ssr` project: **exit 0**, 17 passing (previously exit 1 with the unhandled `DOMException`).
- radiant: 454 passing, 2 skipped. jsx: 96 node + 8 browser passing.
- `pnpm typecheck` clean.
