### PR TITLE
refactor(radiant-ui): compose controls and preserve calendar focus

### DIFF
--- a/apps/docs/src/components/controller-decorator-visualizer/controller-decorator-visualizer.script.tsx
+++ b/apps/docs/src/components/controller-decorator-visualizer/controller-decorator-visualizer.script.tsx
@@ -1,6 +1,4 @@
 import { attr, controller, onEvent, onUpdated, query, RadiantController, state } from '@/utils/radiant-browser-runtime';
-import '@ecopages/radiant-ui/radio-group';
-import type { RuiRadioGroupChangeDetail, RuiRadioGroupElement } from '@ecopages/radiant-ui/radio-group';
 import { ensureDocsControllersStarted } from '@/utils/start-docs-controllers';
 
 @controller('controller-dom-flow-visualizer')
@@ -19,8 +17,6 @@ export class ControllerDomFlowVisualizer extends RadiantController {
 	@query({ ref: 'state-last-action' }) stateLastAction!: HTMLElement;
 	@query({ ref: 'flow-title' }) flowTitle!: HTMLElement;
 	@query({ ref: 'flow-description' }) flowDescription!: HTMLElement;
-	@query({ selector: 'rui-radio-group', cache: true }) signalPicker!: RuiRadioGroupElement;
-
 	override connect(): void {
 		super.connect();
 		this.syncSignalNode();
@@ -34,12 +30,12 @@ export class ControllerDomFlowVisualizer extends RadiantController {
 		);
 	}
 
-	@onEvent({ selector: 'rui-radio-group', type: 'rui-change' })
+	@onEvent({ selector: 'input[type="radio"]', type: 'change' })
 	handleSignalChoice(event: Event) {
-		const { value: nextSignal } = (event as CustomEvent<RuiRadioGroupChangeDetail>).detail;
+		const nextSignal = (event.target as HTMLInputElement).value;
 		if (!nextSignal) return;
 
-		this.lastEvent = `rui-change:${nextSignal}`;
+		this.lastEvent = `change:${nextSignal}`;
 		this.signal = nextSignal;
 		this.pulses += 1;
 		this.lastAction = `Host attribute changed to data-signal="${nextSignal}"`;
@@ -66,8 +62,6 @@ export class ControllerDomFlowVisualizer extends RadiantController {
 		this.hostBusy.textContent = busy;
 		this.stateSignal.textContent = this.signal;
 		this.host.setAttribute('data-signal', this.signal);
-		this.signalPicker.value = this.signal;
-
 		if (busy === 'true') {
 			this.host.setAttribute('aria-busy', 'true');
 		} else {

--- a/apps/docs/test/todo-app.e2e.test.mjs
+++ b/apps/docs/test/todo-app.e2e.test.mjs
@@ -154,14 +154,13 @@ test('Docs controller decorator visualizer example keeps authored DOM wiring in 
 		assert.equal(Number.isNaN(initialQueryCount), false);
 		assert.ok(initialQueryCount > 0);
 
-		await page.waitForFunction(() => customElements.get('rui-radio-group') !== undefined);
 		await visualizer.locator('input[value="alert"]').evaluate((input) => {
 			input.dispatchEvent(new MouseEvent('click', { bubbles: true }));
 		});
 
 		await waitForLocatorText(hostSignal, 'alert');
 		await waitForLocatorText(hostBusy, 'true');
-		await waitForLocatorText(eventAction, 'rui-change:alert');
+		await waitForLocatorText(eventAction, 'change:alert');
 		await waitForLocatorText(stateSignal, 'alert');
 		await waitForLocatorText(statePulses, '1');
 		await waitForLocatorText(stateLastAction, 'Host attribute changed to data-signal="alert"');

--- a/apps/radiant-ui/src/content/components/date-field.mdx
+++ b/apps/radiant-ui/src/content/components/date-field.mdx
@@ -4,7 +4,7 @@ description: Date fields capture a single calendar date with locale-aware format
 category: Forms
 ---
 
-import { meta as DateFieldMeta, Default } from '@/content/stories/date-field';
+import { meta as DateFieldMeta, Default, WithCalendar } from '@/content/stories/date-field';
 import Canvas from '@/components/component-docs/canvas';
 import Demo from '@/components/component-docs/demo';
 
@@ -43,6 +43,37 @@ import { RuiLabel } from '@ecopages/radiant-ui/label';
 </RuiField>
 ```
 
+## Composition
+
+`RuiDateField` provides this structure by default. Pass children when you need to place or customize the input, toggle, popup, or calendar yourself.
+
+```tsx
+import {
+  RuiDateField,
+  RuiDateFieldCalendar,
+  RuiDateFieldControl,
+  RuiDateFieldInput,
+  RuiDateFieldPopover,
+  RuiDateFieldToggle,
+} from '@ecopages/radiant-ui/date-field';
+
+<RuiDateField>
+  <RuiDateFieldControl>
+    <RuiDateFieldInput />
+    <RuiDateFieldToggle />
+  </RuiDateFieldControl>
+  <RuiDateFieldPopover>
+    <RuiDateFieldCalendar />
+  </RuiDateFieldPopover>
+</RuiDateField>
+```
+
+## Calendar input
+
+Use the calendar button to choose a date instead of typing. This example uses a two-month popup for dates near a month boundary.
+
+<Canvas of={WithCalendar} meta={DateFieldMeta} />
+
 ## Masked entry
 
 <p>`masked` guides segment-by-segment typing. Disable it when users paste full ISO strings from external tools.</p>
@@ -68,7 +99,7 @@ Geometry shares control tokens (`--size-control-*`, `--radius-control`, `--space
 
 ## API
 
-`RuiDateField` is a custom element (`<rui-date-field>`) that renders its own light-DOM input, toggle button, and calendar popover.
+`RuiDateField` is a custom element (`<rui-date-field>`) that coordinates its light-DOM input, toggle button, and calendar popover.
 
 ### Attributes
 

--- a/apps/radiant-ui/src/content/components/date-range-picker.mdx
+++ b/apps/radiant-ui/src/content/components/date-range-picker.mdx
@@ -4,7 +4,7 @@ description: Date range pickers collect a start and end date in one control, suc
 category: Forms
 ---
 
-import { meta as DateRangePickerMeta, Default } from '@/content/stories/date-range-picker';
+import { meta as DateRangePickerMeta, Default, WithCalendar } from '@/content/stories/date-range-picker';
 import Canvas from '@/components/component-docs/canvas';
 import Demo from '@/components/component-docs/demo';
 
@@ -43,6 +43,44 @@ import { RuiLabel } from '@ecopages/radiant-ui/label';
 </RuiField>
 ```
 
+## Composition
+
+`RuiDateRangePicker` provides this structure by default. Pass children when you need to compose the inputs, toggle, popup, or calendar yourself.
+
+```tsx
+import {
+  RuiDateRangePicker,
+  RuiDateRangePickerCalendar,
+  RuiDateRangePickerControl,
+  RuiDateRangePickerEndInput,
+  RuiDateRangePickerInputs,
+  RuiDateRangePickerPopover,
+  RuiDateRangePickerSeparator,
+  RuiDateRangePickerStartInput,
+  RuiDateRangePickerToggle,
+} from '@ecopages/radiant-ui/date-range-picker';
+
+<RuiDateRangePicker>
+  <RuiDateRangePickerControl>
+    <RuiDateRangePickerInputs>
+      <RuiDateRangePickerStartInput />
+      <RuiDateRangePickerSeparator />
+      <RuiDateRangePickerEndInput />
+    </RuiDateRangePickerInputs>
+    <RuiDateRangePickerToggle />
+  </RuiDateRangePickerControl>
+  <RuiDateRangePickerPopover>
+    <RuiDateRangePickerCalendar />
+  </RuiDateRangePickerPopover>
+</RuiDateRangePicker>
+```
+
+## Calendar input
+
+Use the calendar button to select the start and end dates. The picker stays open until both dates are selected.
+
+<Canvas of={WithCalendar} meta={DateRangePickerMeta} />
+
 ## Two-month view
 
 <p>Set `visibleMonths` to `2` so users can span month boundaries without extra navigation clicks.</p>
@@ -68,7 +106,7 @@ Geometry shares control tokens (`--size-control-*`, `--radius-control`, `--space
 
 ## API
 
-`RuiDateRangePicker` is a custom element (`<rui-date-range-picker>`) that renders its own light-DOM inputs, toggle button, and range calendar popover.
+`RuiDateRangePicker` is a custom element (`<rui-date-range-picker>`) that coordinates its light-DOM inputs, toggle button, and range calendar popover.
 
 ### Attributes
 

--- a/apps/radiant-ui/src/content/stories/date-field.tsx
+++ b/apps/radiant-ui/src/content/stories/date-field.tsx
@@ -1,9 +1,17 @@
-import { RuiDateField } from '@ecopages/radiant-ui/date-field';
+import {
+	RuiDateField,
+	RuiDateFieldCalendar,
+	RuiDateFieldControl,
+	RuiDateFieldInput,
+	RuiDateFieldPopover,
+	RuiDateFieldToggle,
+} from '@ecopages/radiant-ui/date-field';
 import { docsStory, type DocsMeta, type DocsStory } from '@/lib/docs-stories';
 
 export type DateFieldArgs = {
 	value: string;
 	dateStyle: 'short' | 'medium' | 'long' | 'full';
+	visibleMonths: number;
 	disabled: boolean;
 	readOnly: boolean;
 	masked: boolean;
@@ -13,6 +21,7 @@ export const meta = {
 	args: {
 		value: '2026-08-07',
 		dateStyle: 'medium',
+		visibleMonths: 1,
 		disabled: false,
 		readOnly: false,
 		masked: true,
@@ -23,6 +32,7 @@ export const meta = {
 			control: { type: 'select' },
 			options: ['short', 'medium', 'long', 'full'] as const satisfies readonly DateFieldArgs['dateStyle'][],
 		},
+		visibleMonths: { control: { type: 'number' } },
 		disabled: { control: { type: 'boolean' } },
 		readOnly: { control: { type: 'boolean' } },
 		masked: { control: { type: 'boolean' } },
@@ -32,13 +42,30 @@ export const meta = {
 			label="Start date"
 			value={args.value}
 			dateStyle={args.dateStyle}
+			visibleMonths={args.visibleMonths}
 			disabled={args.disabled}
 			readOnly={args.readOnly}
 			masked={args.masked}
-		/>
+		>
+			<RuiDateFieldControl>
+				<RuiDateFieldInput />
+				<RuiDateFieldToggle />
+			</RuiDateFieldControl>
+			<RuiDateFieldPopover>
+				<RuiDateFieldCalendar />
+			</RuiDateFieldPopover>
+		</RuiDateField>
 	),
 } satisfies DocsMeta<DateFieldArgs>;
 
 type Story = DocsStory<DateFieldArgs>;
 
 export const Default: Story = docsStory(meta, { parameters: { docs: { id: 'date-field/default' } } });
+
+export const WithCalendar: Story = docsStory(meta, {
+	args: {
+		value: '',
+		visibleMonths: 2,
+	},
+	parameters: { docs: { id: 'date-field/with-calendar' } },
+});

--- a/apps/radiant-ui/src/content/stories/date-range-picker.tsx
+++ b/apps/radiant-ui/src/content/stories/date-range-picker.tsx
@@ -1,4 +1,14 @@
-import { RuiDateRangePicker } from '@ecopages/radiant-ui/date-range-picker';
+import {
+	RuiDateRangePicker,
+	RuiDateRangePickerCalendar,
+	RuiDateRangePickerControl,
+	RuiDateRangePickerEndInput,
+	RuiDateRangePickerInputs,
+	RuiDateRangePickerPopover,
+	RuiDateRangePickerSeparator,
+	RuiDateRangePickerStartInput,
+	RuiDateRangePickerToggle,
+} from '@ecopages/radiant-ui/date-range-picker';
 import { RuiField } from '@ecopages/radiant-ui/field';
 import { RuiLabel } from '@ecopages/radiant-ui/label';
 import { docsStory, type DocsMeta, type DocsStory } from '@/lib/docs-stories';
@@ -38,7 +48,19 @@ export const meta = {
 				visibleMonths={args.visibleMonths}
 				disabled={args.disabled}
 				readOnly={args.readOnly}
-			/>
+			>
+				<RuiDateRangePickerControl>
+					<RuiDateRangePickerInputs>
+						<RuiDateRangePickerStartInput />
+						<RuiDateRangePickerSeparator />
+						<RuiDateRangePickerEndInput />
+					</RuiDateRangePickerInputs>
+					<RuiDateRangePickerToggle />
+				</RuiDateRangePickerControl>
+				<RuiDateRangePickerPopover>
+					<RuiDateRangePickerCalendar />
+				</RuiDateRangePickerPopover>
+			</RuiDateRangePicker>
 		</RuiField>
 	),
 } satisfies DocsMeta<DateRangePickerArgs>;
@@ -46,3 +68,11 @@ export const meta = {
 type Story = DocsStory<DateRangePickerArgs>;
 
 export const Default: Story = docsStory(meta, { parameters: { docs: { id: 'date-range-picker/default' } } });
+
+export const WithCalendar: Story = docsStory(meta, {
+	args: {
+		value: '',
+		visibleMonths: 2,
+	},
+	parameters: { docs: { id: 'date-range-picker/with-calendar' } },
+});

--- a/apps/radiant-ui/test/story-previews.test.ts
+++ b/apps/radiant-ui/test/story-previews.test.ts
@@ -82,6 +82,7 @@ describe('story preview renders', () => {
 			dateFieldMeta.render!({
 				value: '2026-12-25',
 				dateStyle: 'long',
+				visibleMonths: 1,
 				disabled: true,
 				readOnly: false,
 				masked: false,

--- a/packages/radiant-ui/AGENTS.md
+++ b/packages/radiant-ui/AGENTS.md
@@ -10,6 +10,18 @@ Guidance for humans and agents working in `packages/radiant-ui`.
 - **Authoring:** Not React; see `src/Introduction.mdx` for component tiers and file layout
 - **Tokens, themes, component CSS:** see [`DESIGN.md`](./DESIGN.md)
 
+## Start here
+
+- Read `src/Introduction.mdx` only when adding, moving, or re-tiering a component.
+- Read [`DESIGN.md`](./DESIGN.md) only when changing tokens, themes, or component CSS.
+- Read the sections below that match the files being edited: views, public API docs, or package conventions.
+
+## Component composition
+
+- Non-atomic components should separate behavior from markup: the custom element owns state, accessibility, and coordination; JSX helpers expose the meaningful structural parts.
+- Keep a convenient prop-based default composition on the primary view, but accept children for the equivalent explicit composition. Do not force consumers to subclass a custom element just to arrange its UI.
+- For keyboard movement within an already-rendered composite surface, update focus and roving attributes imperatively. Re-render only when visible structure or semantic state changes.
+
 ## Imports
 
 - Cross-cutting helpers under `src/lib/` → `@/lib/...` (configured in `tsconfig.app.json`, Vite, Storybook, and `scripts/build.ts`).

--- a/packages/radiant-ui/src/components/ui/calendar/calendar.script.tsx
+++ b/packages/radiant-ui/src/components/ui/calendar/calendar.script.tsx
@@ -206,13 +206,60 @@ export class RuiCalendar extends RadiantElement {
 			return;
 		}
 
-		if (next.date.getMonth() !== this.viewMonth || next.date.getFullYear() !== this.viewYear) {
+		if (!this.isMonthVisible(next.date)) {
 			this.viewYear = next.date.getFullYear();
 			this.viewMonth = next.date.getMonth();
+			this.focusedIso = next.iso;
+			this.refreshGrid();
+			this.focusFocusedDay();
+			return;
 		}
 
 		this.focusedIso = next.iso;
+		this.focusDayInCurrentGrid(next.iso);
+	}
+
+	private isMonthVisible(date: Date): boolean {
+		const visibleStart = this.viewYear * 12 + this.viewMonth;
+		const visibleEnd = visibleStart + this.visibleMonths - 1;
+		const target = date.getFullYear() * 12 + date.getMonth();
+		return target >= visibleStart && target <= visibleEnd;
+	}
+
+	/** Moves roving focus without rebuilding a grid that already contains the target day. */
+	private focusDayInCurrentGrid(iso: string): void {
+		const current = this.querySelector<HTMLButtonElement>('[data-calendar-day][tabindex="0"]');
+		const candidates = Array.from(this.querySelectorAll<HTMLButtonElement>(`[data-calendar-day][data-iso="${iso}"]:not(:disabled)`));
+		const next = candidates.find((day) => !day.hasAttribute('data-outside')) ?? candidates[0];
+		if (!next) {
+			return;
+		}
+
+		if (current && current !== next) {
+			current.tabIndex = -1;
+		}
+		next.tabIndex = 0;
+		next.focus();
+	}
+
+	/** Restores DOM focus after rebuilding the grid around a newly visible day. */
+	private focusFocusedDay(): void {
+		requestAnimationFrame(() => {
+			this.focusDayInCurrentGrid(this.focusedIso);
+		});
+	}
+
+	private moveFocusedMonth(delta: number): void {
+		const current = isoToDate(this.focusedIso) ?? new Date(this.viewYear, this.viewMonth, 1);
+		const target = new Date(current.getFullYear(), current.getMonth() + delta, 1);
+		const lastDay = new Date(target.getFullYear(), target.getMonth() + 1, 0).getDate();
+		const next = new Date(target.getFullYear(), target.getMonth(), Math.min(current.getDate(), lastDay));
+
+		this.viewYear = next.getFullYear();
+		this.viewMonth = next.getMonth();
+		this.focusedIso = dateToIso(next);
 		this.refreshGrid();
+		this.focusFocusedDay();
 	}
 
 	private isIsoAllowed(iso: string): boolean {
@@ -374,6 +421,10 @@ export class RuiCalendar extends RadiantElement {
 		if (this.disabled) {
 			return;
 		}
+		const currentIso = (event.target as HTMLButtonElement).getAttribute('data-iso');
+		if (currentIso) {
+			this.focusedIso = currentIso;
+		}
 
 		if (event.key === 'ArrowLeft') {
 			event.preventDefault();
@@ -397,12 +448,12 @@ export class RuiCalendar extends RadiantElement {
 		}
 		if (event.key === 'PageUp') {
 			event.preventDefault();
-			this.moveMonth(event.shiftKey ? -12 : -this.pageDelta);
+			this.moveFocusedMonth(event.shiftKey ? -12 : -this.pageDelta);
 			return;
 		}
 		if (event.key === 'PageDown') {
 			event.preventDefault();
-			this.moveMonth(event.shiftKey ? 12 : this.pageDelta);
+			this.moveFocusedMonth(event.shiftKey ? 12 : this.pageDelta);
 			return;
 		}
 		if (event.key === 'Enter' || event.key === ' ') {

--- a/packages/radiant-ui/src/components/ui/calendar/calendar.script.tsx
+++ b/packages/radiant-ui/src/components/ui/calendar/calendar.script.tsx
@@ -229,7 +229,9 @@ export class RuiCalendar extends RadiantElement {
 	/** Moves roving focus without rebuilding a grid that already contains the target day. */
 	private focusDayInCurrentGrid(iso: string): void {
 		const current = this.querySelector<HTMLButtonElement>('[data-calendar-day][tabindex="0"]');
-		const candidates = Array.from(this.querySelectorAll<HTMLButtonElement>(`[data-calendar-day][data-iso="${iso}"]:not(:disabled)`));
+		const candidates = Array.from(
+			this.querySelectorAll<HTMLButtonElement>(`[data-calendar-day][data-iso="${iso}"]:not(:disabled)`),
+		);
 		const next = candidates.find((day) => !day.hasAttribute('data-outside')) ?? candidates[0];
 		if (!next) {
 			return;

--- a/packages/radiant-ui/src/components/ui/calendar/calendar.stories.tsx
+++ b/packages/radiant-ui/src/components/ui/calendar/calendar.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@ecopages/storybook-radiant-vite';
-import { expect, userEvent } from 'storybook/test';
+import { expect, userEvent, waitFor } from 'storybook/test';
 import { RuiCalendar } from './calendar';
 import { RuiCalendar as RuiCalendarElement } from './calendar.script';
 
@@ -42,6 +42,36 @@ export const WithMinMax: Story = {
 		await step('disables days outside range', async () => {
 			const disabled = canvasElement.querySelectorAll('[data-calendar-day]:disabled');
 			await expect(disabled.length).toBeGreaterThan(0);
+		});
+	},
+};
+
+export const KeyboardNavigation: Story = {
+	args: {
+		value: '2026-08-31',
+	},
+	play: async ({ canvasElement, step }) => {
+		const selectedDay = canvasElement.querySelector('[data-calendar-day][data-iso="2026-08-31"]') as HTMLButtonElement;
+
+		await step('arrow navigation moves focus across a month boundary', async () => {
+			selectedDay.focus();
+			await userEvent.keyboard('{ArrowLeft}');
+			await expect(selectedDay.isConnected).toBe(true);
+			await expect(selectedDay).toHaveAttribute('tabindex', '-1');
+			await expect(document.activeElement).toHaveAttribute('data-iso', '2026-08-30');
+			await userEvent.keyboard('{ArrowRight}');
+			await expect(document.activeElement).toBe(selectedDay);
+			await userEvent.keyboard('{ArrowRight}');
+			await waitFor(() => {
+				expect(document.activeElement).toHaveAttribute('data-iso', '2026-09-01');
+			});
+		});
+
+		await step('PageDown preserves the focused day in the next month', async () => {
+			await userEvent.keyboard('{PageDown}');
+			await waitFor(() => {
+				expect(document.activeElement).toHaveAttribute('data-iso', '2026-10-01');
+			});
 		});
 	},
 };

--- a/packages/radiant-ui/src/components/ui/calendar/calendar.stories.tsx
+++ b/packages/radiant-ui/src/components/ui/calendar/calendar.stories.tsx
@@ -51,7 +51,9 @@ export const KeyboardNavigation: Story = {
 		value: '2026-08-31',
 	},
 	play: async ({ canvasElement, step }) => {
-		const selectedDay = canvasElement.querySelector('[data-calendar-day][data-iso="2026-08-31"]') as HTMLButtonElement;
+		const selectedDay = canvasElement.querySelector(
+			'[data-calendar-day][data-iso="2026-08-31"]',
+		) as HTMLButtonElement;
 
 		await step('arrow navigation moves focus across a month boundary', async () => {
 			selectedDay.focus();

--- a/packages/radiant-ui/src/components/ui/date-field/date-field.script.tsx
+++ b/packages/radiant-ui/src/components/ui/date-field/date-field.script.tsx
@@ -2,10 +2,8 @@ import { RadiantElement, customElement, event, onEvent, onUpdated, prop, query, 
 import type { EventEmitter } from '@ecopages/radiant/tools/event-emitter';
 import { dateToIso, formatDisplayDate, isoToDate, parseLocaleDateString } from '@/lib/intl-date';
 import type { DateDisplayStyle } from '@/lib/intl-date';
-import { RuiIconCalendar } from '@/lib/icons';
 import { resolveLocale } from '@/lib/intl/locale';
 import type { RuiCalendarChangeDetail } from '../calendar/calendar.script';
-import '../calendar/calendar.script';
 import { PopoverController, shouldDismissPopoverFocus } from '../shared/popover-controller';
 import { syncFieldLabel } from '../shared/field-label';
 import {
@@ -59,7 +57,8 @@ type RuiDateFieldBindings = {
  * On blur, values are parsed flexibly (numeric, masked, or month names like "Aug 21, 2002")
  * and displayed with `dateStyle`. Canonical `value` is ISO `YYYY-MM-DD`.
  *
- * A calendar button toggles a popover grid for picking dates.
+ * Compose the input, toggle, popover, and calendar with the `RuiDateField*`
+ * view helpers. `RuiDateField` supplies that composition when it has no children.
  *
  * @see https://react-aria.adobe.com/DatePicker
  *
@@ -111,7 +110,6 @@ export class RuiDateField extends RadiantElement<RuiDateFieldBindings> {
 	private popoverController: PopoverController | null = null;
 	private suppressPopoverDismiss = false;
 
-	@query({ ref: 'root' }) rootTarget: HTMLElement;
 	@query({ ref: 'popover' }) popoverTarget: HTMLElement;
 
 	private get isoValue(): string {
@@ -134,6 +132,14 @@ export class RuiDateField extends RadiantElement<RuiDateFieldBindings> {
 		return this.querySelector<HTMLInputElement>('[data-date-field-input]');
 	}
 
+	private getToggle(): HTMLButtonElement | null {
+		return this.querySelector<HTMLButtonElement>('[data-date-field-trigger]');
+	}
+
+	private getCalendar(): HTMLElement | null {
+		return this.querySelector<HTMLElement>('[data-date-field-calendar]');
+	}
+
 	private syncLabel(): void {
 		const input = this.getInput();
 		syncFieldLabel(this, input, {
@@ -153,17 +159,40 @@ export class RuiDateField extends RadiantElement<RuiDateFieldBindings> {
 			input.id = this.inputId;
 		}
 
-		if (this.name) {
-			input.name = this.name;
-		}
-		if (this.disabled) {
-			input.disabled = true;
-		}
+		input.name = this.name;
+		input.disabled = this.disabled;
+		input.readOnly = this.readOnly;
+		input.inputMode = this.masked ? 'numeric' : 'text';
 
 		const placeholder = this.resolvedPlaceholder;
 		if (placeholder) {
 			input.placeholder = placeholder;
 		}
+	}
+
+	private syncToggle(): void {
+		const toggle = this.getToggle();
+		if (!toggle) {
+			return;
+		}
+
+		toggle.disabled = this.disabled || this.readOnly;
+		toggle.setAttribute('aria-expanded', String(this.open));
+	}
+
+	private syncCalendar(): void {
+		const calendar = this.getCalendar();
+		if (!calendar) {
+			return;
+		}
+
+		calendar.setAttribute('selection-mode', 'single');
+		calendar.setAttribute('visible-months', String(this.visibleMonths));
+		calendar.setAttribute('value', this.isoValue);
+		calendar.setAttribute('min', this.min);
+		calendar.setAttribute('max', this.max);
+		calendar.setAttribute('locale', this.locale);
+		calendar.toggleAttribute('disabled', this.disabled);
 	}
 
 	private formatForDisplay(iso: string): string {
@@ -260,17 +289,44 @@ export class RuiDateField extends RadiantElement<RuiDateFieldBindings> {
 		this.syncLabel();
 		this.syncInput();
 		this.syncDisplayValue();
+		this.syncToggle();
+		this.syncCalendar();
+		this.setOpen(false);
 	}
 
 	private setOpen(next: boolean): void {
 		this.open = next;
-		queueMicrotask(() => this.syncPopoverPosition());
+		queueMicrotask(() => {
+			this.syncCalendar();
+			this.syncPopoverPosition();
+			if (next) {
+				this.focusCalendarDay();
+			}
+		});
+	}
+
+	/** Focus the calendar's roving day, falling back to its first available day. */
+	private focusCalendarDay(): void {
+		requestAnimationFrame(() => {
+			if (!this.open) {
+				return;
+			}
+
+			const calendar = this.getCalendar();
+			const selectedDay = this.isoValue
+				? calendar?.querySelector<HTMLButtonElement>(`[data-calendar-day][data-iso="${this.isoValue}"]:not(:disabled)`)
+				: null;
+			(selectedDay ??
+				calendar?.querySelector<HTMLButtonElement>(
+					'[data-calendar-day][tabindex="0"]:not(:disabled), [data-calendar-day]:not(:disabled)',
+				))?.focus();
+		});
 	}
 
 	private ensurePopoverController(): PopoverController {
 		if (!this.popoverController) {
 			this.popoverController = new PopoverController({
-				getAnchor: () => this.rootTarget,
+				getAnchor: () => this.getToggle()?.parentElement ?? this,
 				getFloating: () => this.popoverTarget,
 				getOpen: () => this.open,
 				getPlacement: () => 'bottom-start',
@@ -283,7 +339,7 @@ export class RuiDateField extends RadiantElement<RuiDateFieldBindings> {
 
 	private syncPopoverPosition(): void {
 		const popover = this.popoverTarget;
-		if (!popover || !this.rootTarget) {
+		if (!popover) {
 			return;
 		}
 		popover.hidden = !this.open;
@@ -305,15 +361,18 @@ export class RuiDateField extends RadiantElement<RuiDateFieldBindings> {
 		super.disconnectedCallback();
 	}
 
-	@onUpdated(['value', 'min', 'max', 'label', 'placeholder', 'disabled', 'readOnly', 'locale', 'dateStyle', 'masked'])
+	@onUpdated(['value', 'min', 'max', 'label', 'placeholder', 'disabled', 'readOnly', 'locale', 'dateStyle', 'masked', 'visibleMonths'])
 	onPropsUpdated(): void {
 		this.syncLabel();
 		this.syncInput();
 		this.syncDisplayValue();
+		this.syncToggle();
+		this.syncCalendar();
 	}
 
 	@onUpdated(['open'])
 	onOpenUpdated(): void {
+		this.syncToggle();
 		this.syncPopoverPosition();
 	}
 
@@ -361,7 +420,10 @@ export class RuiDateField extends RadiantElement<RuiDateFieldBindings> {
 		}
 	}
 
-	@onEvent({ ref: 'root', type: 'focusout' })
+	@onEvent({
+		selector: '[data-date-field-input], [data-date-field-trigger], [data-date-field-popover]',
+		type: 'focusout',
+	})
 	onRootFocusOut(event: FocusEvent): void {
 		const target = event.target as HTMLElement;
 		const relatedTarget = event.relatedTarget;
@@ -388,7 +450,7 @@ export class RuiDateField extends RadiantElement<RuiDateFieldBindings> {
 			}
 
 			const next = relatedTarget instanceof Node ? relatedTarget : document.activeElement;
-			if (!shouldDismissPopoverFocus(this.rootTarget, this.popoverTarget, next)) {
+			if (!shouldDismissPopoverFocus(this, this.popoverTarget, next)) {
 				return;
 			}
 			this.setOpen(false);
@@ -413,10 +475,10 @@ export class RuiDateField extends RadiantElement<RuiDateFieldBindings> {
 		event.preventDefault();
 	}
 
-	@onEvent({ ref: 'root', type: 'rui-change' })
+	@onEvent({ selector: '[data-date-field-calendar]', type: 'rui-change' })
 	onCalendarChange(event: Event): void {
 		const target = event.target;
-		if (!(target instanceof HTMLElement) || target.tagName.toLowerCase() !== 'rui-calendar') {
+		if (!(target instanceof HTMLElement) || !target.matches('[data-date-field-calendar]')) {
 			return;
 		}
 
@@ -428,7 +490,7 @@ export class RuiDateField extends RadiantElement<RuiDateFieldBindings> {
 		this.setOpen(false);
 	}
 
-	@onEvent({ ref: 'root', type: 'keydown' })
+	@onEvent({ selector: '[data-date-field-input], [data-date-field-trigger], [data-date-field-calendar]', type: 'keydown' })
 	onRootKeydown(event: KeyboardEvent): void {
 		if (event.key === 'Escape' && this.open) {
 			event.preventDefault();
@@ -436,58 +498,6 @@ export class RuiDateField extends RadiantElement<RuiDateFieldBindings> {
 		}
 	}
 
-	override render() {
-		const calendarProps = {
-			'prop:selectionMode': 'single',
-			'prop:visibleMonths': this.visibleMonths,
-			'prop:value': this.isoValue,
-			'prop:min': this.min,
-			'prop:max': this.max,
-			'prop:locale': this.locale,
-			'prop:disabled': this.disabled,
-		};
-
-		return (
-			<div class="rui-date-field" data-ref="root">
-				<div class="rui-date-field__group">
-					<input
-						type="text"
-						data-date-field-input
-						data-rui-control
-						data-rui-control-type="text"
-						class="rui-date-field__input"
-						id={this.inputId}
-						autocomplete="off"
-						inputmode={this.masked ? 'numeric' : 'text'}
-						disabled={this.$.disabled}
-						readOnly={this.$.readOnly}
-						placeholder={this.$.placeholder || this.resolvedPlaceholder}
-					/>
-					<button
-						type="button"
-						class="rui-control-toggle"
-						data-ref="trigger"
-						data-date-field-trigger
-						aria-label="Open calendar"
-						aria-haspopup="dialog"
-						aria-expanded={this.open ? 'true' : 'false'}
-						disabled={this.$.disabled || this.$.readOnly}
-					>
-						<RuiIconCalendar />
-					</button>
-				</div>
-				<div
-					class="rui-date-field__popover rui-popover rui-floating"
-					data-ref="popover"
-					data-date-field-popover
-					hidden={!this.open}
-					role="dialog"
-				>
-					{this.open ? <rui-calendar {...calendarProps} /> : null}
-				</div>
-			</div>
-		);
-	}
 }
 
 function dateToMaskDigits(date: Date, locale: string | string[] | undefined): string {

--- a/packages/radiant-ui/src/components/ui/date-field/date-field.script.tsx
+++ b/packages/radiant-ui/src/components/ui/date-field/date-field.script.tsx
@@ -314,12 +314,16 @@ export class RuiDateField extends RadiantElement<RuiDateFieldBindings> {
 
 			const calendar = this.getCalendar();
 			const selectedDay = this.isoValue
-				? calendar?.querySelector<HTMLButtonElement>(`[data-calendar-day][data-iso="${this.isoValue}"]:not(:disabled)`)
+				? calendar?.querySelector<HTMLButtonElement>(
+						`[data-calendar-day][data-iso="${this.isoValue}"]:not(:disabled)`,
+					)
 				: null;
-			(selectedDay ??
+			(
+				selectedDay ??
 				calendar?.querySelector<HTMLButtonElement>(
 					'[data-calendar-day][tabindex="0"]:not(:disabled), [data-calendar-day]:not(:disabled)',
-				))?.focus();
+				)
+			)?.focus();
 		});
 	}
 
@@ -361,7 +365,19 @@ export class RuiDateField extends RadiantElement<RuiDateFieldBindings> {
 		super.disconnectedCallback();
 	}
 
-	@onUpdated(['value', 'min', 'max', 'label', 'placeholder', 'disabled', 'readOnly', 'locale', 'dateStyle', 'masked', 'visibleMonths'])
+	@onUpdated([
+		'value',
+		'min',
+		'max',
+		'label',
+		'placeholder',
+		'disabled',
+		'readOnly',
+		'locale',
+		'dateStyle',
+		'masked',
+		'visibleMonths',
+	])
 	onPropsUpdated(): void {
 		this.syncLabel();
 		this.syncInput();
@@ -490,14 +506,16 @@ export class RuiDateField extends RadiantElement<RuiDateFieldBindings> {
 		this.setOpen(false);
 	}
 
-	@onEvent({ selector: '[data-date-field-input], [data-date-field-trigger], [data-date-field-calendar]', type: 'keydown' })
+	@onEvent({
+		selector: '[data-date-field-input], [data-date-field-trigger], [data-date-field-calendar]',
+		type: 'keydown',
+	})
 	onRootKeydown(event: KeyboardEvent): void {
 		if (event.key === 'Escape' && this.open) {
 			event.preventDefault();
 			this.setOpen(false);
 		}
 	}
-
 }
 
 function dateToMaskDigits(date: Date, locale: string | string[] | undefined): string {

--- a/packages/radiant-ui/src/components/ui/date-field/date-field.stories.tsx
+++ b/packages/radiant-ui/src/components/ui/date-field/date-field.stories.tsx
@@ -4,7 +4,14 @@ import { RuiField, RuiFieldDescription, RuiFieldError } from '../field';
 import { RuiForm } from '../form';
 import { RuiLabel } from '../label';
 import { RuiButton } from '../button';
-import { RuiDateField } from './date-field';
+import {
+	RuiDateField,
+	RuiDateFieldCalendar,
+	RuiDateFieldControl,
+	RuiDateFieldInput,
+	RuiDateFieldPopover,
+	RuiDateFieldToggle,
+} from './date-field';
 import { RuiDateField as RuiDateFieldElement } from './date-field.script';
 
 const meta = {
@@ -83,6 +90,17 @@ export const WithCalendar: Story = {
 	args: {
 		value: '',
 	},
+	render: () => (
+		<RuiDateField label="Appointment date">
+			<RuiDateFieldControl>
+				<RuiDateFieldInput />
+				<RuiDateFieldToggle />
+			</RuiDateFieldControl>
+			<RuiDateFieldPopover>
+				<RuiDateFieldCalendar />
+			</RuiDateFieldPopover>
+		</RuiDateField>
+	),
 	play: async ({ canvasElement, step }) => {
 		const host = canvasElement.querySelector('rui-date-field') as HTMLElement;
 		const trigger = canvasElement.querySelector('[data-date-field-trigger]') as HTMLButtonElement;
@@ -90,11 +108,34 @@ export const WithCalendar: Story = {
 		await step('opens the calendar from the trigger and selects a date', async () => {
 			await userEvent.click(trigger);
 			await expect(trigger).toHaveAttribute('aria-expanded', 'true');
+			await waitFor(() => {
+				expect(document.activeElement?.matches('[data-calendar-day]')).toBe(true);
+			});
 			await userEvent.click(canvasElement.querySelector('[data-calendar-day][data-iso="2026-08-21"]')!);
 			await waitFor(() => {
 				expect(host.getAttribute('value')).toBe('2026-08-21');
 			});
 			await expect(trigger).toHaveAttribute('aria-expanded', 'false');
+		});
+	},
+};
+
+export const KeyboardCalendar: Story = {
+	args: {
+		value: '2026-08-31',
+	},
+	play: async ({ canvasElement, step }) => {
+		const trigger = canvasElement.querySelector('[data-date-field-trigger]') as HTMLButtonElement;
+
+		await step('the opened calendar accepts day-arrow navigation', async () => {
+			await userEvent.click(trigger);
+			await waitFor(() => {
+				expect(document.activeElement).toHaveAttribute('data-iso', '2026-08-31');
+			});
+			await userEvent.keyboard('{ArrowRight}');
+			await waitFor(() => {
+				expect(document.activeElement).toHaveAttribute('data-iso', '2026-09-01');
+			});
 		});
 	},
 };

--- a/packages/radiant-ui/src/components/ui/date-field/date-field.tsx
+++ b/packages/radiant-ui/src/components/ui/date-field/date-field.tsx
@@ -1,6 +1,86 @@
-import type { JsxHtmlPropsWithChildren } from '@ecopages/jsx';
+import type { JsxHtmlProps, JsxHtmlPropsWithChildren } from '@ecopages/jsx';
+import { cx } from '@/lib/cx';
+import { RuiIconCalendar } from '@/lib/icons';
+import { RuiCalendar, type RuiCalendarProps } from '../calendar';
 import type { RuiDateFieldProps } from './date-field.script';
 import './date-field.script';
+
+export type RuiDateFieldControlProps = JsxHtmlPropsWithChildren;
+
+/** Bordered control row containing the date input and calendar toggle. */
+export function RuiDateFieldControl({ children, class: className, ...props }: RuiDateFieldControlProps) {
+	return (
+		<div {...props} class={cx('rui-date-field', className)}>
+			<div class="rui-date-field__group">{children}</div>
+		</div>
+	);
+}
+
+export type RuiDateFieldInputProps = JsxHtmlProps;
+
+/** Text input controlled by the date-field host. */
+export function RuiDateFieldInput({ class: className, ...props }: RuiDateFieldInputProps) {
+	return (
+		<input
+			{...props}
+			type="text"
+			data-date-field-input
+			data-rui-control
+			data-rui-control-type="text"
+			class={cx('rui-date-field__input', className)}
+			autocomplete="off"
+		/>
+	);
+}
+
+export type RuiDateFieldToggleProps = JsxHtmlPropsWithChildren<{ 'aria-label'?: string }>;
+
+/** Toggle button for the date calendar. */
+export function RuiDateFieldToggle({
+	children,
+	class: className,
+	'aria-label': ariaLabel = 'Open calendar',
+	...props
+}: RuiDateFieldToggleProps) {
+	return (
+		<button
+			{...props}
+			type="button"
+			data-ref="trigger"
+			data-date-field-trigger
+			class={cx('rui-control-toggle', className)}
+			aria-label={ariaLabel}
+			aria-haspopup="dialog"
+		>
+			{children ?? <RuiIconCalendar />}
+		</button>
+	);
+}
+
+export type RuiDateFieldPopoverProps = JsxHtmlPropsWithChildren;
+
+/** Floating shell for a `RuiDateFieldCalendar`. */
+export function RuiDateFieldPopover({ children, class: className, ...props }: RuiDateFieldPopoverProps) {
+	return (
+		<div
+			{...props}
+			data-ref="popover"
+			data-date-field-popover
+			class={cx('rui-date-field__popover rui-popover rui-floating', className)}
+			hidden
+			role="dialog"
+		>
+			{children}
+		</div>
+	);
+}
+
+export type RuiDateFieldCalendarProps = JsxHtmlProps<RuiCalendarProps>;
+
+/** Calendar whose value and constraints are synchronized by the date-field host. */
+export function RuiDateFieldCalendar(props: RuiDateFieldCalendarProps) {
+	return <RuiCalendar {...props} data-date-field-calendar />;
+}
 
 /**
  * Locale-aware date field with optional digit masking, flexible parsing, and a calendar popover.
@@ -8,5 +88,19 @@ import './date-field.script';
  * Pair with `RuiLabel` / `RuiField` for labeling and validation.
  */
 export function RuiDateField({ children, ...props }: JsxHtmlPropsWithChildren<RuiDateFieldProps & { slot?: string }>) {
-	return <rui-date-field {...props}>{children}</rui-date-field>;
+	return (
+		<rui-date-field {...props}>
+			{children ?? (
+				<>
+					<RuiDateFieldControl>
+						<RuiDateFieldInput />
+						<RuiDateFieldToggle />
+					</RuiDateFieldControl>
+					<RuiDateFieldPopover>
+						<RuiDateFieldCalendar />
+					</RuiDateFieldPopover>
+				</>
+			)}
+		</rui-date-field>
+	);
 }

--- a/packages/radiant-ui/src/components/ui/date-field/index.ts
+++ b/packages/radiant-ui/src/components/ui/date-field/index.ts
@@ -3,4 +3,11 @@ export {
 	type RuiDateFieldProps,
 	type RuiDateFieldChangeDetail,
 } from './date-field.script';
-export { RuiDateField } from './date-field';
+export {
+	RuiDateField,
+	RuiDateFieldCalendar,
+	RuiDateFieldControl,
+	RuiDateFieldInput,
+	RuiDateFieldPopover,
+	RuiDateFieldToggle,
+} from './date-field';

--- a/packages/radiant-ui/src/components/ui/date-range-picker/date-range-picker.script.tsx
+++ b/packages/radiant-ui/src/components/ui/date-range-picker/date-range-picker.script.tsx
@@ -237,10 +237,12 @@ export class RuiDateRangePicker extends RadiantElement<RuiDateRangePickerBinding
 			const selectedDay = start
 				? calendar?.querySelector<HTMLButtonElement>(`[data-calendar-day][data-iso="${start}"]:not(:disabled)`)
 				: null;
-			(selectedDay ??
+			(
+				selectedDay ??
 				calendar?.querySelector<HTMLButtonElement>(
 					'[data-calendar-day][tabindex="0"]:not(:disabled), [data-calendar-day]:not(:disabled)',
-				))?.focus();
+				)
+			)?.focus();
 		});
 	}
 
@@ -426,7 +428,10 @@ export class RuiDateRangePicker extends RadiantElement<RuiDateRangePickerBinding
 		this.setOpen(false);
 	}
 
-	@onEvent({ selector: '[data-range-start], [data-range-end], [data-range-trigger], [data-range-calendar]', type: 'keydown' })
+	@onEvent({
+		selector: '[data-range-start], [data-range-end], [data-range-trigger], [data-range-calendar]',
+		type: 'keydown',
+	})
 	onRootKeydown(event: KeyboardEvent): void {
 		if (event.key === 'Escape' && this.open) {
 			event.preventDefault();
@@ -458,5 +463,4 @@ export class RuiDateRangePicker extends RadiantElement<RuiDateRangePickerBinding
 			this.setOpen(false);
 		});
 	}
-
 }

--- a/packages/radiant-ui/src/components/ui/date-range-picker/date-range-picker.script.tsx
+++ b/packages/radiant-ui/src/components/ui/date-range-picker/date-range-picker.script.tsx
@@ -9,9 +9,7 @@ import {
 	serializeIsoRange,
 } from '@/lib/intl-date';
 import type { DateDisplayStyle } from '@/lib/intl-date';
-import { RuiIconCalendar } from '@/lib/icons';
 import type { RuiCalendarChangeDetail } from '../calendar/calendar.script';
-import '../calendar/calendar.script';
 import { PopoverController, shouldDismissPopoverFocus } from '../shared/popover-controller';
 import { resolveLocale } from '@/lib/intl/locale';
 
@@ -49,6 +47,8 @@ type RuiDateRangePickerBindings = {
  * `<rui-date-range-picker>` — start/end date fields with a range calendar popover.
  *
  * Canonical `value` is `YYYY-MM-DD/YYYY-MM-DD`. Pair with `RuiField` for validation.
+ * Compose inputs, a toggle, popover, and calendar with the `RuiDateRangePicker*`
+ * view helpers. `RuiDateRangePicker` supplies that composition when it has no children.
  *
  * @remarks Range entry is intentionally free-text plus calendar based. Masked
  * segment editing is currently limited to `RuiDateField` so two range inputs do
@@ -104,11 +104,9 @@ export class RuiDateRangePicker extends RadiantElement<RuiDateRangePickerBinding
 	@state endDisplay = '';
 	@state editing: EditingField = null;
 
-	private readonly uid = Math.random().toString(36).slice(2, 9);
 	private popoverController: PopoverController | null = null;
 	private suppressPopoverDismiss = false;
 
-	@query({ ref: 'root' }) rootTarget: HTMLElement;
 	@query({ ref: 'popover' }) popoverTarget: HTMLElement;
 
 	private get resolvedLocale(): string | string[] | undefined {
@@ -125,6 +123,14 @@ export class RuiDateRangePicker extends RadiantElement<RuiDateRangePickerBinding
 
 	private getEndInput(): HTMLInputElement | null {
 		return this.querySelector<HTMLInputElement>('[data-range-end]');
+	}
+
+	private getToggle(): HTMLButtonElement | null {
+		return this.querySelector<HTMLButtonElement>('[data-range-trigger]');
+	}
+
+	private getCalendar(): HTMLElement | null {
+		return this.querySelector<HTMLElement>('[data-range-calendar]');
 	}
 
 	private formatIso(iso: string): string {
@@ -210,13 +216,38 @@ export class RuiDateRangePicker extends RadiantElement<RuiDateRangePickerBinding
 
 	private setOpen(next: boolean): void {
 		this.open = next;
-		queueMicrotask(() => this.syncPopoverPosition());
+		queueMicrotask(() => {
+			this.syncCalendar();
+			this.syncPopoverPosition();
+			if (next) {
+				this.focusCalendarDay();
+			}
+		});
+	}
+
+	/** Focus the calendar's roving day, falling back to its first available day. */
+	private focusCalendarDay(): void {
+		requestAnimationFrame(() => {
+			if (!this.open) {
+				return;
+			}
+
+			const calendar = this.getCalendar();
+			const start = parseIsoRange(this.isoValue)?.start;
+			const selectedDay = start
+				? calendar?.querySelector<HTMLButtonElement>(`[data-calendar-day][data-iso="${start}"]:not(:disabled)`)
+				: null;
+			(selectedDay ??
+				calendar?.querySelector<HTMLButtonElement>(
+					'[data-calendar-day][tabindex="0"]:not(:disabled), [data-calendar-day]:not(:disabled)',
+				))?.focus();
+		});
 	}
 
 	private ensurePopoverController(): PopoverController {
 		if (!this.popoverController) {
 			this.popoverController = new PopoverController({
-				getAnchor: () => this.rootTarget,
+				getAnchor: () => this.getToggle()?.parentElement ?? this,
 				getFloating: () => this.popoverTarget,
 				getOpen: () => this.open,
 				getPlacement: () => 'bottom-start',
@@ -229,7 +260,7 @@ export class RuiDateRangePicker extends RadiantElement<RuiDateRangePickerBinding
 
 	private syncPopoverPosition(): void {
 		const popover = this.popoverTarget;
-		if (!popover || !this.rootTarget) {
+		if (!popover) {
 			return;
 		}
 		popover.hidden = !this.open;
@@ -240,20 +271,53 @@ export class RuiDateRangePicker extends RadiantElement<RuiDateRangePickerBinding
 		controller.sync();
 	}
 
+	private syncToggle(): void {
+		const toggle = this.getToggle();
+		if (!toggle) {
+			return;
+		}
+
+		toggle.disabled = this.disabled || this.readOnly;
+		toggle.setAttribute('aria-expanded', String(this.open));
+	}
+
+	private syncCalendar(): void {
+		const calendar = this.getCalendar();
+		if (!calendar) {
+			return;
+		}
+
+		calendar.setAttribute('selection-mode', 'range');
+		calendar.setAttribute('visible-months', String(this.visibleMonths));
+		calendar.setAttribute('value', this.isoValue);
+		calendar.setAttribute('min', this.min);
+		calendar.setAttribute('max', this.max);
+		calendar.setAttribute('locale', this.locale);
+		calendar.toggleAttribute('disabled', this.disabled);
+	}
+
 	private wireInputNames(): void {
 		const startInput = this.getStartInput();
 		const endInput = this.getEndInput();
-		if (startInput && this.startName) {
+		if (startInput) {
 			startInput.name = this.startName;
+			startInput.disabled = this.disabled;
+			startInput.readOnly = this.readOnly;
+			startInput.placeholder = this.placeholderStart || 'Start date';
 		}
-		if (endInput && this.endName) {
+		if (endInput) {
 			endInput.name = this.endName;
+			endInput.disabled = this.disabled;
+			endInput.readOnly = this.readOnly;
+			endInput.placeholder = this.placeholderEnd || 'End date';
 		}
 	}
 
 	private initialize(): void {
 		this.wireInputNames();
 		this.syncDisplayValues();
+		this.syncToggle();
+		this.syncCalendar();
 		this.setOpen(false);
 	}
 
@@ -283,10 +347,13 @@ export class RuiDateRangePicker extends RadiantElement<RuiDateRangePickerBinding
 	onPropsUpdated(): void {
 		this.wireInputNames();
 		this.syncDisplayValues();
+		this.syncToggle();
+		this.syncCalendar();
 	}
 
 	@onUpdated(['open'])
 	onOpenUpdated(): void {
+		this.syncToggle();
 		this.syncPopoverPosition();
 	}
 
@@ -344,10 +411,10 @@ export class RuiDateRangePicker extends RadiantElement<RuiDateRangePickerBinding
 		event.preventDefault();
 	}
 
-	@onEvent({ ref: 'root', type: 'rui-change' })
+	@onEvent({ selector: '[data-range-calendar]', type: 'rui-change' })
 	onCalendarChange(event: Event): void {
 		const target = event.target;
-		if (!(target instanceof HTMLElement) || target.tagName.toLowerCase() !== 'rui-calendar') {
+		if (!(target instanceof HTMLElement) || !target.matches('[data-range-calendar]')) {
 			return;
 		}
 
@@ -359,7 +426,7 @@ export class RuiDateRangePicker extends RadiantElement<RuiDateRangePickerBinding
 		this.setOpen(false);
 	}
 
-	@onEvent({ ref: 'root', type: 'keydown' })
+	@onEvent({ selector: '[data-range-start], [data-range-end], [data-range-trigger], [data-range-calendar]', type: 'keydown' })
 	onRootKeydown(event: KeyboardEvent): void {
 		if (event.key === 'Escape' && this.open) {
 			event.preventDefault();
@@ -367,7 +434,10 @@ export class RuiDateRangePicker extends RadiantElement<RuiDateRangePickerBinding
 		}
 	}
 
-	@onEvent({ ref: 'root', type: 'focusout' })
+	@onEvent({
+		selector: '[data-range-start], [data-range-end], [data-range-trigger], [data-range-popover]',
+		type: 'focusout',
+	})
 	onRootFocusOut(event: FocusEvent): void {
 		const relatedTarget = event.relatedTarget;
 
@@ -382,79 +452,11 @@ export class RuiDateRangePicker extends RadiantElement<RuiDateRangePickerBinding
 			}
 
 			const next = relatedTarget instanceof Node ? relatedTarget : document.activeElement;
-			if (!shouldDismissPopoverFocus(this.rootTarget, this.popoverTarget, next)) {
+			if (!shouldDismissPopoverFocus(this, this.popoverTarget, next)) {
 				return;
 			}
 			this.setOpen(false);
 		});
 	}
 
-	override render() {
-		const calendarProps = {
-			'prop:selectionMode': 'range',
-			'prop:visibleMonths': this.visibleMonths,
-			'prop:value': this.isoValue,
-			'prop:min': this.min,
-			'prop:max': this.max,
-			'prop:locale': this.locale,
-			'prop:disabled': this.disabled,
-		};
-
-		return (
-			<div class="rui-date-range-picker" data-ref="root">
-				<div class="rui-date-range-picker__group">
-					<div class="rui-date-range-picker__values">
-						<input
-							type="text"
-							class="rui-date-range-picker__input"
-							data-range-start
-							data-rui-control
-							data-rui-control-type="text"
-							id={`${this.uid}-start`}
-							autocomplete="off"
-							disabled={this.$.disabled}
-							readOnly={this.$.readOnly}
-							placeholder={this.placeholderStart || 'Start date'}
-						/>
-						<span class="rui-date-range-picker__separator" aria-hidden="true">
-							–
-						</span>
-						<input
-							type="text"
-							class="rui-date-range-picker__input"
-							data-range-end
-							data-rui-control
-							data-rui-control-type="text"
-							id={`${this.uid}-end`}
-							autocomplete="off"
-							disabled={this.$.disabled}
-							readOnly={this.$.readOnly}
-							placeholder={this.placeholderEnd || 'End date'}
-						/>
-					</div>
-					<button
-						type="button"
-						class="rui-control-toggle"
-						data-ref="trigger"
-						data-range-trigger
-						aria-label="Open calendar"
-						aria-haspopup="dialog"
-						aria-expanded={this.open ? 'true' : 'false'}
-						disabled={this.$.disabled || this.$.readOnly}
-					>
-						<RuiIconCalendar />
-					</button>
-				</div>
-				<div
-					class="rui-date-range-picker__popover rui-popover rui-floating"
-					data-ref="popover"
-					data-range-popover
-					hidden={!this.open}
-					role="dialog"
-				>
-					{this.open ? <rui-calendar {...calendarProps} /> : null}
-				</div>
-			</div>
-		);
-	}
 }

--- a/packages/radiant-ui/src/components/ui/date-range-picker/date-range-picker.stories.tsx
+++ b/packages/radiant-ui/src/components/ui/date-range-picker/date-range-picker.stories.tsx
@@ -4,7 +4,17 @@ import { RuiField, RuiFieldError } from '../field';
 import { RuiForm } from '../form';
 import { RuiLabel } from '../label';
 import { RuiButton } from '../button';
-import { RuiDateRangePicker } from './date-range-picker';
+import {
+	RuiDateRangePicker,
+	RuiDateRangePickerCalendar,
+	RuiDateRangePickerControl,
+	RuiDateRangePickerEndInput,
+	RuiDateRangePickerInputs,
+	RuiDateRangePickerPopover,
+	RuiDateRangePickerSeparator,
+	RuiDateRangePickerStartInput,
+	RuiDateRangePickerToggle,
+} from './date-range-picker';
 import { RuiDateRangePicker as RuiDateRangePickerElement } from './date-range-picker.script';
 
 const meta = {
@@ -46,6 +56,21 @@ export const WithCalendar: Story = {
 	args: {
 		value: '',
 	},
+	render: () => (
+		<RuiDateRangePicker>
+			<RuiDateRangePickerControl>
+				<RuiDateRangePickerInputs>
+					<RuiDateRangePickerStartInput />
+					<RuiDateRangePickerSeparator />
+					<RuiDateRangePickerEndInput />
+				</RuiDateRangePickerInputs>
+				<RuiDateRangePickerToggle />
+			</RuiDateRangePickerControl>
+			<RuiDateRangePickerPopover>
+				<RuiDateRangePickerCalendar />
+			</RuiDateRangePickerPopover>
+		</RuiDateRangePicker>
+	),
 	play: async ({ canvasElement, step }) => {
 		const host = canvasElement.querySelector('rui-date-range-picker') as HTMLElement;
 		const trigger = canvasElement.querySelector('[data-range-trigger]') as HTMLButtonElement;
@@ -53,6 +78,9 @@ export const WithCalendar: Story = {
 		await step('opens the range calendar and selects dates', async () => {
 			await userEvent.click(trigger);
 			await expect(trigger).toHaveAttribute('aria-expanded', 'true');
+			await waitFor(() => {
+				expect(document.activeElement?.matches('[data-calendar-day]')).toBe(true);
+			});
 			await userEvent.click(canvasElement.querySelector('[data-calendar-day][data-iso="2026-08-03"]')!);
 			await userEvent.click(canvasElement.querySelector('[data-calendar-day][data-iso="2026-08-14"]')!);
 			await waitFor(() => {

--- a/packages/radiant-ui/src/components/ui/date-range-picker/date-range-picker.tsx
+++ b/packages/radiant-ui/src/components/ui/date-range-picker/date-range-picker.tsx
@@ -64,7 +64,11 @@ export function RuiDateRangePickerEndInput({ class: className, ...props }: RuiDa
 export type RuiDateRangePickerSeparatorProps = JsxHtmlPropsWithChildren;
 
 /** Visual separator between the start and end inputs. */
-export function RuiDateRangePickerSeparator({ children = '–', class: className, ...props }: RuiDateRangePickerSeparatorProps) {
+export function RuiDateRangePickerSeparator({
+	children = '–',
+	class: className,
+	...props
+}: RuiDateRangePickerSeparatorProps) {
 	return (
 		<span {...props} class={cx('rui-date-range-picker__separator', className)} aria-hidden="true">
 			{children}

--- a/packages/radiant-ui/src/components/ui/date-range-picker/date-range-picker.tsx
+++ b/packages/radiant-ui/src/components/ui/date-range-picker/date-range-picker.tsx
@@ -1,6 +1,125 @@
-import type { JsxHtmlPropsWithChildren } from '@ecopages/jsx';
+import type { JsxHtmlProps, JsxHtmlPropsWithChildren } from '@ecopages/jsx';
+import { cx } from '@/lib/cx';
+import { RuiIconCalendar } from '@/lib/icons';
+import { RuiCalendar, type RuiCalendarProps } from '../calendar';
 import type { RuiDateRangePickerProps } from './date-range-picker.script';
 import './date-range-picker.script';
+
+export type RuiDateRangePickerControlProps = JsxHtmlPropsWithChildren;
+
+/** Bordered control row containing the date inputs and calendar toggle. */
+export function RuiDateRangePickerControl({ children, class: className, ...props }: RuiDateRangePickerControlProps) {
+	return (
+		<div {...props} class={cx('rui-date-range-picker', className)}>
+			<div class="rui-date-range-picker__group">{children}</div>
+		</div>
+	);
+}
+
+export type RuiDateRangePickerInputsProps = JsxHtmlPropsWithChildren;
+
+/** Input row for `RuiDateRangePickerStartInput` and `RuiDateRangePickerEndInput`. */
+export function RuiDateRangePickerInputs({ children, class: className, ...props }: RuiDateRangePickerInputsProps) {
+	return (
+		<div {...props} class={cx('rui-date-range-picker__values', className)}>
+			{children}
+		</div>
+	);
+}
+
+export type RuiDateRangePickerStartInputProps = JsxHtmlProps;
+
+/** Start-date text input controlled by the range-picker host. */
+export function RuiDateRangePickerStartInput({ class: className, ...props }: RuiDateRangePickerStartInputProps) {
+	return (
+		<input
+			{...props}
+			type="text"
+			data-range-start
+			data-rui-control
+			data-rui-control-type="text"
+			class={cx('rui-date-range-picker__input', className)}
+			autocomplete="off"
+		/>
+	);
+}
+
+export type RuiDateRangePickerEndInputProps = JsxHtmlProps;
+
+/** End-date text input controlled by the range-picker host. */
+export function RuiDateRangePickerEndInput({ class: className, ...props }: RuiDateRangePickerEndInputProps) {
+	return (
+		<input
+			{...props}
+			type="text"
+			data-range-end
+			data-rui-control
+			data-rui-control-type="text"
+			class={cx('rui-date-range-picker__input', className)}
+			autocomplete="off"
+		/>
+	);
+}
+
+export type RuiDateRangePickerSeparatorProps = JsxHtmlPropsWithChildren;
+
+/** Visual separator between the start and end inputs. */
+export function RuiDateRangePickerSeparator({ children = '–', class: className, ...props }: RuiDateRangePickerSeparatorProps) {
+	return (
+		<span {...props} class={cx('rui-date-range-picker__separator', className)} aria-hidden="true">
+			{children}
+		</span>
+	);
+}
+
+export type RuiDateRangePickerToggleProps = JsxHtmlPropsWithChildren<{ 'aria-label'?: string }>;
+
+/** Toggle button for the range calendar. */
+export function RuiDateRangePickerToggle({
+	children,
+	class: className,
+	'aria-label': ariaLabel = 'Open calendar',
+	...props
+}: RuiDateRangePickerToggleProps) {
+	return (
+		<button
+			{...props}
+			type="button"
+			data-ref="trigger"
+			data-range-trigger
+			class={cx('rui-control-toggle', className)}
+			aria-label={ariaLabel}
+			aria-haspopup="dialog"
+		>
+			{children ?? <RuiIconCalendar />}
+		</button>
+	);
+}
+
+export type RuiDateRangePickerPopoverProps = JsxHtmlPropsWithChildren;
+
+/** Floating shell for a `RuiDateRangePickerCalendar`. */
+export function RuiDateRangePickerPopover({ children, class: className, ...props }: RuiDateRangePickerPopoverProps) {
+	return (
+		<div
+			{...props}
+			data-ref="popover"
+			data-range-popover
+			class={cx('rui-date-range-picker__popover rui-popover rui-floating', className)}
+			hidden
+			role="dialog"
+		>
+			{children}
+		</div>
+	);
+}
+
+export type RuiDateRangePickerCalendarProps = JsxHtmlProps<RuiCalendarProps>;
+
+/** Calendar whose range value and constraints are synchronized by the range-picker host. */
+export function RuiDateRangePickerCalendar(props: RuiDateRangePickerCalendarProps) {
+	return <RuiCalendar {...props} data-range-calendar />;
+}
 
 /**
  * Locale-aware date range picker with text inputs and a range calendar popover.
@@ -11,5 +130,23 @@ export function RuiDateRangePicker({
 	children,
 	...props
 }: JsxHtmlPropsWithChildren<RuiDateRangePickerProps & { slot?: string }>) {
-	return <rui-date-range-picker {...props}>{children}</rui-date-range-picker>;
+	return (
+		<rui-date-range-picker {...props}>
+			{children ?? (
+				<>
+					<RuiDateRangePickerControl>
+						<RuiDateRangePickerInputs>
+							<RuiDateRangePickerStartInput />
+							<RuiDateRangePickerSeparator />
+							<RuiDateRangePickerEndInput />
+						</RuiDateRangePickerInputs>
+						<RuiDateRangePickerToggle />
+					</RuiDateRangePickerControl>
+					<RuiDateRangePickerPopover>
+						<RuiDateRangePickerCalendar />
+					</RuiDateRangePickerPopover>
+				</>
+			)}
+		</rui-date-range-picker>
+	);
 }

--- a/packages/radiant-ui/src/components/ui/date-range-picker/index.ts
+++ b/packages/radiant-ui/src/components/ui/date-range-picker/index.ts
@@ -3,4 +3,14 @@ export {
 	type RuiDateRangePickerProps,
 	type RuiDateRangePickerChangeDetail,
 } from './date-range-picker.script';
-export { RuiDateRangePicker } from './date-range-picker';
+export {
+	RuiDateRangePicker,
+	RuiDateRangePickerCalendar,
+	RuiDateRangePickerControl,
+	RuiDateRangePickerEndInput,
+	RuiDateRangePickerInputs,
+	RuiDateRangePickerPopover,
+	RuiDateRangePickerSeparator,
+	RuiDateRangePickerStartInput,
+	RuiDateRangePickerToggle,
+} from './date-range-picker';

--- a/packages/radiant-ui/src/components/ui/menu-button/index.ts
+++ b/packages/radiant-ui/src/components/ui/menu-button/index.ts
@@ -3,4 +3,10 @@ export {
 	type RuiMenuButtonProps,
 	type RuiMenuButtonSelectDetail,
 } from './menu-button.script';
-export { RuiMenuButton, type RuiMenuItem } from './menu-button';
+export {
+	RuiMenuButton,
+	RuiMenuButtonContent,
+	RuiMenuButtonItem,
+	RuiMenuButtonTrigger,
+	type RuiMenuItem,
+} from './menu-button';

--- a/packages/radiant-ui/src/components/ui/menu-button/menu-button.script.tsx
+++ b/packages/radiant-ui/src/components/ui/menu-button/menu-button.script.tsx
@@ -40,8 +40,8 @@ const MENU_GAP = 6;
  * @element rui-menu-button
  * @attr {boolean} open - Whether the menu starts open. Default: `false`.
  * @attr {('top'|'top-start'|'top-end'|'right'|'right-start'|'right-end'|'bottom'|'bottom-start'|'bottom-end'|'left'|'left-start'|'left-end')} placement - Placement of the menu surface relative to its trigger. Default: `bottom-start`.
- * @slot trigger - Label for the menu button.
- * @slot - Menu items (`role="menuitem"`), typically buttons or anchors.
+ * Compose with `RuiMenuButtonTrigger`, `RuiMenuButtonContent`, and
+ * `RuiMenuButtonItem`. The `trigger` / `items` API supplies that composition.
  * @fires rui-change - Emitted when a menu item is activated; `detail.value` is the item's `data-value` or text.
  * @fires rui-close - Emitted when the menu closes.
  * @cssclass rui-menu-button - Root wrapper around trigger and menu.
@@ -226,23 +226,4 @@ export class RuiMenuButton extends RadiantElement {
 		this.setOpen(false, 'trigger');
 	}
 
-	override render() {
-		return (
-			<div class="rui-menu-button">
-				<button
-					type="button"
-					data-ref="trigger"
-					class="rui-button rui-button--primary rui-button--md rui-menu-button__trigger"
-					aria-haspopup="menu"
-					aria-expanded="false"
-				>
-					<slot name="trigger"></slot>
-					<span class="rui-menu-button__chevron" aria-hidden="true"></span>
-				</button>
-				<div data-ref="menu" class="rui-menu-button__menu rui-popover rui-floating" role="menu" hidden>
-					<slot></slot>
-				</div>
-			</div>
-		);
-	}
 }

--- a/packages/radiant-ui/src/components/ui/menu-button/menu-button.script.tsx
+++ b/packages/radiant-ui/src/components/ui/menu-button/menu-button.script.tsx
@@ -225,5 +225,4 @@ export class RuiMenuButton extends RadiantElement {
 		this.changeEvent.emit({ value });
 		this.setOpen(false, 'trigger');
 	}
-
 }

--- a/packages/radiant-ui/src/components/ui/menu-button/menu-button.stories.tsx
+++ b/packages/radiant-ui/src/components/ui/menu-button/menu-button.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@ecopages/storybook-radiant-vite';
 import { expect, userEvent } from 'storybook/test';
-import { RuiMenuButton } from './menu-button';
+import { RuiMenuButton, RuiMenuButtonContent, RuiMenuButtonItem, RuiMenuButtonTrigger } from './menu-button';
 import { RuiMenuButton as RuiMenuButtonElement } from './menu-button.script';
 
 const meta = {
@@ -81,6 +81,28 @@ export const Keyboard: Story = {
 			await userEvent.keyboard('{Escape}');
 			await expect(trigger).toHaveAttribute('aria-expanded', 'false');
 			await expect(document.activeElement).toBe(trigger);
+		});
+	},
+};
+
+export const Composed: Story = {
+	render: () => (
+		<RuiMenuButton>
+			<RuiMenuButtonTrigger>Actions</RuiMenuButtonTrigger>
+			<RuiMenuButtonContent>
+				<RuiMenuButtonItem value="edit">Edit</RuiMenuButtonItem>
+				<RuiMenuButtonItem value="duplicate">Duplicate</RuiMenuButtonItem>
+				<RuiMenuButtonItem value="delete">Delete</RuiMenuButtonItem>
+			</RuiMenuButtonContent>
+		</RuiMenuButton>
+	),
+	play: async ({ canvasElement, step }) => {
+		const trigger = getTrigger(canvasElement);
+		const menu = getMenu(canvasElement);
+
+		await step('composed trigger opens the composed menu', async () => {
+			await userEvent.click(trigger);
+			await expect(menu).not.toHaveAttribute('hidden');
 		});
 	},
 };

--- a/packages/radiant-ui/src/components/ui/menu-button/menu-button.tsx
+++ b/packages/radiant-ui/src/components/ui/menu-button/menu-button.tsx
@@ -1,4 +1,6 @@
-import type { JsxHtmlProps, JsxRenderable } from '@ecopages/jsx';
+import type { JsxHtmlPropsWithChildren, JsxRenderable } from '@ecopages/jsx';
+import { cx } from '@/lib/cx';
+import { RuiButton, type RuiButtonControlProps } from '../button';
 import type { RuiMenuButtonProps } from './menu-button.script';
 import './menu-button.script';
 
@@ -7,6 +9,73 @@ export type RuiMenuItem = {
 	label: JsxRenderable;
 	disabled?: boolean;
 };
+
+export type RuiMenuButtonTriggerProps = JsxHtmlPropsWithChildren<
+	Pick<RuiButtonControlProps, 'variant' | 'size' | 'type' | 'disabled' | 'aria-label'>
+>;
+
+/** Trigger button for opening a menu-button popup. */
+export function RuiMenuButtonTrigger({
+	children,
+	class: className,
+	variant = 'filled',
+	size = 'md',
+	...props
+}: RuiMenuButtonTriggerProps) {
+	return (
+		<RuiButton
+			{...props}
+			variant={variant}
+			size={size}
+			data-ref="trigger"
+			class={cx('rui-menu-button__trigger', className)}
+			aria-haspopup="menu"
+		>
+			{children}
+			<span class="rui-menu-button__chevron" aria-hidden="true" />
+		</RuiButton>
+	);
+}
+
+export type RuiMenuButtonContentProps = JsxHtmlPropsWithChildren;
+
+/** Floating menu surface containing `RuiMenuButtonItem` elements. */
+export function RuiMenuButtonContent({ children, class: className, ...props }: RuiMenuButtonContentProps) {
+	return (
+		<div
+			{...props}
+			data-ref="menu"
+			class={cx('rui-menu-button__menu', 'rui-popover', 'rui-floating', className)}
+			role="menu"
+			hidden
+		>
+			{children}
+		</div>
+	);
+}
+
+export type RuiMenuButtonItemProps = JsxHtmlPropsWithChildren<{
+	value: string;
+	disabled?: boolean;
+}>;
+
+/** Action item inside `RuiMenuButtonContent`. */
+export function RuiMenuButtonItem({ children, value, disabled, class: className, ...props }: RuiMenuButtonItemProps) {
+	return (
+		<button
+			{...props}
+			type="button"
+			class={cx('rui-menu-button__item', className)}
+			role="menuitem"
+			data-value={value}
+			aria-disabled={disabled ? 'true' : undefined}
+			disabled={disabled}
+			tabIndex={-1}
+		>
+			{children}
+		</button>
+	);
+}
 
 /**
  * Importable JSX helper around `<rui-menu-button>`.
@@ -19,23 +88,28 @@ export type RuiMenuItem = {
 export function RuiMenuButton({
 	trigger,
 	items,
+	children,
+	class: className,
 	...props
-}: JsxHtmlProps<RuiMenuButtonProps & { slot?: string; trigger: JsxRenderable; items: RuiMenuItem[] }>) {
+}: JsxHtmlPropsWithChildren<RuiMenuButtonProps & { slot?: string; trigger?: JsxRenderable; items?: RuiMenuItem[] }>) {
+	if (trigger == null && items == null) {
+		return (
+			<rui-menu-button {...props} class={cx('rui-menu-button', className)}>
+				{children}
+			</rui-menu-button>
+		);
+	}
+
 	return (
-		<rui-menu-button {...props}>
-			<span slot="trigger">{trigger}</span>
-			{items.map((item) => (
-				<button
-					type="button"
-					class="rui-menu-button__item"
-					role="menuitem"
-					data-value={item.value}
-					aria-disabled={item.disabled ? 'true' : undefined}
-					tabindex={-1}
-				>
-					{item.label}
-				</button>
-			))}
+		<rui-menu-button {...props} class={cx('rui-menu-button', className)}>
+			<RuiMenuButtonTrigger>{trigger}</RuiMenuButtonTrigger>
+			<RuiMenuButtonContent>
+				{items?.map((item) => (
+					<RuiMenuButtonItem value={item.value} disabled={item.disabled}>
+						{item.label}
+					</RuiMenuButtonItem>
+				))}
+			</RuiMenuButtonContent>
 		</rui-menu-button>
 	);
 }

--- a/packages/radiant-ui/src/components/ui/radio-group/index.ts
+++ b/packages/radiant-ui/src/components/ui/radio-group/index.ts
@@ -3,4 +3,4 @@ export {
 	type RuiRadioGroupProps,
 	type RuiRadioGroupChangeDetail,
 } from './radio-group.script';
-export { RuiRadioGroup, type RuiRadioOption } from './radio-group';
+export { RuiRadio, RuiRadioGroup, RuiRadioGroupControl, type RuiRadioOption } from './radio-group';

--- a/packages/radiant-ui/src/components/ui/radio-group/radio-group.script.tsx
+++ b/packages/radiant-ui/src/components/ui/radio-group/radio-group.script.tsx
@@ -16,11 +16,6 @@ export type RuiRadioGroupChangeDetail = {
 	value: string;
 };
 
-type RuiRadioGroupBindings = {
-	label: string;
-	disabled: boolean;
-};
-
 /**
  * `<rui-radio-group>` — a set of radio buttons where only one option may
  * be selected at a time.
@@ -48,13 +43,13 @@ type RuiRadioGroupBindings = {
  * @fires rui-change - Emitted after the selected value changes; `detail.value` holds the new value.
  *
  * @remarks
- * The `RuiRadioGroup` view authors the option BEM classes (`.rui-radio*`, see
- * `@cssclass` there). This element owns the `role="radiogroup"` surface and value sync.
+ * Compose with `RuiRadioGroupControl` and `RuiRadio`, or author matching native
+ * radio markup directly. This element owns radio value synchronization.
  *
  * @cssclass rui-radio-group - Group surface (`role="radiogroup"`).
  */
 @customElement('rui-radio-group')
-export class RuiRadioGroup extends RadiantElement<RuiRadioGroupBindings> {
+export class RuiRadioGroup extends RadiantElement {
 	@prop({ type: String, reflect: true, defaultValue: '' }) value: string;
 	@prop({ type: String, defaultValue: '' }) name: string;
 	@prop({ type: String, defaultValue: '' }) label: string;
@@ -63,16 +58,27 @@ export class RuiRadioGroup extends RadiantElement<RuiRadioGroupBindings> {
 	@event({ name: 'rui-change', bubbles: true, composed: true })
 	changeEvent: EventEmitter<RuiRadioGroupChangeDetail>;
 
-	private readonly resolvedAriaLabel = this.$.label.map((label) => label || undefined);
-	private readonly resolvedAriaDisabled = this.$.disabled.map((disabled) => (disabled ? 'true' : undefined));
-
 	override connectedCallback(): void {
 		super.connectedCallback();
 		this.syncRadios();
 	}
 
-	@onUpdated(['value', 'name', 'disabled'])
+	@onUpdated(['value', 'name', 'label', 'disabled'])
 	syncRadios(): void {
+		const group = this.querySelector<HTMLElement>('[data-radio-group-root]');
+		if (group) {
+			if (this.label) {
+				group.setAttribute('aria-label', this.label);
+			} else {
+				group.removeAttribute('aria-label');
+			}
+			if (this.disabled) {
+				group.setAttribute('aria-disabled', 'true');
+			} else {
+				group.removeAttribute('aria-disabled');
+			}
+		}
+
 		const radios = this.querySelectorAll<HTMLInputElement>('input[type="radio"]');
 		const groupName = this.name || this.getAttribute('name') || 'rui-radio-group';
 		for (const radio of radios) {
@@ -90,18 +96,4 @@ export class RuiRadioGroup extends RadiantElement<RuiRadioGroupBindings> {
 		this.changeEvent.emit({ value: this.value });
 	}
 
-	override render() {
-		return (
-			<div
-				class="rui-radio-group"
-				role="radiogroup"
-				data-rui-control
-				data-rui-control-type="text"
-				aria-label={this.resolvedAriaLabel}
-				aria-disabled={this.resolvedAriaDisabled}
-			>
-				<slot></slot>
-			</div>
-		);
-	}
 }

--- a/packages/radiant-ui/src/components/ui/radio-group/radio-group.script.tsx
+++ b/packages/radiant-ui/src/components/ui/radio-group/radio-group.script.tsx
@@ -95,5 +95,4 @@ export class RuiRadioGroup extends RadiantElement {
 		this.value = input.value;
 		this.changeEvent.emit({ value: this.value });
 	}
-
 }

--- a/packages/radiant-ui/src/components/ui/radio-group/radio-group.stories.tsx
+++ b/packages/radiant-ui/src/components/ui/radio-group/radio-group.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@ecopages/storybook-radiant-vite';
 import { expect, userEvent } from 'storybook/test';
 import { RuiField, RuiFieldDescription, RuiFieldError } from '../field';
 import { RuiLabel } from '../label';
-import { RuiRadioGroup } from './radio-group';
+import { RuiRadio, RuiRadioGroup, RuiRadioGroupControl } from './radio-group';
 import { RuiRadioGroup as RuiRadioGroupElement } from './radio-group.script';
 
 const defaultOptions = [
@@ -71,6 +71,27 @@ export const Disabled: Story = {
 			for (const radio of radios) {
 				await expect(radio).toBeDisabled();
 			}
+		});
+	},
+};
+
+export const Composed: Story = {
+	render: () => (
+		<RuiRadioGroup name="contact" label="Preferred contact method">
+			<RuiRadioGroupControl>
+				<RuiRadio value="email">Email</RuiRadio>
+				<RuiRadio value="sms">SMS</RuiRadio>
+				<RuiRadio value="push">Push</RuiRadio>
+			</RuiRadioGroupControl>
+		</RuiRadioGroup>
+	),
+	play: async ({ canvasElement, step }) => {
+		const host = canvasElement.querySelector('rui-radio-group') as HTMLElement;
+		const radios = getRadios(canvasElement);
+
+		await step('composed options update the group value', async () => {
+			await userEvent.click(radios[1]);
+			await expect(host).toHaveAttribute('value', 'sms');
 		});
 	},
 };

--- a/packages/radiant-ui/src/components/ui/radio-group/radio-group.tsx
+++ b/packages/radiant-ui/src/components/ui/radio-group/radio-group.tsx
@@ -1,4 +1,5 @@
-import type { JsxHtmlProps, JsxRenderable } from '@ecopages/jsx';
+import type { JsxHtmlPropsWithChildren, JsxRenderable } from '@ecopages/jsx';
+import { cx } from '@/lib/cx';
 import type { RuiRadioGroupProps } from './radio-group.script';
 import './radio-group.script';
 
@@ -7,6 +8,46 @@ export type RuiRadioOption = {
 	label: JsxRenderable;
 	disabled?: boolean;
 };
+
+export type RuiRadioGroupControlProps = JsxHtmlPropsWithChildren;
+
+/** Accessible surface that contains radio options. */
+export function RuiRadioGroupControl({ children, class: className, ...props }: RuiRadioGroupControlProps) {
+	return (
+		<div
+			{...props}
+			data-radio-group-root
+			class={cx('rui-radio-group', className)}
+			role="radiogroup"
+			data-rui-control
+			data-rui-control-type="text"
+		>
+			{children}
+		</div>
+	);
+}
+
+export type RuiRadioProps = JsxHtmlPropsWithChildren<{
+	value: string;
+	disabled?: boolean;
+}>;
+
+/** A label-wrapped native radio option controlled by `RuiRadioGroup`. */
+export function RuiRadio({ children, value, disabled, class: className, ...props }: RuiRadioProps) {
+	return (
+		<label {...props} class={cx('rui-radio', className)}>
+			<input
+				type="radio"
+				class="rui-radio__input"
+				value={value}
+				disabled={disabled}
+				data-disabled={disabled ? '' : undefined}
+			/>
+			<span class="rui-radio__control" aria-hidden="true" />
+			<span class="rui-radio__label">{children}</span>
+		</label>
+	);
+}
 
 /**
  * Radio group with an `options` convenience API; renders one label-wrapped radio
@@ -19,23 +60,22 @@ export type RuiRadioOption = {
  */
 export function RuiRadioGroup({
 	options,
+	children,
 	...props
-}: JsxHtmlProps<RuiRadioGroupProps & { slot?: string; options: RuiRadioOption[] }>) {
+}: JsxHtmlPropsWithChildren<RuiRadioGroupProps & { slot?: string; options?: RuiRadioOption[] }>) {
+	if (options == null) {
+		return <rui-radio-group {...props}>{children}</rui-radio-group>;
+	}
+
 	return (
 		<rui-radio-group {...props}>
-			{options.map((option) => (
-				<label class="rui-radio">
-					<input
-						type="radio"
-						class="rui-radio__input"
-						value={option.value}
-						disabled={option.disabled}
-						data-disabled={option.disabled ? '' : undefined}
-					/>
-					<span class="rui-radio__control" aria-hidden="true"></span>
-					<span class="rui-radio__label">{option.label}</span>
-				</label>
-			))}
+			<RuiRadioGroupControl>
+				{options.map((option) => (
+					<RuiRadio value={option.value} disabled={option.disabled}>
+						{option.label}
+					</RuiRadio>
+				))}
+			</RuiRadioGroupControl>
 		</rui-radio-group>
 	);
 }

--- a/packages/storybook-radiant-vite/src/preset.ts
+++ b/packages/storybook-radiant-vite/src/preset.ts
@@ -7,3 +7,13 @@ export const core: PresetProperty<'core'> = {
 	builder: import.meta.resolve('@storybook/builder-vite'),
 	renderer: import.meta.resolve('@ecopages/storybook-radiant-vite/renderer-preset'),
 };
+
+/**
+ * Force Vite to prebundle `react-dom` for addon-docs.
+ *
+ * @remarks
+ * Docs chunks default-import `react-dom`. Addon-docs only lists `react-dom/client`
+ * in `optimizeViteDeps`, so Vite 8 serves the raw CJS entry via `/@fs` and the
+ * browser throws "does not provide an export named 'default'".
+ */
+export const optimizeViteDeps = ['react-dom'];


### PR DESCRIPTION
## Summary
Refactor composite Radiant UI controls around explicit JSX composition and fix calendar keyboard focus behavior.

## What changed
- Add composable APIs for Date Field, Date Range Picker, Menu Button, and Radio Group while retaining convenience APIs.
- Preserve calendar day focus during arrow/PageUp/PageDown navigation and rerender only when visible structure changes.
- Add composed and keyboard-focused stories, date-picker content examples, and progressive-disclosure guidance in `packages/radiant-ui/AGENTS.md`.
- Keep the static docs controller visualizer interactive by handling its server-rendered native radio inputs without an unresolved browser-only package import.
- Prebundle `react-dom` for Storybook addon-docs browser chunks.

## Validation
- Full pre-commit suite passes: package tests, docs E2E, Nitro E2E, playground E2E, size checks, formatting, and lint.
- Radiant UI typecheck passes.
- Radiant UI story suite passes: 78 files, 355 tests.
