### PR TITLE
fix(radiant-ui): complete composable stories and control styling

### DIFF
--- a/apps/radiant-ui/src/content/components/date-field.mdx
+++ b/apps/radiant-ui/src/content/components/date-field.mdx
@@ -30,22 +30,7 @@ export const config = {
 
 ## Usage
 
-Bind `value` as an ISO `YYYY-MM-DD` string. Use `dateStyle` to control how the formatted date appears in the input.
-
-```tsx
-import { RuiDateField } from '@ecopages/radiant-ui/date-field';
-import { RuiField } from '@ecopages/radiant-ui/field';
-import { RuiLabel } from '@ecopages/radiant-ui/label';
-
-<RuiField name="startDate">
-  <RuiLabel>Start date</RuiLabel>
-  <RuiDateField value="2026-08-07" dateStyle="medium" />
-</RuiField>
-```
-
-## Composition
-
-`RuiDateField` provides this structure by default. Pass children when you need to place or customize the input, toggle, popup, or calendar yourself.
+Compose the input, calendar trigger, popup, and calendar as children of `RuiDateField`. When no children are supplied, `RuiDateField` renders this same composition for you. Bind `value` as an ISO `YYYY-MM-DD` string and use `dateStyle` to control the formatted value.
 
 ```tsx
 import {
@@ -56,21 +41,26 @@ import {
   RuiDateFieldPopover,
   RuiDateFieldToggle,
 } from '@ecopages/radiant-ui/date-field';
+import { RuiField } from '@ecopages/radiant-ui/field';
+import { RuiLabel } from '@ecopages/radiant-ui/label';
 
-<RuiDateField>
-  <RuiDateFieldControl>
-    <RuiDateFieldInput />
-    <RuiDateFieldToggle />
-  </RuiDateFieldControl>
-  <RuiDateFieldPopover>
-    <RuiDateFieldCalendar />
-  </RuiDateFieldPopover>
-</RuiDateField>
+<RuiField name="startDate">
+  <RuiLabel>Start date</RuiLabel>
+  <RuiDateField value="2026-08-07" dateStyle="medium">
+    <RuiDateFieldControl>
+      <RuiDateFieldInput />
+      <RuiDateFieldToggle />
+    </RuiDateFieldControl>
+    <RuiDateFieldPopover>
+      <RuiDateFieldCalendar />
+    </RuiDateFieldPopover>
+  </RuiDateField>
+</RuiField>
 ```
 
 ## Calendar input
 
-Use the calendar button to choose a date instead of typing. This example uses a two-month popup for dates near a month boundary.
+Use the calendar button to choose a date instead of typing. When the popup opens, focus moves to the selected date or the first available date. This example uses a two-month popup for dates near a month boundary.
 
 <Canvas of={WithCalendar} meta={DateFieldMeta} />
 
@@ -124,6 +114,18 @@ Geometry shares control tokens (`--size-control-*`, `--radius-control`, `--space
 | --- | --- | --- |
 | `rui-change` | `{ value }` | Fired when a valid date is committed (typing or calendar pick). |
 
+### Composition helpers
+
+Pass these helpers as `RuiDateField` children when the default structure is not enough:
+
+| Helper | Renders |
+| --- | --- |
+| `RuiDateFieldControl` | Bordered control row containing the input and trigger. |
+| `RuiDateFieldInput` | Locale-aware text input managed by the date-field host. |
+| `RuiDateFieldToggle` | Button that opens and closes the calendar popup. |
+| `RuiDateFieldPopover` | Popup shell for the calendar. |
+| `RuiDateFieldCalendar` | `RuiCalendar` synchronized with the field value and constraints. |
+
 ### CSS classes
 
 Public BEM classes on the composed light-DOM surface (documented via `@cssclass` on `RuiDateField`):
@@ -150,4 +152,4 @@ Public BEM classes on the composed light-DOM surface (documented via `@cssclass`
 
 - Pair every date field with a visible `RuiLabel` or `aria-label`.
 - Invalid dates should surface through `RuiField` error text, not color alone.
-- Calendar popup content is reachable by keyboard from the trigger button.
+- The trigger opens the popup and moves focus to the selected date or first available date; arrow keys move between days, Page Up / Page Down change months, and Escape closes the popup.

--- a/apps/radiant-ui/src/content/components/date-range-picker.mdx
+++ b/apps/radiant-ui/src/content/components/date-range-picker.mdx
@@ -30,22 +30,7 @@ export const config = {
 
 ## Usage
 
-Pass `value` as `start/end` ISO dates. Increase `visibleMonths` to show two months side by side for range selection.
-
-```tsx
-import { RuiDateRangePicker } from '@ecopages/radiant-ui/date-range-picker';
-import { RuiField } from '@ecopages/radiant-ui/field';
-import { RuiLabel } from '@ecopages/radiant-ui/label';
-
-<RuiField name="tripDates">
-  <RuiLabel>Trip dates</RuiLabel>
-  <RuiDateRangePicker value="2026-08-01/2026-08-14" visibleMonths={2} />
-</RuiField>
-```
-
-## Composition
-
-`RuiDateRangePicker` provides this structure by default. Pass children when you need to compose the inputs, toggle, popup, or calendar yourself.
+Compose the two inputs, separator, calendar trigger, popup, and calendar as children of `RuiDateRangePicker`. When no children are supplied, `RuiDateRangePicker` renders this same composition for you. Pass `value` as `start/end` ISO dates and give each input its own accessible name.
 
 ```tsx
 import {
@@ -59,25 +44,30 @@ import {
   RuiDateRangePickerStartInput,
   RuiDateRangePickerToggle,
 } from '@ecopages/radiant-ui/date-range-picker';
+import { RuiField } from '@ecopages/radiant-ui/field';
+import { RuiLabel } from '@ecopages/radiant-ui/label';
 
-<RuiDateRangePicker>
-  <RuiDateRangePickerControl>
-    <RuiDateRangePickerInputs>
-      <RuiDateRangePickerStartInput />
-      <RuiDateRangePickerSeparator />
-      <RuiDateRangePickerEndInput />
-    </RuiDateRangePickerInputs>
-    <RuiDateRangePickerToggle />
-  </RuiDateRangePickerControl>
-  <RuiDateRangePickerPopover>
-    <RuiDateRangePickerCalendar />
-  </RuiDateRangePickerPopover>
-</RuiDateRangePicker>
+<RuiField name="tripDates">
+  <RuiLabel>Trip dates</RuiLabel>
+  <RuiDateRangePicker value="2026-08-01/2026-08-14" visibleMonths={2}>
+    <RuiDateRangePickerControl>
+      <RuiDateRangePickerInputs>
+        <RuiDateRangePickerStartInput aria-label="Start date" />
+        <RuiDateRangePickerSeparator />
+        <RuiDateRangePickerEndInput aria-label="End date" />
+      </RuiDateRangePickerInputs>
+      <RuiDateRangePickerToggle />
+    </RuiDateRangePickerControl>
+    <RuiDateRangePickerPopover>
+      <RuiDateRangePickerCalendar />
+    </RuiDateRangePickerPopover>
+  </RuiDateRangePicker>
+</RuiField>
 ```
 
 ## Calendar input
 
-Use the calendar button to select the start and end dates. The picker stays open until both dates are selected.
+Use the calendar button to select the start and end dates. After the first date is selected, the popup stays open for the second date and closes when the range is complete. Focus moves to the selected start date or the first available date when the popup opens.
 
 <Canvas of={WithCalendar} meta={DateRangePickerMeta} />
 
@@ -132,6 +122,21 @@ Geometry shares control tokens (`--size-control-*`, `--radius-control`, `--space
 | --- | --- | --- |
 | `rui-change` | `{ value, start, end }` | Fired when a valid range is committed (typing or calendar pick). |
 
+### Composition helpers
+
+Pass these helpers as `RuiDateRangePicker` children when the default structure is not enough:
+
+| Helper | Renders |
+| --- | --- |
+| `RuiDateRangePickerControl` | Bordered control row containing the inputs and trigger. |
+| `RuiDateRangePickerInputs` | Row containing the start input, separator, and end input. |
+| `RuiDateRangePickerStartInput` | Native text input for the range start. Give it an accessible name. |
+| `RuiDateRangePickerSeparator` | Visual separator between the two inputs. |
+| `RuiDateRangePickerEndInput` | Native text input for the range end. Give it an accessible name. |
+| `RuiDateRangePickerToggle` | Button that opens and closes the range calendar popup. |
+| `RuiDateRangePickerPopover` | Popup shell for the range calendar. |
+| `RuiDateRangePickerCalendar` | `RuiCalendar` in range-selection mode, synchronized with the picker value and constraints. |
+
 ### CSS classes
 
 Public BEM classes on the composed light-DOM surface (documented via `@cssclass` on `RuiDateRangePicker`):
@@ -158,6 +163,6 @@ Public BEM classes on the composed light-DOM surface (documented via `@cssclass`
 
 ## Accessibility
 
-- Label both start and end inputs, placeholders alone are not sufficient.
-- Selected range endpoints are announced when focus moves between segments.
+- Give both native inputs distinct accessible names; placeholders alone are not sufficient. The example uses `aria-label` on each input.
+- The calendar trigger opens the popup and moves focus to the selected start date or first available date; arrow keys move between days, Page Up / Page Down change months, and Escape closes the popup.
 - Surface validation errors for incomplete ranges before form submission.

--- a/apps/radiant-ui/src/content/components/menu-button.mdx
+++ b/apps/radiant-ui/src/content/components/menu-button.mdx
@@ -30,19 +30,22 @@ export const config = {
 
 ## Usage
 
-Pass `items` with labels and handlers, or compose menu content as children. Control `placement` to avoid viewport clipping.
+Compose the trigger, menu content, and action items explicitly. Control `placement` to avoid viewport clipping.
 
 ```tsx
-import { RuiMenuButton } from '@ecopages/radiant-ui/menu-button';
+import {
+  RuiMenuButton,
+  RuiMenuButtonContent,
+  RuiMenuButtonItem,
+  RuiMenuButtonTrigger,
+} from '@ecopages/radiant-ui/menu-button';
 
-<RuiMenuButton
-  items={[
-    { label: 'Edit', onSelect: editItem },
-    { label: 'Delete', onSelect: deleteItem },
-  ]}
-  placement="bottom-start"
->
-  Actions
+<RuiMenuButton placement="bottom-start">
+  <RuiMenuButtonTrigger>Actions</RuiMenuButtonTrigger>
+  <RuiMenuButtonContent>
+    <RuiMenuButtonItem value="edit">Edit</RuiMenuButtonItem>
+    <RuiMenuButtonItem value="delete">Delete</RuiMenuButtonItem>
+  </RuiMenuButtonContent>
 </RuiMenuButton>
 ```
 
@@ -64,7 +67,7 @@ The trigger shares control geometry (`--size-control-md`, `--space-control-x`, `
 
 ## API
 
-`RuiMenuButton` is a custom element (`<rui-menu-button>`) with a composed light-DOM surface. The JSX helper renders the trigger and popup items; compose the slots directly for custom items.
+`RuiMenuButton` is a custom element (`<rui-menu-button>`) with a composed light-DOM surface. Use the view helpers to compose the trigger and popup items, or use the convenience `trigger` / `items` props for generated content.
 
 ### Attributes
 
@@ -91,7 +94,10 @@ The trigger shares control geometry (`--size-control-md`, `--space-control-x`, `
 
 | Component | Renders | Notes |
 | --- | --- | --- |
-| `RuiMenuButton` | `<rui-menu-button>` | Accepts `trigger` + `items` (`RuiMenuItem[]`); authors the `rui-menu-button__item` buttons. |
+| `RuiMenuButton` | `<rui-menu-button>` | Hosts the composed trigger and menu content. The convenience `trigger` + `items` props generate the same helpers. |
+| `RuiMenuButtonTrigger` | Button | Trigger control that opens the menu. |
+| `RuiMenuButtonContent` | `<div role="menu">` | Popup surface containing menu items. |
+| `RuiMenuButtonItem` | `<button role="menuitem">` | Selectable action inside the menu. |
 
 ### CSS classes
 

--- a/apps/radiant-ui/src/content/components/radio-group.mdx
+++ b/apps/radiant-ui/src/content/components/radio-group.mdx
@@ -33,15 +33,17 @@ export const config = {
 Set `value` for the selected option and provide radio inputs as children. Wrap in `RuiField` for form integration.
 
 ```tsx
-import { RuiRadioGroup } from '@ecopages/radiant-ui/radio-group';
+import { RuiRadio, RuiRadioGroup, RuiRadioGroupControl } from '@ecopages/radiant-ui/radio-group';
 import { RuiField } from '@ecopages/radiant-ui/field';
 import { RuiLabel } from '@ecopages/radiant-ui/label';
 
 <RuiField name="plan">
   <RuiLabel>Plan</RuiLabel>
   <RuiRadioGroup value="pro" name="plan" label="Plan">
-    <label><input type="radio" value="free" /> Free</label>
-    <label><input type="radio" value="pro" /> Pro</label>
+    <RuiRadioGroupControl>
+      <RuiRadio value="free">Free</RuiRadio>
+      <RuiRadio value="pro">Pro</RuiRadio>
+    </RuiRadioGroupControl>
   </RuiRadioGroup>
 </RuiField>
 ```
@@ -66,7 +68,7 @@ The custom control dot is decorative (`aria-hidden`), the visually hidden native
 
 ## API
 
-`RuiRadioGroup` is a custom element (`<rui-radio-group>`); the `RuiRadioGroup` view renders one labeled radio per `options` entry.
+`RuiRadioGroup` is a custom element (`<rui-radio-group>`). Compose its options with `RuiRadioGroupControl` and `RuiRadio`, or use the convenience `options` prop to generate the same structure.
 
 ### Attributes
 

--- a/apps/radiant-ui/src/content/stories/date-range-picker.tsx
+++ b/apps/radiant-ui/src/content/stories/date-range-picker.tsx
@@ -51,9 +51,9 @@ export const meta = {
 			>
 				<RuiDateRangePickerControl>
 					<RuiDateRangePickerInputs>
-						<RuiDateRangePickerStartInput />
+						<RuiDateRangePickerStartInput aria-label="Start date" />
 						<RuiDateRangePickerSeparator />
-						<RuiDateRangePickerEndInput />
+						<RuiDateRangePickerEndInput aria-label="End date" />
 					</RuiDateRangePickerInputs>
 					<RuiDateRangePickerToggle />
 				</RuiDateRangePickerControl>

--- a/apps/radiant-ui/src/content/stories/menu-button.tsx
+++ b/apps/radiant-ui/src/content/stories/menu-button.tsx
@@ -1,4 +1,9 @@
-import { RuiMenuButton } from '@ecopages/radiant-ui/menu-button';
+import {
+	RuiMenuButton,
+	RuiMenuButtonContent,
+	RuiMenuButtonItem,
+	RuiMenuButtonTrigger,
+} from '@ecopages/radiant-ui/menu-button';
 import { docsStory, type DocsMeta, type DocsStory } from '@/lib/docs-stories';
 
 export type MenuButtonArgs = {
@@ -28,16 +33,14 @@ export const meta = {
 	},
 	render: (args) => (
 		<div class="playground-menu-button-demo">
-			<RuiMenuButton
-				{...(args.open ? { open: true } : {})}
-				placement={args.placement}
-				trigger={args.children}
-				items={[
-					{ value: 'edit', label: 'Edit' },
-					{ value: 'duplicate', label: 'Duplicate' },
-					{ value: 'delete', label: 'Delete' },
-				]}
-			/>
+			<RuiMenuButton open={args.open} placement={args.placement}>
+				<RuiMenuButtonTrigger>{args.children}</RuiMenuButtonTrigger>
+				<RuiMenuButtonContent>
+					<RuiMenuButtonItem value="edit">Edit</RuiMenuButtonItem>
+					<RuiMenuButtonItem value="duplicate">Duplicate</RuiMenuButtonItem>
+					<RuiMenuButtonItem value="delete">Delete</RuiMenuButtonItem>
+				</RuiMenuButtonContent>
+			</RuiMenuButton>
 		</div>
 	),
 } satisfies DocsMeta<MenuButtonArgs>;

--- a/apps/radiant-ui/src/content/stories/radio-group.tsx
+++ b/apps/radiant-ui/src/content/stories/radio-group.tsx
@@ -1,4 +1,4 @@
-import { RuiRadioGroup } from '@ecopages/radiant-ui/radio-group';
+import { RuiRadio, RuiRadioGroup, RuiRadioGroupControl } from '@ecopages/radiant-ui/radio-group';
 import { docsStory, type DocsMeta, type DocsStory } from '@/lib/docs-stories';
 
 export type RadioGroupArgs = {
@@ -19,15 +19,12 @@ export const meta = {
 		label: { control: { type: 'text' } },
 	},
 	render: (args) => (
-		<RuiRadioGroup
-			value={args.value}
-			disabled={args.disabled}
-			label={args.label}
-			options={[
-				{ value: 'free', label: 'Free' },
-				{ value: 'pro', label: 'Pro' },
-			]}
-		/>
+		<RuiRadioGroup value={args.value} disabled={args.disabled} label={args.label} name="plan">
+			<RuiRadioGroupControl>
+				<RuiRadio value="free">Free</RuiRadio>
+				<RuiRadio value="pro">Pro</RuiRadio>
+			</RuiRadioGroupControl>
+		</RuiRadioGroup>
 	),
 } satisfies DocsMeta<RadioGroupArgs>;
 

--- a/apps/radiant-ui/test/story-previews.test.ts
+++ b/apps/radiant-ui/test/story-previews.test.ts
@@ -9,6 +9,8 @@ import { meta as navigationMenuMeta } from '../src/content/stories/navigation-me
 import { meta as dateFieldMeta } from '../src/content/stories/date-field';
 import { meta as dateRangePickerMeta } from '../src/content/stories/date-range-picker';
 import { meta as autocompleteMeta } from '../src/content/stories/autocomplete';
+import { meta as menuButtonMeta } from '../src/content/stories/menu-button';
+import { meta as radioGroupMeta } from '../src/content/stories/radio-group';
 
 function serialize(element: unknown): string {
 	return JSON.stringify(element);
@@ -100,6 +102,18 @@ describe('story preview renders', () => {
 
 		expect(preview).toContain('case');
 		expect(preview).toContain('rui-listbox');
+	});
+
+	test('menu button and radio group render composed controls', () => {
+		const menuButton = serialize(
+			menuButtonMeta.render!({ open: false, placement: 'bottom-start', children: 'Actions' }),
+		);
+		const radioGroup = serialize(radioGroupMeta.render!({ value: 'pro', disabled: false, label: 'Plan' }));
+
+		expect(menuButton).toContain('rui-menu-button__trigger');
+		expect(menuButton).toContain('rui-menu-button__item');
+		expect(radioGroup).toContain('rui-radio-group');
+		expect(radioGroup).toContain('rui-radio');
 	});
 
 	test('date range picker renders props on the host element', () => {

--- a/apps/radiant-ui/test/story-previews.test.ts
+++ b/apps/radiant-ui/test/story-previews.test.ts
@@ -92,6 +92,8 @@ describe('story preview renders', () => {
 		);
 
 		expect(preview).toContain('rui-date-field');
+		expect(preview).toContain('data-date-field-calendar');
+		expect(preview).toContain('data-date-field-trigger');
 		expect(preview).toContain('2026-12-25');
 		expect(preview).toContain('long');
 		expect(preview).not.toContain('rui-field');
@@ -128,6 +130,9 @@ describe('story preview renders', () => {
 		);
 
 		expect(preview).toContain('rui-date-range-picker');
+		expect(preview).toContain('data-range-calendar');
+		expect(preview).toContain('Start date');
+		expect(preview).toContain('End date');
 		expect(preview).toContain('2026-08-01/2026-08-14');
 		expect(preview).toContain('Trip dates');
 	});

--- a/packages/radiant-ui/src/components/ui/combobox/combobox.css
+++ b/packages/radiant-ui/src/components/ui/combobox/combobox.css
@@ -1,4 +1,5 @@
 @reference '../../../styles/radiant-ui.css';
+@import '../shared/control-toggle.css';
 @import '../shared/popover.css';
 
 rui-combobox {

--- a/packages/radiant-ui/src/components/ui/date-field/date-field.css
+++ b/packages/radiant-ui/src/components/ui/date-field/date-field.css
@@ -1,4 +1,5 @@
 @reference '../../../styles/radiant-ui.css';
+@import '../shared/control-toggle.css';
 @import '../shared/popover.css';
 
 rui-date-field {

--- a/packages/radiant-ui/src/components/ui/date-range-picker/date-range-picker.css
+++ b/packages/radiant-ui/src/components/ui/date-range-picker/date-range-picker.css
@@ -1,4 +1,5 @@
 @reference '../../../styles/radiant-ui.css';
+@import '../shared/control-toggle.css';
 @import '../shared/popover.css';
 
 rui-date-range-picker {

--- a/packages/radiant-ui/src/components/ui/date-range-picker/date-range-picker.stories.tsx
+++ b/packages/radiant-ui/src/components/ui/date-range-picker/date-range-picker.stories.tsx
@@ -60,9 +60,9 @@ export const WithCalendar: Story = {
 		<RuiDateRangePicker>
 			<RuiDateRangePickerControl>
 				<RuiDateRangePickerInputs>
-					<RuiDateRangePickerStartInput />
+					<RuiDateRangePickerStartInput aria-label="Start date" />
 					<RuiDateRangePickerSeparator />
-					<RuiDateRangePickerEndInput />
+					<RuiDateRangePickerEndInput aria-label="End date" />
 				</RuiDateRangePickerInputs>
 				<RuiDateRangePickerToggle />
 			</RuiDateRangePickerControl>

--- a/packages/radiant-ui/src/components/ui/select/select.css
+++ b/packages/radiant-ui/src/components/ui/select/select.css
@@ -1,4 +1,5 @@
 @reference '../../../styles/radiant-ui.css';
+@import '../shared/control-toggle.css';
 @import '../shared/popover.css';
 
 rui-select {


### PR DESCRIPTION
## Summary
- update radiant-ui-docs menu-button and radio-group stories to use composable APIs
- align MDX usage examples with the composable helpers
- add preview coverage for composed controls
- include shared control-toggle styles in date-field, date-range-picker, select, and combobox bundles so calendar/list triggers are visible
- make date-field and date-range-picker usage docs canonical composable examples
- document composition helpers, focus behavior, keyboard navigation, and accessible start/end range inputs

## Validation
- story preview tests: 10 passed
- radiant-ui docs typecheck passed
- full commit hook passed: package tests, docs E2E 3/3, Nitro E2E 12/12, Vite E2E 5/5, and size checks