### PR TITLE
fix(radiant-ui): label default date range inputs

### DIFF
--- a/apps/radiant-ui/src/content/components/date-range-picker.mdx
+++ b/apps/radiant-ui/src/content/components/date-range-picker.mdx
@@ -32,6 +32,8 @@ export const config = {
 
 Compose the two inputs, separator, calendar trigger, popup, and calendar as children of `RuiDateRangePicker`. When no children are supplied, `RuiDateRangePicker` renders this same composition for you. Pass `value` as `start/end` ISO dates and give each input its own accessible name.
 
+The default composition accepts `startLabel` and `endLabel` view props for the two native inputs. Use those props when the default structure is sufficient; set `aria-label` directly on `RuiDateRangePickerStartInput` and `RuiDateRangePickerEndInput` when composing the children yourself.
+
 ```tsx
 import {
   RuiDateRangePicker,
@@ -121,6 +123,15 @@ Geometry shares control tokens (`--size-control-*`, `--radius-control`, `--space
 | Event | Detail | Description |
 | --- | --- | --- |
 | `rui-change` | `{ value, start, end }` | Fired when a valid range is committed (typing or calendar pick). |
+
+### JSX view props
+
+These props configure the default child composition rendered by the `RuiDateRangePicker` JSX view. They are not custom-element attributes.
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `startLabel` | `string` | `Start date` | Accessible name for the default start-date input. |
+| `endLabel` | `string` | `End date` | Accessible name for the default end-date input. |
 
 ### Composition helpers
 

--- a/packages/radiant-ui/src/components/ui/date-range-picker/date-range-picker.ssr.test.tsx
+++ b/packages/radiant-ui/src/components/ui/date-range-picker/date-range-picker.ssr.test.tsx
@@ -1,0 +1,15 @@
+import { renderToString } from '@ecopages/jsx/server';
+import { describe, expect, it } from 'vitest';
+import { RuiDateRangePicker } from './date-range-picker';
+
+describe('RuiDateRangePicker view', () => {
+	it('provides distinct default input labels and accepts custom labels', () => {
+		const defaults = renderToString(<RuiDateRangePicker />);
+		const custom = renderToString(<RuiDateRangePicker startLabel="Arrival date" endLabel="Departure date" />);
+
+		expect(defaults).toContain('aria-label="Start date"');
+		expect(defaults).toContain('aria-label="End date"');
+		expect(custom).toContain('aria-label="Arrival date"');
+		expect(custom).toContain('aria-label="Departure date"');
+	});
+});

--- a/packages/radiant-ui/src/components/ui/date-range-picker/date-range-picker.tsx
+++ b/packages/radiant-ui/src/components/ui/date-range-picker/date-range-picker.tsx
@@ -125,6 +125,14 @@ export function RuiDateRangePickerCalendar(props: RuiDateRangePickerCalendarProp
 	return <RuiCalendar {...props} data-range-calendar />;
 }
 
+export type RuiDateRangePickerViewProps = RuiDateRangePickerProps & {
+	slot?: string;
+	/** Accessible name for the default start-date input. */
+	startLabel?: string;
+	/** Accessible name for the default end-date input. */
+	endLabel?: string;
+};
+
 /**
  * Locale-aware date range picker with text inputs and a range calendar popover.
  *
@@ -132,17 +140,19 @@ export function RuiDateRangePickerCalendar(props: RuiDateRangePickerCalendarProp
  */
 export function RuiDateRangePicker({
 	children,
+	startLabel = 'Start date',
+	endLabel = 'End date',
 	...props
-}: JsxHtmlPropsWithChildren<RuiDateRangePickerProps & { slot?: string }>) {
+}: JsxHtmlPropsWithChildren<RuiDateRangePickerViewProps>) {
 	return (
 		<rui-date-range-picker {...props}>
 			{children ?? (
 				<>
 					<RuiDateRangePickerControl>
 						<RuiDateRangePickerInputs>
-							<RuiDateRangePickerStartInput />
+							<RuiDateRangePickerStartInput aria-label={startLabel} />
 							<RuiDateRangePickerSeparator />
-							<RuiDateRangePickerEndInput />
+							<RuiDateRangePickerEndInput aria-label={endLabel} />
 						</RuiDateRangePickerInputs>
 						<RuiDateRangePickerToggle />
 					</RuiDateRangePickerControl>

--- a/packages/radiant-ui/src/components/ui/date-range-picker/index.ts
+++ b/packages/radiant-ui/src/components/ui/date-range-picker/index.ts
@@ -13,4 +13,5 @@ export {
 	RuiDateRangePickerSeparator,
 	RuiDateRangePickerStartInput,
 	RuiDateRangePickerToggle,
+	type RuiDateRangePickerViewProps,
 } from './date-range-picker';


### PR DESCRIPTION
## Summary
- add distinct accessible names to the default date-range-picker start and end inputs
- expose `startLabel` and `endLabel` view props for custom labels
- preserve direct `aria-label` control for explicit composed inputs
- document the convenience props and add SSR regression coverage

## Validation
- focused date-range-picker SSR test passed
- radiant-ui package typecheck passed
- radiant-ui docs typecheck passed
- full commit hook passed: package tests, docs E2E 3/3, Nitro E2E 12/12, Vite E2E 5/5, and size checks