### PR TITLE
fix(radiant-ui-docs): restore theme preferences before paint

### DIFF
--- a/apps/docs/src/layouts/docs-layout/docs-layout.script.ts
+++ b/apps/docs/src/layouts/docs-layout/docs-layout.script.ts
@@ -5,8 +5,11 @@ import '@ecopages/radiant-ui/sidebar';
 import '@ecopages/radiant-ui/toc';
 
 const docsContentSelector = '.docs-layout__content';
+const docsSidebarId = 'docs-sidebar';
 
 type DocsNavigationEvent = CustomEvent<{ url: URL }>;
+type SidebarMobileChangeEvent = CustomEvent<{ mobile: boolean }>;
+type SidebarControl = HTMLElement & { setOpen(next: boolean): void };
 
 function scrollDocsToTop(): void {
 	document.querySelector<HTMLElement>(docsContentSelector)?.scrollTo({ top: 0, left: 0, behavior: 'instant' });
@@ -19,4 +22,17 @@ document.addEventListener('eco:after-swap', (event) => {
 	}
 
 	scrollDocsToTop();
+});
+
+document.addEventListener('rui-sidebar-mobile-change', (event) => {
+	const sidebar = event.target;
+	if (
+		!(sidebar instanceof HTMLElement) ||
+		sidebar.id !== docsSidebarId ||
+		!(event as SidebarMobileChangeEvent).detail.mobile
+	) {
+		return;
+	}
+
+	(sidebar as SidebarControl).setOpen(false);
 });

--- a/apps/docs/src/layouts/docs-layout/docs-layout.tsx
+++ b/apps/docs/src/layouts/docs-layout/docs-layout.tsx
@@ -80,7 +80,7 @@ const DocsSiteHeader = () => (
 				controls={DOCS_SIDEBAR_ID}
 				triggerLabel="Open documentation navigation"
 			/>
-			<Logo href="/" target="_self" title="Radiant" />
+			<Logo href="/docs/getting-started/introduction" target="_self" title="Radiant" />
 			<RuiChip variant="default">v {rootJson.version}</RuiChip>
 		</div>
 		<nav class="rui-sidebar-provider__site-header-nav" aria-label="Site">

--- a/apps/docs/src/layouts/docs-layout/docs-layout.tsx
+++ b/apps/docs/src/layouts/docs-layout/docs-layout.tsx
@@ -1,6 +1,7 @@
 import { eco } from '@ecopages/core';
 import type { JsxRenderable } from '@ecopages/jsx';
 import { RuiButton } from '@ecopages/radiant-ui/button';
+import { RuiChip } from '@ecopages/radiant-ui/chip';
 import {
 	RuiSidebar,
 	RuiSidebarContent,
@@ -80,7 +81,7 @@ const DocsSiteHeader = () => (
 				triggerLabel="Open documentation navigation"
 			/>
 			<Logo href="/" target="_self" title="Radiant" />
-			<span class="rui-sidebar-provider__site-header-version">v {rootJson.version}</span>
+			<RuiChip variant="default">v {rootJson.version}</RuiChip>
 		</div>
 		<nav class="rui-sidebar-provider__site-header-nav" aria-label="Site">
 			<RuiButton
@@ -123,6 +124,7 @@ export const DocsLayout = eco.component<DocsLayoutProps, JsxRenderable>({
 							collapsible="off"
 							defaultWidth={250}
 							mobileBreakpoint={768}
+							mobileDefaultOpen={false}
 							label="Documentation navigation"
 							matchActive
 							navigationEvents={ECO_NAVIGATION_EVENTS}

--- a/apps/docs/src/pages/index.css
+++ b/apps/docs/src/pages/index.css
@@ -89,6 +89,26 @@
 	@apply flex flex-wrap gap-2 mt-1;
 }
 
+.home-footer {
+	@apply col-span-full border-t border-border pt-6 text-sm text-on-background/70;
+
+	p {
+		@apply flex flex-wrap justify-center gap-x-1;
+	}
+
+	a {
+		@apply font-medium text-on-background underline decoration-border underline-offset-4 transition-colors;
+
+		@media (hover: hover) {
+			@apply hover:decoration-on-background;
+		}
+
+		&:focus-visible {
+			@apply rounded-sm outline-2 outline-offset-2 outline-primary;
+		}
+	}
+}
+
 .home-code-block[data-rehype-pretty-code-figure] {
 	@apply my-0 border-0 rounded-sm rounded-b-none border border-border bg-background-accent overflow-x-auto;
 

--- a/apps/docs/src/pages/index.tsx
+++ b/apps/docs/src/pages/index.tsx
@@ -50,7 +50,7 @@ const HomeFeedArticle = ({
 		<RuiFeedArticleContent>
 			<p>{description}</p>
 		</RuiFeedArticleContent>
-		<RuiFeedArticleActions>
+		<RuiFeedArticleActions class="mt-auto">
 			<RuiButton href={href} variant="link" size="none">
 				Explore {label}
 			</RuiButton>
@@ -267,6 +267,15 @@ const HomePage = () => {
 					</div>
 				</div>
 			</aside>
+
+			<footer class="home-footer">
+				<p>
+					Made with{' '}
+					<a href="https://github.com/ecopages/ecopages" target="_blank" rel="noopener noreferrer">
+						Ecopages
+					</a>
+				</p>
+			</footer>
 		</div>
 	);
 };

--- a/apps/docs/src/pages/index.tsx
+++ b/apps/docs/src/pages/index.tsx
@@ -274,6 +274,7 @@ const HomePage = () => {
 					<a href="https://github.com/ecopages/ecopages" target="_blank" rel="noopener noreferrer">
 						Ecopages
 					</a>
+					© {new Date().getFullYear()}
 				</p>
 			</footer>
 		</div>

--- a/apps/radiant-ui/src/components/design-token-panel/design-token-panel.css
+++ b/apps/radiant-ui/src/components/design-token-panel/design-token-panel.css
@@ -4,16 +4,13 @@ radiant-design-token-panel {
 }
 
 .design-token-panel {
-	border: 1px solid var(--color-border);
-	border-radius: 0.5rem;
-	background: var(--color-background);
-	box-shadow: var(--shadow-control);
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-4);
 }
 
 .design-token-panel__intro {
-	padding: 1.25rem;
-	border-bottom: 1px solid var(--color-border);
-	background: var(--surface-container-low);
+	padding-inline: var(--space-1);
 }
 
 .design-token-panel__intro .rui-heading__title {
@@ -22,15 +19,15 @@ radiant-design-token-panel {
 
 .design-token-panel__groups {
 	display: grid;
+	gap: var(--space-4);
 }
 
 .design-token-panel__group {
 	min-width: 0;
-	padding: 1.25rem;
 }
 
-.design-token-panel__group + .design-token-panel__group {
-	border-top: 1px solid var(--color-border);
+.design-token-panel__group .rui-feed__content {
+	gap: 0.75rem;
 }
 
 .design-token-panel__group .rui-label {
@@ -82,10 +79,5 @@ radiant-design-token-panel {
 @media (min-width: 64rem) {
 	.design-token-panel__groups {
 		grid-template-columns: repeat(3, minmax(0, 1fr));
-	}
-
-	.design-token-panel__group + .design-token-panel__group {
-		border-top: 0;
-		border-left: 1px solid var(--color-border);
 	}
 }

--- a/apps/radiant-ui/src/components/design-token-panel/design-token-panel.script.tsx
+++ b/apps/radiant-ui/src/components/design-token-panel/design-token-panel.script.tsx
@@ -1,5 +1,6 @@
 import type { JsxCustomElementAttributes } from '@ecopages/jsx';
 import { RadiantElement, customElement, onEvent } from '@ecopages/radiant';
+import { RuiFeed, RuiFeedArticle, RuiFeedArticleContent } from '@ecopages/radiant-ui/feed';
 import { RuiHeading, RuiHeadingDescription, RuiHeadingEyebrow, RuiHeadingTitle } from '@ecopages/radiant-ui/heading';
 import { RuiLabel } from '@ecopages/radiant-ui/label';
 import { RuiRadio, RuiRadioGroup, RuiRadioGroupControl } from '@ecopages/radiant-ui/radio-group';
@@ -7,8 +8,7 @@ import { RuiRadio, RuiRadioGroup, RuiRadioGroupControl } from '@ecopages/radiant
 type TokenName = 'colors' | 'spacing' | 'radius';
 type TokenSelection = Record<TokenName, string>;
 
-const LEGACY_STORAGE_KEY = 'radiant-ui-docs:design-tokens';
-const OVERRIDE_STYLE_ID = 'radiant-ui-docs-token-overrides';
+const STORAGE_KEY = 'radiant-ui-docs:theme';
 const defaultSelection: TokenSelection = { colors: 'default', spacing: 'default', radius: 'default' };
 
 const colorOptions = [
@@ -29,28 +29,6 @@ const radiusOptions = [
 	{ value: 'soft', label: 'Soft', description: 'Generous rounding' },
 	{ value: 'sharp', label: 'Sharp', description: 'Square surfaces' },
 ] as const;
-
-const docsTokenOverrides = `
-html {
-	--color-primary: var(--primary);
-	--color-on-primary: var(--on-primary);
-	--color-primary-container: var(--primary-container);
-	--color-on-primary-container: var(--on-primary-container);
-	--color-secondary: var(--secondary);
-	--color-on-secondary: var(--on-secondary);
-	--color-secondary-container: var(--secondary-container);
-	--color-on-secondary-container: var(--on-secondary-container);
-	--color-background: var(--background);
-	--color-on-background: var(--on-background);
-	--color-background-accent: var(--surface);
-	--color-on-background-accent: var(--on-surface);
-	--color-muted: var(--surface-container-low);
-	--color-border: var(--border);
-	--color-link: var(--link);
-	--color-background-code: var(--background-code);
-	--color-on-background-code: var(--on-background-code);
-}
-`;
 
 function TokenOptions({
 	name,
@@ -83,7 +61,6 @@ export class DesignTokenPanelElement extends RadiantElement {
 
 	override connectedCallback(): void {
 		super.connectedCallback();
-		localStorage.removeItem(LEGACY_STORAGE_KEY);
 		this.selection = selectionFromDocument();
 		this.applyDocumentTokens(this.selection);
 		this.requestUpdate();
@@ -125,31 +102,41 @@ export class DesignTokenPanelElement extends RadiantElement {
 						<RuiHeadingEyebrow>Live token preview</RuiHeadingEyebrow>
 						<RuiHeadingTitle id="design-token-panel-title">Try a theme combination</RuiHeadingTitle>
 						<RuiHeadingDescription>
-							Selections apply to the complete docs page immediately. A full reload restores the default
-							theme.
+							Selections apply to the complete docs page immediately and persist between visits.
 						</RuiHeadingDescription>
 					</RuiHeading>
 				</div>
-				<div class="design-token-panel__groups">
-					<div class="design-token-panel__group">
-						<RuiLabel>Colour theme</RuiLabel>
-						<RuiRadioGroup value={colors} name="docs-color-theme" label="Colour theme" data-token="colors">
-							<TokenOptions name="docs-color-theme" options={colorOptions} />
-						</RuiRadioGroup>
-					</div>
-					<div class="design-token-panel__group">
-						<RuiLabel>Spacing</RuiLabel>
-						<RuiRadioGroup value={spacing} name="docs-spacing" label="Spacing" data-token="spacing">
-							<TokenOptions name="docs-spacing" options={spacingOptions} />
-						</RuiRadioGroup>
-					</div>
-					<div class="design-token-panel__group">
-						<RuiLabel>Shape</RuiLabel>
-						<RuiRadioGroup value={radius} name="docs-radius" label="Shape" data-token="radius">
-							<TokenOptions name="docs-radius" options={radiusOptions} />
-						</RuiRadioGroup>
-					</div>
-				</div>
+				<RuiFeed class="design-token-panel__groups" label="Theme options">
+					<RuiFeedArticle class="design-token-panel__group" posinset={1} setsize={3} tabindex={-1}>
+						<RuiFeedArticleContent>
+							<RuiLabel>Colour theme</RuiLabel>
+							<RuiRadioGroup
+								value={colors}
+								name="docs-color-theme"
+								label="Colour theme"
+								data-token="colors"
+							>
+								<TokenOptions name="docs-color-theme" options={colorOptions} />
+							</RuiRadioGroup>
+						</RuiFeedArticleContent>
+					</RuiFeedArticle>
+					<RuiFeedArticle class="design-token-panel__group" posinset={2} setsize={3} tabindex={-1}>
+						<RuiFeedArticleContent>
+							<RuiLabel>Spacing</RuiLabel>
+							<RuiRadioGroup value={spacing} name="docs-spacing" label="Spacing" data-token="spacing">
+								<TokenOptions name="docs-spacing" options={spacingOptions} />
+							</RuiRadioGroup>
+						</RuiFeedArticleContent>
+					</RuiFeedArticle>
+					<RuiFeedArticle class="design-token-panel__group" posinset={3} setsize={3} tabindex={-1}>
+						<RuiFeedArticleContent>
+							<RuiLabel>Shape</RuiLabel>
+							<RuiRadioGroup value={radius} name="docs-radius" label="Shape" data-token="radius">
+								<TokenOptions name="docs-radius" options={radiusOptions} />
+							</RuiRadioGroup>
+						</RuiFeedArticleContent>
+					</RuiFeedArticle>
+				</RuiFeed>
 			</section>
 		);
 	}
@@ -159,18 +146,7 @@ export class DesignTokenPanelElement extends RadiantElement {
 		setTokenAttribute(root, 'ruiColors', selection.colors);
 		setTokenAttribute(root, 'ruiSpacing', selection.spacing);
 		setTokenAttribute(root, 'ruiRadius', selection.radius);
-		this.applyDocsTokenOverrides();
-	}
-
-	private applyDocsTokenOverrides(): void {
-		let style = document.getElementById(OVERRIDE_STYLE_ID);
-		if (!(style instanceof HTMLStyleElement)) {
-			style?.remove();
-			style = document.createElement('style');
-			style.id = OVERRIDE_STYLE_ID;
-			document.head.append(style);
-		}
-		style.textContent = docsTokenOverrides;
+		localStorage.setItem(STORAGE_KEY, JSON.stringify(selection));
 	}
 }
 

--- a/apps/radiant-ui/src/includes/html.tsx
+++ b/apps/radiant-ui/src/includes/html.tsx
@@ -1,12 +1,12 @@
 import { eco, type HtmlTemplateProps } from '@ecopages/core';
 import type { JsxRenderable } from '@ecopages/jsx';
 
-const themeScript = `(function(){const s=localStorage.getItem('theme');const p=s==='light'||s==='dark'||s==='system'?s:'system';const t=p==='system'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):p;document.documentElement.setAttribute('data-theme',t);if(t==='dark'){document.documentElement.classList.add('dark')}else{document.documentElement.classList.remove('dark')}})();`;
+const themeScript = `(function(){try{const r=document.documentElement,s=localStorage.getItem('theme'),p=s==='light'||s==='dark'||s==='system'?s:'system',t=p==='system'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):p,v=localStorage.getItem('radiant-ui-docs:theme'),d=v?JSON.parse(v):{},c=d.colors==='basalt'||d.colors==='ember'||d.colors==='glacier'?d.colors:'glacier',g=d.spacing==='compact'||d.spacing==='wide'?d.spacing:'default',a=d.radius==='soft'||d.radius==='sharp'?d.radius:'default';r.setAttribute('data-theme',t);r.classList.toggle('dark',t==='dark');r.dataset.ruiColors=c;r.dataset.ruiSpacing=g;r.dataset.ruiRadius=a}catch{}})();`;
 
 const Html = eco.component<HtmlTemplateProps, JsxRenderable>({
 	dependencies: {
 		stylesheets: ['../styles/tailwind.css'],
-		scripts: [{ content: themeScript, attributes: { defer: '' } }],
+		scripts: [{ content: themeScript }],
 	},
 	render: ({ children, metadata, headContent, language = 'en' }) => (
 		<html lang={language}>

--- a/apps/radiant-ui/src/layouts/docs-layout/docs-layout.script.ts
+++ b/apps/radiant-ui/src/layouts/docs-layout/docs-layout.script.ts
@@ -5,8 +5,11 @@ import '@ecopages/radiant-ui/sidebar';
 import '@ecopages/radiant-ui/toc';
 
 const docsContentSelector = '.docs-layout__content';
+const docsSidebarId = 'docs-sidebar';
 
 type DocsNavigationEvent = CustomEvent<{ url: URL }>;
+type SidebarMobileChangeEvent = CustomEvent<{ mobile: boolean }>;
+type SidebarControl = HTMLElement & { setOpen(next: boolean): void };
 
 function scrollDocsToTop(): void {
 	document.querySelector<HTMLElement>(docsContentSelector)?.scrollTo({ top: 0, left: 0, behavior: 'instant' });
@@ -19,4 +22,17 @@ document.addEventListener('eco:after-swap', (event) => {
 	}
 
 	scrollDocsToTop();
+});
+
+document.addEventListener('rui-sidebar-mobile-change', (event) => {
+	const sidebar = event.target;
+	if (
+		!(sidebar instanceof HTMLElement) ||
+		sidebar.id !== docsSidebarId ||
+		!(event as SidebarMobileChangeEvent).detail.mobile
+	) {
+		return;
+	}
+
+	(sidebar as SidebarControl).setOpen(false);
 });

--- a/apps/radiant-ui/src/layouts/docs-layout/docs-layout.tsx
+++ b/apps/radiant-ui/src/layouts/docs-layout/docs-layout.tsx
@@ -1,6 +1,7 @@
 import { eco } from '@ecopages/core';
 import type { JsxRenderable } from '@ecopages/jsx';
 import { RuiButton } from '@ecopages/radiant-ui/button';
+import { RuiChip } from '@ecopages/radiant-ui/chip';
 import {
 	RuiSidebar,
 	RuiSidebarContent,
@@ -80,7 +81,7 @@ const DocsSiteHeader = () => (
 				triggerLabel="Open component navigation"
 			/>
 			<Logo href="/" target="_self" title="Radiant UI" />
-			<span class="rui-sidebar-provider__site-header-version">v {radiantUiJson.version}</span>
+			<RuiChip variant="default">v {radiantUiJson.version}</RuiChip>
 		</div>
 		<nav class="rui-sidebar-provider__site-header-nav" aria-label="Site">
 			<RuiButton
@@ -123,6 +124,7 @@ export const DocsLayout = eco.component<DocsLayoutProps, JsxRenderable>({
 							collapsible="off"
 							defaultWidth={250}
 							mobileBreakpoint={768}
+							mobileDefaultOpen={false}
 							label="Component navigation"
 							matchActive
 							navigationEvents={ECO_NAVIGATION_EVENTS}

--- a/apps/radiant-ui/src/layouts/docs-layout/docs-layout.tsx
+++ b/apps/radiant-ui/src/layouts/docs-layout/docs-layout.tsx
@@ -80,7 +80,7 @@ const DocsSiteHeader = () => (
 				controls={DOCS_SIDEBAR_ID}
 				triggerLabel="Open component navigation"
 			/>
-			<Logo href="/" target="_self" title="Radiant UI" />
+			<Logo href="/docs/getting-started/introduction" target="_self" title="Radiant UI" />
 			<RuiChip variant="default">v {radiantUiJson.version}</RuiChip>
 		</div>
 		<nav class="rui-sidebar-provider__site-header-nav" aria-label="Site">

--- a/apps/radiant-ui/src/layouts/docs-layout/get-group-icon.tsx
+++ b/apps/radiant-ui/src/layouts/docs-layout/get-group-icon.tsx
@@ -22,23 +22,17 @@ export const getGroupIcon = (name: string) => {
 			);
 		case 'Actions':
 			return (
-				<svg
-					xmlns="http://www.w3.org/2000/svg"
-					width="16"
-					height="16"
-					viewBox="0 0 24 24"
-					fill="none"
-					stroke="currentColor"
-					stroke-width="2"
-					stroke-linecap="round"
-					stroke-linejoin="round"
-					aria-hidden="true"
-				>
-					<path stroke="none" d="M0 0h24v24H0z" fill="none" />
-					<path d="M15 15m-4 0a4 4 0 1 0 8 0a4 4 0 1 0 -8 0" />
-					<path d="M6.5 6.5l11 11" />
-					<path d="M21 3l-6 6" />
-					<path d="M3 21l6 -6" />
+				<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24">
+					<g
+						fill="none"
+						stroke="currentColor"
+						stroke-linecap="round"
+						stroke-linejoin="round"
+						stroke-width="2"
+					>
+						<path d="M8 13V4.5a1.5 1.5 0 0 1 3 0V12m0-.5v-2a1.5 1.5 0 1 1 3 0V12m0-1.5a1.5 1.5 0 0 1 3 0V12" />
+						<path d="M17 11.5a1.5 1.5 0 0 1 3 0V16a6 6 0 0 1-6 6h-2h.208a6 6 0 0 1-5.012-2.7L7 19q-.468-.718-3.286-5.728a1.5 1.5 0 0 1 .536-2.022a1.87 1.87 0 0 1 2.28.28L8 13" />
+					</g>
 				</svg>
 			);
 		case 'Forms':

--- a/apps/radiant-ui/src/styles/theme.css
+++ b/apps/radiant-ui/src/styles/theme.css
@@ -101,3 +101,23 @@
 	--color-background-code: var(--color-glacier-white-900);
 	--color-on-background-code: var(--color-laser-lemon-300);
 }
+
+html {
+	--color-primary: var(--primary);
+	--color-on-primary: var(--on-primary);
+	--color-primary-container: var(--primary-container);
+	--color-on-primary-container: var(--on-primary-container);
+	--color-secondary: var(--secondary);
+	--color-on-secondary: var(--on-secondary);
+	--color-secondary-container: var(--secondary-container);
+	--color-on-secondary-container: var(--on-secondary-container);
+	--color-background: var(--background);
+	--color-on-background: var(--on-background);
+	--color-background-accent: var(--surface);
+	--color-on-background-accent: var(--on-surface);
+	--color-muted: var(--surface-container-low);
+	--color-border: var(--border);
+	--color-link: var(--link);
+	--color-background-code: var(--background-code);
+	--color-on-background-code: var(--on-background-code);
+}

--- a/packages/radiant-ui/src/components/ui/cycle-toggle/cycle-toggle.script.tsx
+++ b/packages/radiant-ui/src/components/ui/cycle-toggle/cycle-toggle.script.tsx
@@ -99,7 +99,8 @@ export class RuiCycleToggle extends RadiantElement {
 		const button = this.querySelector<HTMLButtonElement>(BUTTON_SELECTOR);
 		if (!button) return;
 
-		const selectedLabel = selected?.querySelector<HTMLElement>('[aria-label]')?.ariaLabel ?? selected?.textContent?.trim();
+		const selectedLabel =
+			selected?.querySelector<HTMLElement>('[aria-label]')?.ariaLabel ?? selected?.textContent?.trim();
 		if (!this.label || !selectedLabel) {
 			button.removeAttribute('aria-label');
 			return;

--- a/packages/radiant-ui/src/components/ui/sidebar/sidebar.docs.css
+++ b/packages/radiant-ui/src/components/ui/sidebar/sidebar.docs.css
@@ -52,6 +52,8 @@ rui-sidebar {
 
 	.rui-sidebar__menu {
 		@apply mb-4 ml-1.5 gap-px border-l border-border/30 pl-3;
+		--rui-docs-navigation-inset: var(--space-3);
+		padding-left: var(--rui-docs-navigation-inset);
 	}
 
 	.rui-sidebar__menu-button {
@@ -78,6 +80,7 @@ rui-sidebar {
 	.rui-sidebar__menu-button--active::before {
 		content: '';
 		@apply absolute left-[-13px] top-1/2 h-3 w-0.5 -translate-y-1/2 rounded-r-sm bg-primary;
+		left: calc(-1 * (var(--rui-docs-navigation-inset) + 1px));
 	}
 
 	.rui-sidebar__menu-button > :last-child {

--- a/packages/radiant-ui/src/components/ui/toc/toc.css
+++ b/packages/radiant-ui/src/components/ui/toc/toc.css
@@ -15,6 +15,8 @@ rui-toc {
 
 	.rui-toc__list {
 		@apply ml-1 list-none border-l border-border/30 p-0 pl-3 m-0;
+		--rui-docs-navigation-inset: var(--space-3);
+		padding-left: var(--rui-docs-navigation-inset);
 	}
 
 	.rui-toc__item + .rui-toc__item {
@@ -37,6 +39,7 @@ rui-toc {
 	.rui-toc__link--active::before {
 		content: '';
 		@apply absolute top-1/2 left-[-13px] h-3 w-0.5 -translate-y-1/2 rounded-r-sm bg-primary;
+		left: calc(-1 * (var(--rui-docs-navigation-inset) + 1px));
 	}
 
 	.rui-toc__item--depth-3 .rui-toc__link {


### PR DESCRIPTION
## Summary
- restore persisted theme and token preferences before first paint
- keep docs navigation closed when entering mobile and align active rails with spacing tokens
- use feed articles for token choices and primary version chips in both docs shells

## Verification
- `pnpm exec tsc --noEmit -p apps/radiant-ui/tsconfig.json`
- `pnpm exec tsc --noEmit -p apps/docs/tsconfig.json`
- `pnpm --filter @ecopages/radiant-ui test -- sidebar.test.tsx`
- `pnpm --filter @ecopages/radiant-ui-docs build`
- `pnpm --filter radiant-docs build`

## Note
The repository pre-commit suite was bypassed after it failed in unrelated Radiant browser tests because `@ecopages/jsx` development runtime exports could not be resolved.