### PR TITLE
docs(radiant-ui): clarify token composition

### DIFF
--- a/apps/radiant-ui/src/components/design-token-panel/design-token-panel.script.tsx
+++ b/apps/radiant-ui/src/components/design-token-panel/design-token-panel.script.tsx
@@ -9,13 +9,13 @@ type TokenName = 'colors' | 'spacing' | 'radius';
 type TokenSelection = Record<TokenName, string>;
 
 const STORAGE_KEY = 'radiant-ui-docs:theme';
-const defaultSelection: TokenSelection = { colors: 'default', spacing: 'default', radius: 'default' };
+const defaultSelection: TokenSelection = { colors: 'glacier', spacing: 'default', radius: 'default' };
 
 const colorOptions = [
-	{ value: 'default', label: 'Default', description: 'Glacier alias' },
 	{ value: 'glacier', label: 'Glacier', description: 'Cool, editorial' },
 	{ value: 'basalt', label: 'Basalt', description: 'Carbon-inspired' },
 	{ value: 'ember', label: 'Ember', description: 'Warm accent' },
+	{ value: 'aurora', label: 'Aurora', description: 'Vivid and expressive' },
 ] as const;
 
 const spacingOptions = [
@@ -100,7 +100,7 @@ export class DesignTokenPanelElement extends RadiantElement {
 				<div class="design-token-panel__intro">
 					<RuiHeading size="sm">
 						<RuiHeadingEyebrow>Live token preview</RuiHeadingEyebrow>
-						<RuiHeadingTitle id="design-token-panel-title">Try a theme combination</RuiHeadingTitle>
+						<RuiHeadingTitle id="design-token-panel-title">Try a token combination</RuiHeadingTitle>
 						<RuiHeadingDescription>
 							Selections apply to the complete docs page immediately and persist between visits.
 						</RuiHeadingDescription>
@@ -109,11 +109,11 @@ export class DesignTokenPanelElement extends RadiantElement {
 				<RuiFeed class="design-token-panel__groups" label="Theme options">
 					<RuiFeedArticle class="design-token-panel__group" posinset={1} setsize={3} tabindex={-1}>
 						<RuiFeedArticleContent>
-							<RuiLabel>Colour theme</RuiLabel>
+							<RuiLabel>Colour profile</RuiLabel>
 							<RuiRadioGroup
 								value={colors}
 								name="docs-color-theme"
-								label="Colour theme"
+								label="Colour profile"
 								data-token="colors"
 							>
 								<TokenOptions name="docs-color-theme" options={colorOptions} />
@@ -158,14 +158,17 @@ function isTokenName(value: string | undefined): value is TokenName {
 function selectionFromDocument(): TokenSelection {
 	const { ruiColors, ruiSpacing, ruiRadius } = document.documentElement.dataset;
 	return {
-		colors: ruiColors === 'glacier' || ruiColors == null || ruiColors === '' ? 'default' : ruiColors,
+		colors:
+			ruiColors === 'basalt' || ruiColors === 'ember' || ruiColors === 'aurora'
+				? ruiColors
+				: defaultSelection.colors,
 		spacing: ruiSpacing != null && ruiSpacing !== '' ? ruiSpacing : defaultSelection.spacing,
 		radius: ruiRadius != null && ruiRadius !== '' ? ruiRadius : defaultSelection.radius,
 	};
 }
 
 function setTokenAttribute(root: HTMLElement, name: 'ruiColors' | 'ruiSpacing' | 'ruiRadius', value: string): void {
-	root.dataset[name] = name === 'ruiColors' && value === 'default' ? 'glacier' : value;
+	root.dataset[name] = value;
 }
 
 declare module '@ecopages/jsx/jsx-runtime' {

--- a/apps/radiant-ui/src/content/components/getting-started/theming.mdx
+++ b/apps/radiant-ui/src/content/components/getting-started/theming.mdx
@@ -1,6 +1,6 @@
 ---
 title: Themes and tokens
-description: Choose colour, density, and shape token packs, then apply them as a complete Radiant UI theme.
+description: Compose colour, spacing, and radius tokens into a Radiant UI foundation.
 group: Getting started
 ---
 
@@ -16,29 +16,29 @@ export const config = {
 # Themes and tokens
 
 <p class="docs-lede">
-	Radiant UI separates colour, spacing, and radius into token packs. Combine them to give an entire product a
-	consistent visual character without changing component code.
+	Radiant UI separates colour, spacing, and radius into token packs. Choose the combination once in your application
+	stylesheet; components consume the resulting semantic tokens without component-specific overrides.
 </p>
 
 <DesignTokenPanel />
 
-## Choose a theme with CSS imports
+## Start with the foundation
 
-Themes are build-time CSS composition. Import one complete theme and the component stylesheet in your application's
-entry stylesheet. The `default` theme is an alias for Glacier, the balanced blue profile used by this documentation;
-it includes the default spacing and radius packs.
+Import the default foundation and component stylesheet in your application's entry stylesheet. It provides Glacier with
+the default spacing and radius packs.
 
 ```css
 @import '@ecopages/radiant-ui/themes/default';
 @import '@ecopages/radiant-ui/styles.css';
 ```
 
-Use Aurora when you want its more vivid colour profile:
+## Explore colour profiles
 
-```css
-@import '@ecopages/radiant-ui/themes/aurora';
-@import '@ecopages/radiant-ui/styles.css';
-```
+The live preview above includes Glacier, Basalt, Ember, and Aurora. Aurora is the vivid, expressive option; the other
+profiles are deliberately more restrained.
+
+Important: this preview is documentation-only. It uses `data-rui-colors` to switch profiles at runtime so you can
+compare combinations. Those attributes are not a supported application API.
 
 ## Spacing and shape
 
@@ -52,10 +52,10 @@ the sharp radius pack.
 @import '@ecopages/radiant-ui/tokens/radius/soft';
 ```
 
-## Compose intentionally
+## Compose the geometry you need
 
-Load one complete theme first, then layer a spacing or radius pack when a product needs a distinct density or shape.
-All component styles consume semantic roles and shared geometry tokens, so no component-specific overrides are needed.
+Layer a spacing or radius pack after the foundation when a product needs a distinct density or shape. Do not start from
+a named full preset: select only the packs your product needs.
 
 ```css
 @import '@ecopages/radiant-ui/themes/default';
@@ -64,9 +64,8 @@ All component styles consume semantic roles and shared geometry tokens, so no co
 @import '@ecopages/radiant-ui/styles.css';
 ```
 
-`data-rui-colors`, `data-rui-spacing`, and `data-rui-radius` are only used by this documentation's live preview. They
-are not an application theming API. Do not add them to production markup; select the complete theme and optional token
-packs with CSS imports instead.
+`data-rui-colors`, `data-rui-spacing`, and `data-rui-radius` are only used by this documentation's live preview. Do
+not add them to production markup.
 
 ## Build a custom theme
 

--- a/apps/radiant-ui/src/includes/html.tsx
+++ b/apps/radiant-ui/src/includes/html.tsx
@@ -1,7 +1,7 @@
 import { eco, type HtmlTemplateProps } from '@ecopages/core';
 import type { JsxRenderable } from '@ecopages/jsx';
 
-const themeScript = `(function(){try{const r=document.documentElement,s=localStorage.getItem('theme'),p=s==='light'||s==='dark'||s==='system'?s:'system',t=p==='system'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):p,v=localStorage.getItem('radiant-ui-docs:theme'),d=v?JSON.parse(v):{},c=d.colors==='basalt'||d.colors==='ember'||d.colors==='glacier'?d.colors:'glacier',g=d.spacing==='compact'||d.spacing==='wide'?d.spacing:'default',a=d.radius==='soft'||d.radius==='sharp'?d.radius:'default';r.setAttribute('data-theme',t);r.classList.toggle('dark',t==='dark');r.dataset.ruiColors=c;r.dataset.ruiSpacing=g;r.dataset.ruiRadius=a}catch{}})();`;
+const themeScript = `(function(){try{const r=document.documentElement,s=localStorage.getItem('theme'),p=s==='light'||s==='dark'||s==='system'?s:'system',t=p==='system'?(window.matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light'):p,v=localStorage.getItem('radiant-ui-docs:theme'),d=v?JSON.parse(v):{},c=d.colors==='basalt'||d.colors==='ember'||d.colors==='aurora'||d.colors==='glacier'?d.colors:'glacier',g=d.spacing==='compact'||d.spacing==='wide'?d.spacing:'default',a=d.radius==='soft'||d.radius==='sharp'?d.radius:'default';r.setAttribute('data-theme',t);r.classList.toggle('dark',t==='dark');r.dataset.ruiColors=c;r.dataset.ruiSpacing=g;r.dataset.ruiRadius=a}catch{}})();`;
 
 const Html = eco.component<HtmlTemplateProps, JsxRenderable>({
 	dependencies: {

--- a/packages/radiant-ui/src/styles/tokens/presets/colors/aurora.css
+++ b/packages/radiant-ui/src/styles/tokens/presets/colors/aurora.css
@@ -61,20 +61,20 @@ html[data-rui-colors='aurora'] {
 
 	--neutral: var(--color-pale-sky-500);
 
-	--surface: var(--color-pale-sky-50);
+	--surface: color-mix(in oklab, var(--color-havelock-blue-50) 70%, var(--color-hit-pink-50));
 	--on-surface: var(--color-black);
-	--surface-container-lowest: var(--color-pale-sky-100);
+	--surface-container-lowest: color-mix(in oklab, var(--color-havelock-blue-50) 60%, var(--color-hit-pink-50));
 	--on-surface-container-lowest: var(--color-black);
-	--surface-container-low: var(--color-pale-sky-200);
+	--surface-container-low: color-mix(in oklab, var(--color-havelock-blue-100) 75%, var(--color-hit-pink-50));
 	--on-surface-container-low: var(--color-black);
-	--surface-container: var(--color-pale-sky-300);
+	--surface-container: color-mix(in oklab, var(--color-havelock-blue-100) 65%, var(--color-hit-pink-100));
 	--on-surface-container: var(--color-black);
-	--surface-container-high: var(--color-pale-sky-400);
+	--surface-container-high: color-mix(in oklab, var(--color-havelock-blue-200) 60%, var(--color-hit-pink-100));
 	--on-surface-container-high: var(--color-black);
-	--surface-container-highest: var(--color-pale-sky-500);
+	--surface-container-highest: color-mix(in oklab, var(--color-havelock-blue-200) 50%, var(--color-hit-pink-200));
 	--on-surface-container-highest: var(--color-black);
 
-	--background: var(--color-white);
+	--background: color-mix(in oklab, var(--color-havelock-blue-50) 75%, var(--color-hit-pink-50));
 	--on-background: var(--color-black);
 
 	--border: var(--color-pale-sky-400);
@@ -128,20 +128,20 @@ html.dark[data-rui-colors='aurora'] {
 	--warning-light: var(--color-hit-pink-300);
 	--warning-dark: var(--color-hit-pink-800);
 
-	--surface: var(--color-pale-sky-975);
+	--surface: color-mix(in oklab, var(--color-pale-sky-975) 65%, var(--color-havelock-blue-950));
 	--on-surface: var(--color-white);
-	--surface-container-lowest: var(--color-pale-sky-950);
+	--surface-container-lowest: color-mix(in oklab, var(--color-pale-sky-950) 75%, var(--color-havelock-blue-950));
 	--on-surface-container-lowest: var(--color-white);
-	--surface-container-low: var(--color-pale-sky-900);
+	--surface-container-low: color-mix(in oklab, var(--color-pale-sky-900) 70%, var(--color-havelock-blue-900));
 	--on-surface-container-low: var(--color-white);
-	--surface-container: var(--color-pale-sky-800);
+	--surface-container: color-mix(in oklab, var(--color-pale-sky-800) 65%, var(--color-havelock-blue-900));
 	--on-surface-container: var(--color-white);
-	--surface-container-high: var(--color-pale-sky-700);
+	--surface-container-high: color-mix(in oklab, var(--color-pale-sky-800) 60%, var(--color-hit-pink-900));
 	--on-surface-container-high: var(--color-white);
-	--surface-container-highest: var(--color-pale-sky-600);
+	--surface-container-highest: color-mix(in oklab, var(--color-pale-sky-700) 55%, var(--color-hit-pink-800));
 	--on-surface-container-highest: var(--color-white);
 
-	--background: var(--color-black);
+	--background: color-mix(in oklab, var(--color-pale-sky-975) 70%, var(--color-havelock-blue-950));
 	--on-background: var(--color-white);
 
 	--border: var(--color-pale-sky-700);


### PR DESCRIPTION
## Summary
- describe colour, spacing, and radius as independently composed tokens
- mark runtime `data-rui-*` selectors as docs-preview-only
- add Aurora to the docs colour preview and remove the duplicate default option

## Verification
- `pnpm exec tsc --noEmit -p apps/radiant-ui/tsconfig.json`
- `pnpm --filter @ecopages/radiant-ui-docs build`