### PR TITLE
feat(sidebar): apply mobileDefaultOpen when entering mobile

### DIFF
--- a/.changeset/sidebar-mobile-default-open-on-cross.md
+++ b/.changeset/sidebar-mobile-default-open-on-cross.md
@@ -1,0 +1,10 @@
+---
+'@ecopages/radiant-ui': minor
+---
+
+Apply `mobileDefaultOpen` when the viewport crosses into mobile, not only on first connect.
+
+**@ecopages/radiant-ui**
+
+- Uncontrolled `rui-sidebar` now closes (or opens) to `mobileDefaultOpen` when resizing below `mobileBreakpoint`, so a desktop-open pane does not become an overlay drawer.
+- Controlled `open` is left unchanged on viewport crossings; listen to `rui-sidebar-mobile-change` if the parent needs to react.

--- a/apps/docs/src/layouts/docs-layout/docs-layout.script.ts
+++ b/apps/docs/src/layouts/docs-layout/docs-layout.script.ts
@@ -5,11 +5,8 @@ import '@ecopages/radiant-ui/sidebar';
 import '@ecopages/radiant-ui/toc';
 
 const docsContentSelector = '.docs-layout__content';
-const docsSidebarId = 'docs-sidebar';
 
 type DocsNavigationEvent = CustomEvent<{ url: URL }>;
-type SidebarMobileChangeEvent = CustomEvent<{ mobile: boolean }>;
-type SidebarControl = HTMLElement & { setOpen(next: boolean): void };
 
 function scrollDocsToTop(): void {
 	document.querySelector<HTMLElement>(docsContentSelector)?.scrollTo({ top: 0, left: 0, behavior: 'instant' });
@@ -22,17 +19,4 @@ document.addEventListener('eco:after-swap', (event) => {
 	}
 
 	scrollDocsToTop();
-});
-
-document.addEventListener('rui-sidebar-mobile-change', (event) => {
-	const sidebar = event.target;
-	if (
-		!(sidebar instanceof HTMLElement) ||
-		sidebar.id !== docsSidebarId ||
-		!(event as SidebarMobileChangeEvent).detail.mobile
-	) {
-		return;
-	}
-
-	(sidebar as SidebarControl).setOpen(false);
 });

--- a/apps/radiant-ui/src/content/components/sidebar.mdx
+++ b/apps/radiant-ui/src/content/components/sidebar.mdx
@@ -108,8 +108,8 @@ Rounded corners use `rounded-container`; the collapsible pane in `docs` layout s
 | `minWidth` / `maxWidth` | `number` | | Width bounds. |
 | `resizable` | `boolean` | `false` | Draggable resize handle. |
 | `defaultOpen` | `boolean` | `true` | Initial open state (desktop). |
-| `mobileDefaultOpen` | `boolean` | `false` | Initial open state (mobile). |
-| `open` | `boolean` | | Controlled open state. |
+| `mobileDefaultOpen` | `boolean` | `false` | Open state on mobile when uncontrolled (mount and when the viewport crosses into mobile). |
+| `open` | `boolean` | | Controlled open state. Viewport crossings do not override this. |
 | `mobileBreakpoint` | `number` | | Width below which the mobile rail applies. |
 | `label` | `string` | `Sidebar` | Accessible name for the `nav` landmark. |
 | `matchActive` | `boolean` | `false` | Highlight the current route in the menu. |

--- a/apps/radiant-ui/src/layouts/docs-layout/docs-layout.script.ts
+++ b/apps/radiant-ui/src/layouts/docs-layout/docs-layout.script.ts
@@ -5,11 +5,8 @@ import '@ecopages/radiant-ui/sidebar';
 import '@ecopages/radiant-ui/toc';
 
 const docsContentSelector = '.docs-layout__content';
-const docsSidebarId = 'docs-sidebar';
 
 type DocsNavigationEvent = CustomEvent<{ url: URL }>;
-type SidebarMobileChangeEvent = CustomEvent<{ mobile: boolean }>;
-type SidebarControl = HTMLElement & { setOpen(next: boolean): void };
 
 function scrollDocsToTop(): void {
 	document.querySelector<HTMLElement>(docsContentSelector)?.scrollTo({ top: 0, left: 0, behavior: 'instant' });
@@ -22,17 +19,4 @@ document.addEventListener('eco:after-swap', (event) => {
 	}
 
 	scrollDocsToTop();
-});
-
-document.addEventListener('rui-sidebar-mobile-change', (event) => {
-	const sidebar = event.target;
-	if (
-		!(sidebar instanceof HTMLElement) ||
-		sidebar.id !== docsSidebarId ||
-		!(event as SidebarMobileChangeEvent).detail.mobile
-	) {
-		return;
-	}
-
-	(sidebar as SidebarControl).setOpen(false);
 });

--- a/packages/radiant-ui/src/components/ui/sidebar/sidebar.script.tsx
+++ b/packages/radiant-ui/src/components/ui/sidebar/sidebar.script.tsx
@@ -18,9 +18,16 @@ export type RuiSidebarProps = {
 	collapsible?: RuiSidebarCollapsible;
 	/** Initial open state when uncontrolled. Default: `true`. */
 	defaultOpen?: boolean;
-	/** Initial open state below `mobileBreakpoint` when uncontrolled. Default: `false`. */
+	/**
+	 * Open state below `mobileBreakpoint` when uncontrolled. Applied on connect
+	 * and when the viewport crosses into mobile. Ignored when `open` is set.
+	 * Default: `false`.
+	 */
 	mobileDefaultOpen?: boolean;
-	/** Controlled open state. */
+	/**
+	 * Controlled open state. Viewport crossings do not override this; listen to
+	 * `rui-sidebar-mobile-change` if the parent needs to react.
+	 */
 	open?: boolean;
 	/** Initial width in pixels when uncontrolled. Default: `256`. */
 	defaultWidth?: number;
@@ -154,6 +161,19 @@ export class RuiSidebar extends RadiantElement<RuiSidebarBindings> {
 	/** @remarks Remains `false` until a projected active link has been scrolled. */
 	private didScrollActiveOnMount = false;
 
+	/**
+	 * @remarks Captured once before defaults are applied. `setOpen` later assigns
+	 * `open`, which must not be mistaken for a controlled binding.
+	 */
+	private openControlled = false;
+
+	/**
+	 * @remarks Viewport policy must not run until connect has snapshotted
+	 * `open` and applied defaults. Deferred JSX props can update
+	 * `mobileBreakpoint` before that microtask.
+	 */
+	private mobileReady = false;
+
 	override connectedCallback(): void {
 		super.connectedCallback();
 
@@ -165,14 +185,16 @@ export class RuiSidebar extends RadiantElement<RuiSidebarBindings> {
 		this.attachNavigationListeners();
 		queueMicrotask(() => {
 			this.ensureWidthInitialized();
+			this.openControlled = this.open !== undefined;
 			this.bindMobileMediaQuery();
-			if (this.open === undefined) {
+			if (!this.openControlled) {
 				this.open = this.isMobile ? this.mobileDefaultOpen : this.defaultOpen;
 			}
 
 			this.syncHostAttributes();
 			this.syncPaneWidthVar();
 			this.syncActiveLinksAfterRender(true);
+			this.mobileReady = true;
 		});
 	}
 
@@ -203,6 +225,7 @@ export class RuiSidebar extends RadiantElement<RuiSidebarBindings> {
 		this.endDrag();
 		this.unbindMobileMediaQuery();
 		this.detachNavigationListeners();
+		this.mobileReady = false;
 		super.disconnectedCallback();
 	}
 
@@ -356,16 +379,23 @@ export class RuiSidebar extends RadiantElement<RuiSidebarBindings> {
 	 * Flip between mobile drawer and inline layout.
 	 *
 	 * @remarks
-	 * Leaving mobile while closed with `collapsible="off"` reopens — desktop hides
-	 * reopen triggers for that mode, so a closed drawer would otherwise stick at
-	 * width 0. Other collapsible modes keep the consumer's open state.
+	 * After connect, entering mobile applies `mobileDefaultOpen` so a
+	 * desktop-open pane does not become an overlay drawer. Leaving mobile while
+	 * closed with `collapsible="off"` reopens — desktop hides reopen triggers for
+	 * that mode, so a closed drawer would otherwise stick at width 0. Controlled
+	 * `open` is left alone; other collapsible modes keep the consumer's open
+	 * state when leaving mobile.
 	 */
 	private setMobile(next: boolean): void {
 		if (next === this.isMobile) return;
 		const leavingMobile = this.isMobile && !next;
+		const enteringMobile = !this.isMobile && next;
 		this.isMobile = next;
-		if (leavingMobile && this.collapsible === 'off' && !this.isOpen()) {
+		const applyPolicy = this.mobileReady && !this.openControlled;
+		if (applyPolicy && leavingMobile && this.collapsible === 'off' && !this.isOpen()) {
 			this.setOpen(true);
+		} else if (applyPolicy && enteringMobile) {
+			this.setOpen(this.mobileDefaultOpen);
 		} else {
 			this.syncPaneWidthVar();
 		}

--- a/packages/radiant-ui/src/components/ui/sidebar/sidebar.test.tsx
+++ b/packages/radiant-ui/src/components/ui/sidebar/sidebar.test.tsx
@@ -625,10 +625,96 @@ describe('RuiSidebar mobile drawer', () => {
 		cleanup();
 	});
 
-	it('reopens automatically when leaving mobile mode while closed (mobileBreakpoint <= 0 forces desktop)', async () => {
-		const { sidebar, cleanup } = mountMobileSidebar({ collapsible: 'off', open: true });
+	it('closes when entering mobile mode', async () => {
+		const { host, cleanup } = mountDesktopSidebar(
+			<RuiSidebar id="primary-sidebar" collapsible="off" mobileBreakpoint={0} label="Primary">
+				<span>Navigation</span>
+			</RuiSidebar>,
+		);
 		await settled();
 
+		const sidebar = host.querySelector('rui-sidebar') as SidebarEl;
+		expect(sidebar.getAttribute('data-mobile')).toBe('false');
+		expect(sidebar.getAttribute('data-state')).toBe('expanded');
+
+		sidebar.mobileBreakpoint = 10_000;
+		await settled();
+
+		expect(sidebar.getAttribute('data-mobile')).toBe('true');
+		expect(sidebar.getAttribute('data-state')).toBe('collapsed');
+
+		cleanup();
+	});
+
+	it('stays open when entering mobile if mobileDefaultOpen is true', async () => {
+		const { host, cleanup } = mountDesktopSidebar(
+			<RuiSidebar
+				id="primary-sidebar"
+				collapsible="off"
+				mobileBreakpoint={0}
+				mobileDefaultOpen={true}
+				label="Primary"
+			>
+				<span>Navigation</span>
+			</RuiSidebar>,
+		);
+		await settled();
+
+		const sidebar = host.querySelector('rui-sidebar') as SidebarEl;
+		expect(sidebar.getAttribute('data-state')).toBe('expanded');
+
+		sidebar.mobileBreakpoint = 10_000;
+		await settled();
+
+		expect(sidebar.getAttribute('data-mobile')).toBe('true');
+		expect(sidebar.getAttribute('data-state')).toBe('expanded');
+
+		cleanup();
+	});
+
+	it('does not override a controlled open when entering mobile', async () => {
+		const { host, cleanup } = mountDesktopSidebar(
+			<RuiSidebar id="primary-sidebar" collapsible="off" mobileBreakpoint={0} open={true} label="Primary">
+				<span>Navigation</span>
+			</RuiSidebar>,
+		);
+		await settled();
+
+		const sidebar = host.querySelector('rui-sidebar') as SidebarEl;
+		expect(sidebar.getAttribute('data-state')).toBe('expanded');
+
+		sidebar.mobileBreakpoint = 10_000;
+		await settled();
+
+		expect(sidebar.getAttribute('data-mobile')).toBe('true');
+		expect(sidebar.getAttribute('data-state')).toBe('expanded');
+
+		cleanup();
+	});
+
+	it('reopens automatically when leaving mobile mode while closed (mobileBreakpoint <= 0 forces desktop)', async () => {
+		const { host, cleanup } = mount(
+			<RuiSidebarProvider
+				sidebar={
+					<RuiSidebar
+						id="primary-sidebar"
+						collapsible="off"
+						mobileBreakpoint={10_000}
+						mobileDefaultOpen={true}
+						label="Primary"
+					>
+						<span>Navigation</span>
+					</RuiSidebar>
+				}
+			>
+				<RuiSidebarInset id="main">
+					<p>Content</p>
+				</RuiSidebarInset>
+			</RuiSidebarProvider>,
+		);
+		await settled();
+
+		const sidebar = host.querySelector('rui-sidebar') as SidebarEl;
 		expect(sidebar.getAttribute('data-mobile')).toBe('true');
 		sidebar.setOpen(false);
 		await settled();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,11961 +1,9219 @@
 lockfileVersion: '9.0'
 
 settings:
-    autoInstallPeers: true
-    excludeLinksFromLockfile: false
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
 
 catalogs:
-    default:
-        typescript:
-            specifier: ~7.0.2
-            version: 7.0.2
+  default:
+    typescript:
+      specifier: ~7.0.2
+      version: 7.0.2
 
 importers:
-    .:
-        dependencies:
-            rehype-pretty-code:
-                specifier: ^0.14.1
-                version: 0.14.5(shiki@3.23.0)
-        devDependencies:
-            '@changesets/changelog-github':
-                specifier: ^0.5.0
-                version: 0.5.2
-            '@changesets/cli':
-                specifier: ^2.27.7
-                version: 2.31.1(@types/node@24.13.3)
-            '@types/ws':
-                specifier: ^8.18.1
-                version: 8.18.1
-            better-commits:
-                specifier: ^1.18.1
-                version: 1.24.0(typescript@7.0.2)
-            oxlint:
-                specifier: ^1.32.0
-                version: 1.76.0
-            playwright:
-                specifier: ^1.52.0
-                version: 1.62.1
-            prettier:
-                specifier: ^3.7.4
-                version: 3.9.6
-            tsx:
-                specifier: ^4.20.6
-                version: 4.23.1
-            typescript:
-                specifier: 'catalog:'
-                version: 7.0.2
 
-    apps/docs:
-        devDependencies:
-            '@ecopages/browser-router':
-                specifier: 0.2.0-beta.43
-                version: 0.2.0-beta.43(@ecopages/core@0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(typescript@7.0.2))
-            '@ecopages/content-processor':
-                specifier: 0.2.0-beta.43
-                version: 0.2.0-beta.43(@ecopages/core@0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(typescript@7.0.2))(supports-color@7.2.0)(typescript@7.0.2)
-            '@ecopages/core':
-                specifier: 0.2.0-beta.43
-                version: 0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(typescript@7.0.2)
-            '@ecopages/dev-toolbar':
-                specifier: 0.2.0-beta.43
-                version: 0.2.0-beta.43
-            '@ecopages/ecopages-jsx':
-                specifier: 0.2.0-beta.43
-                version: 0.2.0-beta.43(@ecopages/core@0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(typescript@7.0.2))(@ecopages/jsx@packages+jsx+dist)(@ecopages/radiant@packages+radiant+dist)(supports-color@7.2.0)(typescript@7.0.2)
-            '@ecopages/file-system':
-                specifier: 0.2.0-beta.43
-                version: 0.2.0-beta.43
-            '@ecopages/jsx':
-                specifier: workspace:*
-                version: link:../../packages/jsx/dist
-            '@ecopages/postcss-processor':
-                specifier: 0.2.0-beta.43
-                version: 0.2.0-beta.43(@ecopages/core@0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(typescript@7.0.2))(@tailwindcss/postcss@4.3.3)(tailwindcss@4.3.3)(typescript@7.0.2)
-            '@ecopages/radiant':
-                specifier: workspace:*
-                version: link:../../packages/radiant/dist
-            '@ecopages/radiant-ui':
-                specifier: workspace:*
-                version: link:../../packages/radiant-ui
-            '@ecopages/scripts-injector':
-                specifier: ^0.1.5
-                version: 0.1.5(typescript@7.0.2)
-            '@mdx-js/esbuild':
-                specifier: ^3.1.1
-                version: 3.1.1(esbuild@0.28.1)(supports-color@7.2.0)
-            '@mdx-js/mdx':
-                specifier: ^3.1.1
-                version: 3.1.1(supports-color@7.2.0)
-            '@tailwindcss/postcss':
-                specifier: ^4.0.0
-                version: 4.3.3
-            '@types/hast':
-                specifier: ^3.0.4
-                version: 3.0.5
-            '@types/node':
-                specifier: ^24.13.2
-                version: 24.13.3
-            ecopages:
-                specifier: 0.2.0-beta.43
-                version: 0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(bun-types@1.3.14)(typescript@7.0.2)
-            remark-gfm:
-                specifier: ^4.0.1
-                version: 4.0.1(supports-color@7.2.0)
-            shiki:
-                specifier: ^3.20.0
-                version: 3.23.0
-            tailwindcss:
-                specifier: ^4.1.18
-                version: 4.3.3
-            tsx:
-                specifier: ^4.20.6
-                version: 4.23.1
-            typescript:
-                specifier: 'catalog:'
-                version: 7.0.2
-            unified:
-                specifier: ^11.0.5
-                version: 11.0.5
-            unist-util-visit:
-                specifier: ^5.1.0
-                version: 5.1.0
-            zod:
-                specifier: ^4.4.3
-                version: 4.4.3
+  .:
+    dependencies:
+      rehype-pretty-code:
+        specifier: ^0.14.1
+        version: 0.14.5(shiki@3.23.0)
+    devDependencies:
+      '@changesets/changelog-github':
+        specifier: ^0.5.0
+        version: 0.5.2
+      '@changesets/cli':
+        specifier: ^2.27.7
+        version: 2.31.1(@types/node@24.13.3)
+      '@types/ws':
+        specifier: ^8.18.1
+        version: 8.18.1
+      better-commits:
+        specifier: ^1.18.1
+        version: 1.24.0(typescript@7.0.2)
+      oxlint:
+        specifier: ^1.32.0
+        version: 1.78.0
+      playwright:
+        specifier: ^1.52.0
+        version: 1.62.1
+      prettier:
+        specifier: ^3.7.4
+        version: 3.9.6
+      tsx:
+        specifier: ^4.20.6
+        version: 4.23.12
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
 
-    apps/radiant-ui:
-        devDependencies:
-            '@ecopages/browser-router':
-                specifier: 0.2.0-beta.43
-                version: 0.2.0-beta.43(@ecopages/core@0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(typescript@7.0.2))
-            '@ecopages/content-processor':
-                specifier: 0.2.0-beta.43
-                version: 0.2.0-beta.43(@ecopages/core@0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(typescript@7.0.2))(supports-color@7.2.0)(typescript@7.0.2)
-            '@ecopages/core':
-                specifier: 0.2.0-beta.43
-                version: 0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(typescript@7.0.2)
-            '@ecopages/ecopages-jsx':
-                specifier: 0.2.0-beta.43
-                version: 0.2.0-beta.43(@ecopages/core@0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(typescript@7.0.2))(@ecopages/jsx@packages+jsx+dist)(@ecopages/radiant@packages+radiant+dist)(supports-color@7.2.0)(typescript@7.0.2)
-            '@ecopages/file-system':
-                specifier: 0.2.0-beta.43
-                version: 0.2.0-beta.43
-            '@ecopages/jsx':
-                specifier: workspace:*
-                version: link:../../packages/jsx/dist
-            '@ecopages/postcss-processor':
-                specifier: 0.2.0-beta.43
-                version: 0.2.0-beta.43(@ecopages/core@0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(typescript@7.0.2))(@tailwindcss/postcss@4.3.3)(tailwindcss@4.3.3)(typescript@7.0.2)
-            '@ecopages/radiant':
-                specifier: workspace:*
-                version: link:../../packages/radiant/dist
-            '@ecopages/radiant-ui':
-                specifier: workspace:*
-                version: link:../../packages/radiant-ui
-            '@types/hast':
-                specifier: ^3.0.4
-                version: 3.0.5
-            '@types/node':
-                specifier: ^24.13.2
-                version: 24.13.3
-            ecopages:
-                specifier: 0.2.0-beta.43
-                version: 0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(bun-types@1.3.14)(typescript@7.0.2)
-            happy-dom:
-                specifier: ^20.0.0
-                version: 20.11.1
-            rehype-pretty-code:
-                specifier: ^0.14.1
-                version: 0.14.5(shiki@3.23.0)
-            remark-gfm:
-                specifier: ^4.0.1
-                version: 4.0.1(supports-color@7.2.0)
-            shiki:
-                specifier: ^3.20.0
-                version: 3.23.0
-            tailwindcss:
-                specifier: ^4.3.0
-                version: 4.3.3
-            tsx:
-                specifier: ^4.20.6
-                version: 4.23.1
-            unist-util-visit:
-                specifier: ^5.1.0
-                version: 5.1.0
-            vitest:
-                specifier: ^4.1.10
-                version: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
-            zod:
-                specifier: ^4.4.3
-                version: 4.4.3
+  apps/docs:
+    devDependencies:
+      '@ecopages/browser-router':
+        specifier: 0.2.0-beta.43
+        version: 0.2.0-beta.43(@ecopages/core@0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(typescript@7.0.2))
+      '@ecopages/content-processor':
+        specifier: 0.2.0-beta.43
+        version: 0.2.0-beta.43(@ecopages/core@0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(typescript@7.0.2))(supports-color@7.2.0)(typescript@7.0.2)
+      '@ecopages/core':
+        specifier: 0.2.0-beta.43
+        version: 0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(typescript@7.0.2)
+      '@ecopages/dev-toolbar':
+        specifier: 0.2.0-beta.43
+        version: 0.2.0-beta.43
+      '@ecopages/ecopages-jsx':
+        specifier: 0.2.0-beta.43
+        version: 0.2.0-beta.43(@ecopages/core@0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(typescript@7.0.2))(@ecopages/jsx@packages+jsx+dist)(@ecopages/radiant@packages+radiant+dist)(supports-color@7.2.0)(typescript@7.0.2)
+      '@ecopages/file-system':
+        specifier: 0.2.0-beta.43
+        version: 0.2.0-beta.43
+      '@ecopages/jsx':
+        specifier: workspace:*
+        version: link:../../packages/jsx/dist
+      '@ecopages/postcss-processor':
+        specifier: 0.2.0-beta.43
+        version: 0.2.0-beta.43(@ecopages/core@0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(typescript@7.0.2))(@tailwindcss/postcss@4.3.3)(tailwindcss@4.3.3)(typescript@7.0.2)
+      '@ecopages/radiant':
+        specifier: workspace:*
+        version: link:../../packages/radiant/dist
+      '@ecopages/radiant-ui':
+        specifier: workspace:*
+        version: link:../../packages/radiant-ui
+      '@ecopages/scripts-injector':
+        specifier: ^0.1.5
+        version: 0.1.5(typescript@7.0.2)
+      '@mdx-js/esbuild':
+        specifier: ^3.1.1
+        version: 3.1.1(esbuild@0.28.2)(supports-color@7.2.0)
+      '@mdx-js/mdx':
+        specifier: ^3.1.1
+        version: 3.1.1(supports-color@7.2.0)
+      '@tailwindcss/postcss':
+        specifier: ^4.0.0
+        version: 4.3.3
+      '@types/hast':
+        specifier: ^3.0.4
+        version: 3.0.5
+      '@types/node':
+        specifier: ^24.13.2
+        version: 24.13.3
+      ecopages:
+        specifier: 0.2.0-beta.43
+        version: 0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(bun-types@1.3.14)(typescript@7.0.2)
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1(supports-color@7.2.0)
+      shiki:
+        specifier: ^3.20.0
+        version: 3.23.0
+      tailwindcss:
+        specifier: ^4.1.18
+        version: 4.3.3
+      tsx:
+        specifier: ^4.20.6
+        version: 4.23.12
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
+      unified:
+        specifier: ^11.0.5
+        version: 11.0.5
+      unist-util-visit:
+        specifier: ^5.1.0
+        version: 5.1.0
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
 
-    packages/jsx:
-        devDependencies:
-            '@ecopages/signals':
-                specifier: workspace:*
-                version: link:../signals/dist
-            '@types/node':
-                specifier: ^24.13.2
-                version: 24.13.3
-            '@vitest/browser':
-                specifier: ^4.1.10
-                version: 4.1.10(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)
-            '@vitest/browser-playwright':
-                specifier: ^4.1.10
-                version: 4.1.10(playwright@1.62.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)
-            esbuild:
-                specifier: ^0.28.1
-                version: 0.28.1
-            happy-dom:
-                specifier: ^20.0.0
-                version: 20.11.1
-            mitata:
-                specifier: ^1.0.34
-                version: 1.0.34
-            playwright:
-                specifier: ^1.52.0
-                version: 1.62.1
-            tsx:
-                specifier: ^4.20.6
-                version: 4.23.1
-            typescript:
-                specifier: 'catalog:'
-                version: 7.0.2
-            vite:
-                specifier: ^8.1.1
-                version: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
-            vitest:
-                specifier: ^4.1.10
-                version: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
-        publishDirectory: dist
+  apps/radiant-ui:
+    devDependencies:
+      '@ecopages/browser-router':
+        specifier: 0.2.0-beta.43
+        version: 0.2.0-beta.43(@ecopages/core@0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(typescript@7.0.2))
+      '@ecopages/content-processor':
+        specifier: 0.2.0-beta.43
+        version: 0.2.0-beta.43(@ecopages/core@0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(typescript@7.0.2))(supports-color@7.2.0)(typescript@7.0.2)
+      '@ecopages/core':
+        specifier: 0.2.0-beta.43
+        version: 0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(typescript@7.0.2)
+      '@ecopages/ecopages-jsx':
+        specifier: 0.2.0-beta.43
+        version: 0.2.0-beta.43(@ecopages/core@0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(typescript@7.0.2))(@ecopages/jsx@packages+jsx+dist)(@ecopages/radiant@packages+radiant+dist)(supports-color@7.2.0)(typescript@7.0.2)
+      '@ecopages/file-system':
+        specifier: 0.2.0-beta.43
+        version: 0.2.0-beta.43
+      '@ecopages/jsx':
+        specifier: workspace:*
+        version: link:../../packages/jsx/dist
+      '@ecopages/postcss-processor':
+        specifier: 0.2.0-beta.43
+        version: 0.2.0-beta.43(@ecopages/core@0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(typescript@7.0.2))(@tailwindcss/postcss@4.3.3)(tailwindcss@4.3.3)(typescript@7.0.2)
+      '@ecopages/radiant':
+        specifier: workspace:*
+        version: link:../../packages/radiant/dist
+      '@ecopages/radiant-ui':
+        specifier: workspace:*
+        version: link:../../packages/radiant-ui
+      '@types/hast':
+        specifier: ^3.0.4
+        version: 3.0.5
+      '@types/node':
+        specifier: ^24.13.2
+        version: 24.13.3
+      ecopages:
+        specifier: 0.2.0-beta.43
+        version: 0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(bun-types@1.3.14)(typescript@7.0.2)
+      happy-dom:
+        specifier: ^20.0.0
+        version: 20.11.2
+      rehype-pretty-code:
+        specifier: ^0.14.1
+        version: 0.14.5(shiki@3.23.0)
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1(supports-color@7.2.0)
+      shiki:
+        specifier: ^3.20.0
+        version: 3.23.0
+      tailwindcss:
+        specifier: ^4.3.0
+        version: 4.3.3
+      tsx:
+        specifier: ^4.20.6
+        version: 4.23.12
+      unist-util-visit:
+        specifier: ^5.1.0
+        version: 5.1.0
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
 
-    packages/radiant:
-        dependencies:
-            '@ecopages/signals':
-                specifier: '>=0.3.0-beta.8'
-                version: link:../signals/dist
-        devDependencies:
-            '@babel/core':
-                specifier: ^7.28.0
-                version: 7.29.7(supports-color@7.2.0)
-            '@babel/plugin-proposal-decorators':
-                specifier: ^7.28.0
-                version: 7.29.7(@babel/core@7.29.7(supports-color@7.2.0))(supports-color@7.2.0)
-            '@babel/plugin-syntax-typescript':
-                specifier: ^7.28.0
-                version: 7.29.7(@babel/core@7.29.7(supports-color@7.2.0))
-            '@ecopages/jsx':
-                specifier: workspace:*
-                version: link:../jsx/dist
-            '@oxc-project/runtime':
-                specifier: ^0.141.0
-                version: 0.141.0
-            '@rolldown/plugin-babel':
-                specifier: ^0.2.1
-                version: 0.2.3(@babel/core@7.29.7(supports-color@7.2.0))(@babel/runtime@7.29.7)(rolldown@1.2.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
-            '@testing-library/dom':
-                specifier: ^10.4.0
-                version: 10.4.1
-            '@testing-library/user-event':
-                specifier: ^14.5.2
-                version: 14.6.1(@testing-library/dom@10.4.1)
-            '@types/node':
-                specifier: ^24.13.2
-                version: 24.13.3
-            '@vitest/browser':
-                specifier: ^4.1.10
-                version: 4.1.10(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)
-            '@vitest/browser-playwright':
-                specifier: ^4.1.10
-                version: 4.1.10(playwright@1.62.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)
-            '@vitest/coverage-istanbul':
-                specifier: ^4.1.10
-                version: 4.1.10(supports-color@7.2.0)(vitest@4.1.10)
-            esbuild:
-                specifier: ^0.28.1
-                version: 0.28.1
-            happy-dom:
-                specifier: ^20.0.0
-                version: 20.11.1
-            playwright:
-                specifier: ^1.52.0
-                version: 1.62.1
-            tsc-alias:
-                specifier: 1.8.10
-                version: 1.8.10
-            tsx:
-                specifier: ^4.20.6
-                version: 4.23.1
-            typescript:
-                specifier: 'catalog:'
-                version: 7.0.2
-            vite:
-                specifier: ^8.1.1
-                version: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
-            vitest:
-                specifier: ^4.1.10
-                version: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
-        publishDirectory: dist
+  packages/jsx:
+    devDependencies:
+      '@ecopages/signals':
+        specifier: workspace:*
+        version: link:../signals/dist
+      '@types/node':
+        specifier: ^24.13.2
+        version: 24.13.3
+      '@vitest/browser':
+        specifier: ^4.1.10
+        version: 4.1.10(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))(vitest@4.1.10)
+      '@vitest/browser-playwright':
+        specifier: ^4.1.10
+        version: 4.1.10(playwright@1.62.1)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))(vitest@4.1.10)
+      esbuild:
+        specifier: ^0.28.1
+        version: 0.28.2
+      happy-dom:
+        specifier: ^20.0.0
+        version: 20.11.2
+      mitata:
+        specifier: ^1.0.34
+        version: 1.0.34
+      playwright:
+        specifier: ^1.52.0
+        version: 1.62.1
+      tsx:
+        specifier: ^4.20.6
+        version: 4.23.12
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
+      vite:
+        specifier: ^8.1.1
+        version: 8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+    publishDirectory: dist
 
-    packages/radiant-ui:
-        devDependencies:
-            '@babel/core':
-                specifier: ^7.28.0
-                version: 7.29.7(supports-color@7.2.0)
-            '@babel/plugin-proposal-decorators':
-                specifier: ^7.28.0
-                version: 7.29.7(@babel/core@7.29.7(supports-color@7.2.0))(supports-color@7.2.0)
-            '@babel/plugin-syntax-typescript':
-                specifier: ^7.28.0
-                version: 7.29.7(@babel/core@7.29.7(supports-color@7.2.0))
-            '@chromatic-com/storybook':
-                specifier: ^5.2.1
-                version: 5.2.1(storybook@10.5.5(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))
-            '@ecopages/jsx':
-                specifier: workspace:*
-                version: link:../jsx/dist
-            '@ecopages/radiant':
-                specifier: workspace:*
-                version: link:../radiant/dist
-            '@ecopages/signals':
-                specifier: workspace:*
-                version: link:../signals/dist
-            '@ecopages/storybook-radiant-vite':
-                specifier: workspace:*
-                version: link:../storybook-radiant-vite
-            '@ecopages/vite-plugin-radiant':
-                specifier: workspace:*
-                version: link:../vite-plugin-radiant
-            '@rolldown/plugin-babel':
-                specifier: ^0.2.1
-                version: 0.2.3(@babel/core@7.29.7(supports-color@7.2.0))(@babel/runtime@7.29.7)(rolldown@1.2.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
-            '@storybook/addon-a11y':
-                specifier: ^10.5.2
-                version: 10.5.5(storybook@10.5.5(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))
-            '@storybook/addon-docs':
-                specifier: ^10.5.2
-                version: 10.5.5(@types/react@19.2.18)(esbuild@0.28.1)(rollup@4.62.4)(storybook@10.5.5(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
-            '@storybook/addon-vitest':
-                specifier: ^10.5.2
-                version: 10.5.5(@vitest/browser-playwright@4.1.10)(@vitest/browser@4.1.10)(@vitest/runner@4.1.10)(react@19.2.8)(storybook@10.5.5(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))(vitest@4.1.10)
-            '@tailwindcss/postcss':
-                specifier: ^4.3.3
-                version: 4.3.3
-            '@tailwindcss/vite':
-                specifier: ^4.1.11
-                version: 4.3.3(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
-            '@types/node':
-                specifier: ^24.13.2
-                version: 24.13.3
-            '@vitest/browser':
-                specifier: ^4.1.10
-                version: 4.1.10(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)
-            '@vitest/browser-playwright':
-                specifier: ^4.1.10
-                version: 4.1.10(playwright@1.62.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)
-            '@vitest/coverage-v8':
-                specifier: ^4.1.10
-                version: 4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)
-            esbuild:
-                specifier: ^0.28.1
-                version: 0.28.1
-            oxlint:
-                specifier: ^1.71.0
-                version: 1.76.0
-            playwright:
-                specifier: ^1.61.1
-                version: 1.62.1
-            postcss:
-                specifier: ^8.5.24
-                version: 8.5.25
-            react:
-                specifier: ^19.2.0
-                version: 19.2.8
-            react-dom:
-                specifier: ^19.2.0
-                version: 19.2.8(react@19.2.8)
-            storybook:
-                specifier: ^10.5.2
-                version: 10.5.5(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8)
-            ts-dedent:
-                specifier: ^2.2.0
-                version: 2.3.0
-            tailwindcss:
-                specifier: ^4.1.11
-                version: 4.3.3
-            tsx:
-                specifier: ^4.20.6
-                version: 4.23.1
-            typescript:
-                specifier: 'catalog:'
-                version: 7.0.2
-            vite:
-                specifier: ^8.1.1
-                version: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
-            vitest:
-                specifier: ^4.1.10
-                version: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+  packages/radiant:
+    dependencies:
+      '@ecopages/signals':
+        specifier: '>=0.3.0-beta.8'
+        version: 0.3.0-beta.8
+    devDependencies:
+      '@babel/core':
+        specifier: ^7.28.0
+        version: 7.29.7(supports-color@7.2.0)
+      '@babel/plugin-proposal-decorators':
+        specifier: ^7.28.0
+        version: 7.29.7(@babel/core@7.29.7(supports-color@7.2.0))(supports-color@7.2.0)
+      '@babel/plugin-syntax-typescript':
+        specifier: ^7.28.0
+        version: 7.29.7(@babel/core@7.29.7(supports-color@7.2.0))
+      '@ecopages/jsx':
+        specifier: workspace:*
+        version: link:../jsx/dist
+      '@oxc-project/runtime':
+        specifier: ^0.141.0
+        version: 0.141.0
+      '@rolldown/plugin-babel':
+        specifier: ^0.2.1
+        version: 0.2.3(@babel/core@7.29.7(supports-color@7.2.0))(@babel/runtime@7.29.7)(rolldown@1.2.4)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+      '@testing-library/dom':
+        specifier: ^10.4.0
+        version: 10.4.1
+      '@testing-library/user-event':
+        specifier: ^14.5.2
+        version: 14.6.4(@testing-library/dom@10.4.1)
+      '@types/node':
+        specifier: ^24.13.2
+        version: 24.13.3
+      '@vitest/browser':
+        specifier: ^4.1.10
+        version: 4.1.10(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))(vitest@4.1.10)
+      '@vitest/browser-playwright':
+        specifier: ^4.1.10
+        version: 4.1.10(playwright@1.62.1)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))(vitest@4.1.10)
+      '@vitest/coverage-istanbul':
+        specifier: ^4.1.10
+        version: 4.1.10(supports-color@7.2.0)(vitest@4.1.10)
+      esbuild:
+        specifier: ^0.28.1
+        version: 0.28.2
+      happy-dom:
+        specifier: ^20.0.0
+        version: 20.11.2
+      playwright:
+        specifier: ^1.52.0
+        version: 1.62.1
+      tsc-alias:
+        specifier: 1.8.10
+        version: 1.8.10
+      tsx:
+        specifier: ^4.20.6
+        version: 4.23.12
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
+      vite:
+        specifier: ^8.1.1
+        version: 8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+    publishDirectory: dist
 
-    packages/signals:
-        devDependencies:
-            '@types/node':
-                specifier: ^24.13.3
-                version: 24.13.3
-            '@vitest/coverage-v8':
-                specifier: ^4.1.10
-                version: 4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)
-            esbuild:
-                specifier: ^0.28.1
-                version: 0.28.1
-            tsx:
-                specifier: ^4.20.6
-                version: 4.23.1
-            typescript:
-                specifier: 'catalog:'
-                version: 7.0.2
-            vitest:
-                specifier: ^4.1.10
-                version: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
-        publishDirectory: dist
+  packages/radiant-ui:
+    devDependencies:
+      '@babel/core':
+        specifier: ^7.28.0
+        version: 7.29.7(supports-color@7.2.0)
+      '@babel/plugin-proposal-decorators':
+        specifier: ^7.28.0
+        version: 7.29.7(@babel/core@7.29.7(supports-color@7.2.0))(supports-color@7.2.0)
+      '@babel/plugin-syntax-typescript':
+        specifier: ^7.28.0
+        version: 7.29.7(@babel/core@7.29.7(supports-color@7.2.0))
+      '@chromatic-com/storybook':
+        specifier: ^5.2.1
+        version: 5.3.0(storybook@10.5.7(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))
+      '@ecopages/jsx':
+        specifier: workspace:*
+        version: link:../jsx/dist
+      '@ecopages/radiant':
+        specifier: workspace:*
+        version: link:../radiant/dist
+      '@ecopages/signals':
+        specifier: workspace:*
+        version: link:../signals/dist
+      '@ecopages/storybook-radiant-vite':
+        specifier: workspace:*
+        version: link:../storybook-radiant-vite
+      '@ecopages/vite-plugin-radiant':
+        specifier: workspace:*
+        version: link:../vite-plugin-radiant
+      '@rolldown/plugin-babel':
+        specifier: ^0.2.1
+        version: 0.2.3(@babel/core@7.29.7(supports-color@7.2.0))(@babel/runtime@7.29.7)(rolldown@1.2.4)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+      '@storybook/addon-a11y':
+        specifier: ^10.5.2
+        version: 10.5.7(storybook@10.5.7(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))
+      '@storybook/addon-docs':
+        specifier: ^10.5.2
+        version: 10.5.7(@types/react@19.2.18)(esbuild@0.28.2)(rollup@4.62.4)(storybook@10.5.7(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+      '@storybook/addon-vitest':
+        specifier: ^10.5.2
+        version: 10.5.7(@vitest/browser-playwright@4.1.10)(@vitest/browser@4.1.10)(@vitest/runner@4.1.10)(react@19.2.8)(storybook@10.5.7(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))(vitest@4.1.10)
+      '@tailwindcss/postcss':
+        specifier: ^4.3.3
+        version: 4.3.3
+      '@tailwindcss/vite':
+        specifier: ^4.1.11
+        version: 4.3.3(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+      '@types/node':
+        specifier: ^24.13.2
+        version: 24.13.3
+      '@vitest/browser':
+        specifier: ^4.1.10
+        version: 4.1.10(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))(vitest@4.1.10)
+      '@vitest/browser-playwright':
+        specifier: ^4.1.10
+        version: 4.1.10(playwright@1.62.1)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))(vitest@4.1.10)
+      '@vitest/coverage-v8':
+        specifier: ^4.1.10
+        version: 4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)
+      esbuild:
+        specifier: ^0.28.1
+        version: 0.28.2
+      oxlint:
+        specifier: ^1.71.0
+        version: 1.78.0
+      playwright:
+        specifier: ^1.61.1
+        version: 1.62.1
+      postcss:
+        specifier: ^8.5.24
+        version: 8.5.26
+      react:
+        specifier: ^19.2.0
+        version: 19.2.8
+      react-dom:
+        specifier: ^19.2.0
+        version: 19.2.8(react@19.2.8)
+      storybook:
+        specifier: ^10.5.2
+        version: 10.5.7(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8)
+      tailwindcss:
+        specifier: ^4.1.11
+        version: 4.3.3
+      ts-dedent:
+        specifier: ^2.2.0
+        version: 2.3.0
+      tsx:
+        specifier: ^4.20.6
+        version: 4.23.12
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
+      vite:
+        specifier: ^8.1.1
+        version: 8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
 
-    packages/storybook-radiant-vite:
-        dependencies:
-            '@ecopages/radiant':
-                specifier: '>=0.3.0-beta.8'
-                version: link:../radiant/dist
-            '@ecopages/signals':
-                specifier: '>=0.3.0-beta.8'
-                version: link:../signals/dist
-            '@ecopages/vite-plugin-radiant':
-                specifier: workspace:*
-                version: link:../vite-plugin-radiant
-            '@storybook/builder-vite':
-                specifier: ^10.5.2
-                version: 10.5.5(esbuild@0.28.1)(rollup@4.62.4)(storybook@10.5.5(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
-            '@storybook/global':
-                specifier: ^5.0.0
-                version: 5.0.0
-            esbuild:
-                specifier: ^0.28.1
-                version: 0.28.1
-            storybook:
-                specifier: ^10.5.2
-                version: 10.5.5(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8)
-            ts-dedent:
-                specifier: ^2.2.0
-                version: 2.3.0
-        devDependencies:
-            '@ecopages/jsx':
-                specifier: workspace:*
-                version: link:../jsx/dist
-            '@types/node':
-                specifier: ^24.13.2
-                version: 24.13.3
-            tsup:
-                specifier: ^8.5.0
-                version: 8.5.1(jiti@2.7.0)(postcss@8.5.25)(supports-color@7.2.0)(tsx@4.23.1)(typescript@7.0.2)(yaml@2.9.0)
-            typescript:
-                specifier: 'catalog:'
-                version: 7.0.2
-            vite:
-                specifier: ^8.1.1
-                version: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
-            vitest:
-                specifier: ^4.1.10
-                version: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+  packages/signals:
+    devDependencies:
+      '@types/node':
+        specifier: ^24.13.3
+        version: 24.13.3
+      '@vitest/coverage-v8':
+        specifier: ^4.1.10
+        version: 4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)
+      esbuild:
+        specifier: ^0.28.1
+        version: 0.28.2
+      tsx:
+        specifier: ^4.20.6
+        version: 4.23.12
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+    publishDirectory: dist
 
-    packages/vite-plugin-radiant:
-        dependencies:
-            '@babel/parser':
-                specifier: ^7.28.0
-                version: 7.29.8
-            '@babel/traverse':
-                specifier: ^7.28.0
-                version: 7.29.8(supports-color@7.2.0)
-            parse5:
-                specifier: ^7.3.0
-                version: 7.3.0
-            picomatch:
-                specifier: ^4.0.2
-                version: 4.0.5
-        devDependencies:
-            '@babel/core':
-                specifier: ^7.28.0
-                version: 7.29.7(supports-color@7.2.0)
-            '@babel/plugin-proposal-decorators':
-                specifier: ^7.28.0
-                version: 7.29.7(@babel/core@7.29.7(supports-color@7.2.0))(supports-color@7.2.0)
-            '@babel/plugin-syntax-typescript':
-                specifier: ^7.28.0
-                version: 7.29.7(@babel/core@7.29.7(supports-color@7.2.0))
-            '@babel/plugin-transform-class-properties':
-                specifier: ^7.28.0
-                version: 7.29.7(@babel/core@7.29.7(supports-color@7.2.0))(supports-color@7.2.0)
-            '@babel/types':
-                specifier: ^8.0.4
-                version: 8.0.4
-            '@ecopages/jsx':
-                specifier: workspace:*
-                version: link:../jsx/dist
-            '@ecopages/radiant':
-                specifier: workspace:*
-                version: link:../radiant/dist
-            '@ecopages/signals':
-                specifier: workspace:*
-                version: link:../signals/dist
-            '@rolldown/plugin-babel':
-                specifier: ^0.2.1
-                version: 0.2.3(@babel/core@7.29.7(supports-color@7.2.0))(@babel/runtime@7.29.7)(rolldown@1.2.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
-            '@types/babel__traverse':
-                specifier: ^7.28.0
-                version: 7.28.0
-            '@types/node':
-                specifier: ^24.13.2
-                version: 24.13.3
-            '@types/picomatch':
-                specifier: ^4.0.0
-                version: 4.0.3
-            nitro:
-                specifier: ^3.0.260311-beta
-                version: 3.0.260311-beta(chokidar@5.0.0)(dotenv@8.6.0)(giget@2.0.0)(jiti@2.7.0)(rollup@4.62.4)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
-            rollup:
-                specifier: ^4.53.2
-                version: 4.62.4
-            tsup:
-                specifier: ^8.5.0
-                version: 8.5.1(jiti@2.7.0)(postcss@8.5.25)(supports-color@7.2.0)(tsx@4.23.1)(typescript@7.0.2)(yaml@2.9.0)
-            typescript:
-                specifier: 'catalog:'
-                version: 7.0.2
-            vite:
-                specifier: ^8.1.1
-                version: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
-            vitest:
-                specifier: ^4.1.10
-                version: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+  packages/storybook-radiant-vite:
+    dependencies:
+      '@ecopages/radiant':
+        specifier: '>=0.3.0-beta.8'
+        version: 0.3.0-beta.8(@ecopages/jsx@packages+jsx+dist)
+      '@ecopages/signals':
+        specifier: '>=0.3.0-beta.8'
+        version: 0.3.0-beta.8
+      '@ecopages/vite-plugin-radiant':
+        specifier: workspace:*
+        version: link:../vite-plugin-radiant
+      '@storybook/builder-vite':
+        specifier: ^10.5.2
+        version: 10.5.7(esbuild@0.28.2)(rollup@4.62.4)(storybook@10.5.7(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+      '@storybook/global':
+        specifier: ^5.0.0
+        version: 5.0.0
+      esbuild:
+        specifier: ^0.28.1
+        version: 0.28.2
+      storybook:
+        specifier: ^10.5.2
+        version: 10.5.7(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8)
+      ts-dedent:
+        specifier: ^2.2.0
+        version: 2.3.0
+    devDependencies:
+      '@ecopages/jsx':
+        specifier: workspace:*
+        version: link:../jsx/dist
+      '@types/node':
+        specifier: ^24.13.2
+        version: 24.13.3
+      tsup:
+        specifier: ^8.5.0
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(supports-color@7.2.0)(tsx@4.23.12)(typescript@7.0.2)(yaml@2.9.0)
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
+      vite:
+        specifier: ^8.1.1
+        version: 8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
 
-    playground/vite:
-        dependencies:
-            '@ecopages/jsx':
-                specifier: workspace:*
-                version: link:../../packages/jsx/dist
-            '@ecopages/radiant':
-                specifier: workspace:*
-                version: link:../../packages/radiant/dist
-            '@ecopages/radiant-ui':
-                specifier: workspace:*
-                version: link:../../packages/radiant-ui
-            '@ecopages/signals':
-                specifier: workspace:*
-                version: link:../../packages/signals/dist
-        devDependencies:
-            '@ecopages/vite-plugin-radiant':
-                specifier: workspace:*
-                version: link:../../packages/vite-plugin-radiant
-            '@tailwindcss/vite':
-                specifier: ^4.1.18
-                version: 4.3.3(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
-            '@vitest/browser':
-                specifier: ^4.1.10
-                version: 4.1.10(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)
-            '@vitest/browser-playwright':
-                specifier: ^4.1.10
-                version: 4.1.10(playwright@1.62.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)
-            playwright:
-                specifier: ^1.52.0
-                version: 1.62.1
-            tailwindcss:
-                specifier: ^4.1.18
-                version: 4.3.3
-            typescript:
-                specifier: 'catalog:'
-                version: 7.0.2
-            vite:
-                specifier: ^8.1.1
-                version: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
-            vitest:
-                specifier: ^4.1.10
-                version: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+  packages/vite-plugin-radiant:
+    dependencies:
+      '@babel/parser':
+        specifier: ^7.28.0
+        version: 7.29.8
+      '@babel/traverse':
+        specifier: ^7.28.0
+        version: 7.29.8(supports-color@7.2.0)
+      parse5:
+        specifier: ^7.3.0
+        version: 7.3.0
+      picomatch:
+        specifier: ^4.0.2
+        version: 4.0.5
+    devDependencies:
+      '@babel/core':
+        specifier: ^7.28.0
+        version: 7.29.7(supports-color@7.2.0)
+      '@babel/plugin-proposal-decorators':
+        specifier: ^7.28.0
+        version: 7.29.7(@babel/core@7.29.7(supports-color@7.2.0))(supports-color@7.2.0)
+      '@babel/plugin-syntax-typescript':
+        specifier: ^7.28.0
+        version: 7.29.7(@babel/core@7.29.7(supports-color@7.2.0))
+      '@babel/plugin-transform-class-properties':
+        specifier: ^7.28.0
+        version: 7.29.7(@babel/core@7.29.7(supports-color@7.2.0))(supports-color@7.2.0)
+      '@babel/types':
+        specifier: ^8.0.4
+        version: 8.0.4
+      '@ecopages/jsx':
+        specifier: workspace:*
+        version: link:../jsx/dist
+      '@ecopages/radiant':
+        specifier: workspace:*
+        version: link:../radiant/dist
+      '@ecopages/signals':
+        specifier: workspace:*
+        version: link:../signals/dist
+      '@rolldown/plugin-babel':
+        specifier: ^0.2.1
+        version: 0.2.3(@babel/core@7.29.7(supports-color@7.2.0))(@babel/runtime@7.29.7)(rolldown@1.2.4)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+      '@types/babel__traverse':
+        specifier: ^7.28.0
+        version: 7.28.0
+      '@types/node':
+        specifier: ^24.13.2
+        version: 24.13.3
+      '@types/picomatch':
+        specifier: ^4.0.0
+        version: 4.0.3
+      nitro:
+        specifier: ^3.0.260311-beta
+        version: 3.0.260311-beta(chokidar@5.0.0)(dotenv@8.6.0)(giget@2.0.0)(jiti@2.7.0)(rollup@4.62.4)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+      rollup:
+        specifier: ^4.53.2
+        version: 4.62.4
+      tsup:
+        specifier: ^8.5.0
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(supports-color@7.2.0)(tsx@4.23.12)(typescript@7.0.2)(yaml@2.9.0)
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
+      vite:
+        specifier: ^8.1.1
+        version: 8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
 
-    playground/vite-nitro:
-        dependencies:
-            '@ecopages/jsx':
-                specifier: workspace:*
-                version: link:../../packages/jsx/dist
-            '@ecopages/radiant':
-                specifier: workspace:*
-                version: link:../../packages/radiant/dist
-            '@ecopages/signals':
-                specifier: workspace:*
-                version: link:../../packages/signals/dist
-        devDependencies:
-            '@ecopages/vite-plugin-radiant':
-                specifier: workspace:*
-                version: link:../../packages/vite-plugin-radiant
-            '@tailwindcss/vite':
-                specifier: ^4.1.18
-                version: 4.3.3(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
-            nitro:
-                specifier: ^3.0.260311-beta
-                version: 3.0.260311-beta(chokidar@5.0.0)(dotenv@8.6.0)(giget@2.0.0)(jiti@2.7.0)(rollup@4.62.4)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
-            playwright:
-                specifier: ^1.52.0
-                version: 1.62.1
-            tailwindcss:
-                specifier: ^4.1.18
-                version: 4.3.3
-            typescript:
-                specifier: 'catalog:'
-                version: 7.0.2
-            vite:
-                specifier: ^8.1.1
-                version: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
+  playground/vite:
+    dependencies:
+      '@ecopages/jsx':
+        specifier: workspace:*
+        version: link:../../packages/jsx/dist
+      '@ecopages/radiant':
+        specifier: workspace:*
+        version: link:../../packages/radiant/dist
+      '@ecopages/radiant-ui':
+        specifier: workspace:*
+        version: link:../../packages/radiant-ui
+      '@ecopages/signals':
+        specifier: workspace:*
+        version: link:../../packages/signals/dist
+    devDependencies:
+      '@ecopages/vite-plugin-radiant':
+        specifier: workspace:*
+        version: link:../../packages/vite-plugin-radiant
+      '@tailwindcss/vite':
+        specifier: ^4.1.18
+        version: 4.3.3(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+      '@vitest/browser':
+        specifier: ^4.1.10
+        version: 4.1.10(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))(vitest@4.1.10)
+      '@vitest/browser-playwright':
+        specifier: ^4.1.10
+        version: 4.1.10(playwright@1.62.1)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))(vitest@4.1.10)
+      playwright:
+        specifier: ^1.52.0
+        version: 1.62.1
+      tailwindcss:
+        specifier: ^4.1.18
+        version: 4.3.3
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
+      vite:
+        specifier: ^8.1.1
+        version: 8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+
+  playground/vite-nitro:
+    dependencies:
+      '@ecopages/jsx':
+        specifier: workspace:*
+        version: link:../../packages/jsx/dist
+      '@ecopages/radiant':
+        specifier: workspace:*
+        version: link:../../packages/radiant/dist
+      '@ecopages/signals':
+        specifier: workspace:*
+        version: link:../../packages/signals/dist
+    devDependencies:
+      '@ecopages/vite-plugin-radiant':
+        specifier: workspace:*
+        version: link:../../packages/vite-plugin-radiant
+      '@tailwindcss/vite':
+        specifier: ^4.1.18
+        version: 4.3.3(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+      nitro:
+        specifier: ^3.0.260311-beta
+        version: 3.0.260311-beta(chokidar@5.0.0)(dotenv@8.6.0)(giget@2.0.0)(jiti@2.7.0)(rollup@4.62.4)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+      playwright:
+        specifier: ^1.52.0
+        version: 1.62.1
+      tailwindcss:
+        specifier: ^4.1.18
+        version: 4.3.3
+      typescript:
+        specifier: 'catalog:'
+        version: 7.0.2
+      vite:
+        specifier: ^8.1.1
+        version: 8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
 
 packages:
-    '@adobe/css-tools@4.5.0':
-        resolution:
-            {
-                integrity: sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==,
-            }
-
-    '@alloc/quick-lru@5.2.0':
-        resolution:
-            {
-                integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==,
-            }
-        engines: { node: '>=10' }
-
-    '@babel/code-frame@7.29.7':
-        resolution:
-            {
-                integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==,
-            }
-        engines: { node: '>=6.9.0' }
-
-    '@babel/compat-data@7.29.7':
-        resolution:
-            {
-                integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==,
-            }
-        engines: { node: '>=6.9.0' }
-
-    '@babel/core@7.29.7':
-        resolution:
-            {
-                integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==,
-            }
-        engines: { node: '>=6.9.0' }
-
-    '@babel/generator@7.29.8':
-        resolution:
-            {
-                integrity: sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==,
-            }
-        engines: { node: '>=6.9.0' }
-
-    '@babel/helper-annotate-as-pure@7.29.7':
-        resolution:
-            {
-                integrity: sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw==,
-            }
-        engines: { node: '>=6.9.0' }
-
-    '@babel/helper-compilation-targets@7.29.7':
-        resolution:
-            {
-                integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==,
-            }
-        engines: { node: '>=6.9.0' }
-
-    '@babel/helper-create-class-features-plugin@7.29.7':
-        resolution:
-            {
-                integrity: sha512-IY3ZD9Tmooqr3TUhc3DUWxiuo8xx1DWLhd5M7hQ+ZWJamqM2BbalrBJb2MisSLoYorOj75U03qULCxQTY9r3hg==,
-            }
-        engines: { node: '>=6.9.0' }
-        peerDependencies:
-            '@babel/core': ^7.0.0
-
-    '@babel/helper-globals@7.29.7':
-        resolution:
-            {
-                integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==,
-            }
-        engines: { node: '>=6.9.0' }
-
-    '@babel/helper-member-expression-to-functions@7.29.7':
-        resolution:
-            {
-                integrity: sha512-j+7JYmk1JYDtACIGj0QJqqWZjoUpMoEikQGADMaHgCMCSDqd2+P32rfcibUNrGOMWrlzK1WJBdxrB3JJQZwWtg==,
-            }
-        engines: { node: '>=6.9.0' }
-
-    '@babel/helper-module-imports@7.29.7':
-        resolution:
-            {
-                integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==,
-            }
-        engines: { node: '>=6.9.0' }
-
-    '@babel/helper-module-transforms@7.29.7':
-        resolution:
-            {
-                integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==,
-            }
-        engines: { node: '>=6.9.0' }
-        peerDependencies:
-            '@babel/core': ^7.0.0
-
-    '@babel/helper-optimise-call-expression@7.29.7':
-        resolution:
-            {
-                integrity: sha512-+kmGVjcT9RGYzoDwdwEqEvGgKe3BYq+O1iGzjFubaNgZHwYHP6lsF2Yghf4kEuv9BV7tYDZ913aBW9am6YKong==,
-            }
-        engines: { node: '>=6.9.0' }
-
-    '@babel/helper-plugin-utils@7.29.7':
-        resolution:
-            {
-                integrity: sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==,
-            }
-        engines: { node: '>=6.9.0' }
-
-    '@babel/helper-replace-supers@7.29.7':
-        resolution:
-            {
-                integrity: sha512-atfGXWSeCiF4DnKZIfmJfQRkSw9b9gNNXR1kqKjbhG4pGYCOnkp8OcTB8E3NXjBu8NpheSnOeNKz8KT7UNFTmQ==,
-            }
-        engines: { node: '>=6.9.0' }
-        peerDependencies:
-            '@babel/core': ^7.0.0
-
-    '@babel/helper-skip-transparent-expression-wrappers@7.29.7':
-        resolution:
-            {
-                integrity: sha512-brcMGQaVzIeUb+6/bs1Av0f8YuNNjKY2JyvfRCsFuFsdKccEQ5Ges2y74D74NZ1Rz8lKJ9ksJkfqwQFJ/iNEyQ==,
-            }
-        engines: { node: '>=6.9.0' }
-
-    '@babel/helper-string-parser@7.29.7':
-        resolution:
-            {
-                integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==,
-            }
-        engines: { node: '>=6.9.0' }
-
-    '@babel/helper-string-parser@8.0.0':
-        resolution:
-            {
-                integrity: sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==,
-            }
-        engines: { node: ^22.18.0 || >=24.11.0 }
-
-    '@babel/helper-validator-identifier@7.29.7':
-        resolution:
-            {
-                integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==,
-            }
-        engines: { node: '>=6.9.0' }
-
-    '@babel/helper-validator-identifier@8.0.4':
-        resolution:
-            {
-                integrity: sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==,
-            }
-        engines: { node: ^22.18.0 || >=24.11.0 }
-
-    '@babel/helper-validator-option@7.29.7':
-        resolution:
-            {
-                integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==,
-            }
-        engines: { node: '>=6.9.0' }
-
-    '@babel/helpers@7.29.7':
-        resolution:
-            {
-                integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==,
-            }
-        engines: { node: '>=6.9.0' }
-
-    '@babel/parser@7.29.8':
-        resolution:
-            {
-                integrity: sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==,
-            }
-        engines: { node: '>=6.0.0' }
-        hasBin: true
-
-    '@babel/plugin-proposal-decorators@7.29.7':
-        resolution:
-            {
-                integrity: sha512-EtU0Hi3GvrTqD56xKmZvV/uCXK2ZbwVNPNLAquVItcAZpUhkXwWlo3Fmj0c2LxgSf2I8IDULeAepwNP1OefLXg==,
-            }
-        engines: { node: '>=6.9.0' }
-        peerDependencies:
-            '@babel/core': ^7.0.0-0
-
-    '@babel/plugin-syntax-decorators@7.29.7':
-        resolution:
-            {
-                integrity: sha512-9MTTLbF39X6sqM92JPEsoI7++26hjZvzkxKZy64aMhWLH2mPkJ/Q3AV4QLmls3R14FpSpkOwQQfUh962JGQxxg==,
-            }
-        engines: { node: '>=6.9.0' }
-        peerDependencies:
-            '@babel/core': ^7.0.0-0
-
-    '@babel/plugin-syntax-typescript@7.29.7':
-        resolution:
-            {
-                integrity: sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==,
-            }
-        engines: { node: '>=6.9.0' }
-        peerDependencies:
-            '@babel/core': ^7.0.0-0
-
-    '@babel/plugin-transform-class-properties@7.29.7':
-        resolution:
-            {
-                integrity: sha512-GtcpjFvanPfzNQi3eTitsCqtRRmmqzpy/A+yhTR1HaZo1Ly3EA8ZXxlPyHdR8/IuRMYc3E4wdGBewB2QKQjAaA==,
-            }
-        engines: { node: '>=6.9.0' }
-        peerDependencies:
-            '@babel/core': ^7.0.0-0
-
-    '@babel/runtime@7.29.7':
-        resolution:
-            {
-                integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==,
-            }
-        engines: { node: '>=6.9.0' }
-
-    '@babel/template@7.29.7':
-        resolution:
-            {
-                integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==,
-            }
-        engines: { node: '>=6.9.0' }
-
-    '@babel/traverse@7.29.8':
-        resolution:
-            {
-                integrity: sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==,
-            }
-        engines: { node: '>=6.9.0' }
-
-    '@babel/types@7.29.8':
-        resolution:
-            {
-                integrity: sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==,
-            }
-        engines: { node: '>=6.9.0' }
-
-    '@babel/types@8.0.4':
-        resolution:
-            {
-                integrity: sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==,
-            }
-        engines: { node: ^22.18.0 || >=24.11.0 }
-
-    '@bcoe/v8-coverage@1.0.2':
-        resolution:
-            {
-                integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==,
-            }
-        engines: { node: '>=18' }
-
-    '@blazediff/core@1.9.1':
-        resolution:
-            {
-                integrity: sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA==,
-            }
-
-    '@bomb.sh/args@0.3.1':
-        resolution:
-            {
-                integrity: sha512-CwxKrfgcorUPP6KfYD59aRdBYWBTsfsxT+GmoLVnKo5Tmyoqbpo0UNcjngRMyU+6tiPbd18RuIYxhgAn44wU/Q==,
-            }
-
-    '@changesets/apply-release-plan@7.1.1':
-        resolution:
-            {
-                integrity: sha512-9qPCm/rLx/xoOFXIHGB229+4GOL76S4MC+7tyOuTsR6+1jYlfFDQORdvwR5hDA6y4FL2BPt3qpbcQIS+dW85LA==,
-            }
-
-    '@changesets/assemble-release-plan@6.0.10':
-        resolution:
-            {
-                integrity: sha512-rSDcqdJ9KbVyjpBIuCidhvZNIiVt1XaIYp73ycVQRIA5n/j6wQaEk0ChRLMUQ1vkxZe51PTQ9OIhbg6HQMW45A==,
-            }
-
-    '@changesets/changelog-git@0.2.1':
-        resolution:
-            {
-                integrity: sha512-x/xEleCFLH28c3bQeQIyeZf8lFXyDFVn1SgcBiR2Tw/r4IAWlk1fzxCEZ6NxQAjF2Nwtczoen3OA2qR+UawQ8Q==,
-            }
-
-    '@changesets/changelog-github@0.5.2':
-        resolution:
-            {
-                integrity: sha512-HeGeDl8HaIGj9fQHo/tv5XKQ2SNEi9+9yl1Bss1jttPqeiASRXhfi0A2wv8yFKCp07kR1gpOI5ge6+CWNm1jPw==,
-            }
-
-    '@changesets/cli@2.31.1':
-        resolution:
-            {
-                integrity: sha512-uO05WTcRBwuVOJVSW8Cmpqw6q0WDL53ajGCMyszutvOe5toOnunbpM4jZzf+qxBOz7i0AzopZ8diBuewjmF40w==,
-            }
-        hasBin: true
-
-    '@changesets/config@3.1.4':
-        resolution:
-            {
-                integrity: sha512-pf0bvD/v6WI2cRlZ6hzpjtZdSlXDXMAJ+Iz7xfFzV4ZxJ8OGGAON+1qYc99ZPrijnt4xp3VGG7eNvAOGS24V1Q==,
-            }
-
-    '@changesets/errors@0.2.0':
-        resolution:
-            {
-                integrity: sha512-6BLOQUscTpZeGljvyQXlWOItQyU71kCdGz7Pi8H8zdw6BI0g3m43iL4xKUVPWtG+qrrL9DTjpdn8eYuCQSRpow==,
-            }
-
-    '@changesets/get-dependents-graph@2.1.4':
-        resolution:
-            {
-                integrity: sha512-ZsS00x6WvmHq3sQv8oCMwL0f/z3wbXCVuSVTJwCnnmbC/iBdNJGFx1EcbMG4PC6sXRyH69liM4A2WKXzn/kRPg==,
-            }
-
-    '@changesets/get-github-info@0.7.0':
-        resolution:
-            {
-                integrity: sha512-+i67Bmhfj9V4KfDeS1+Tz3iF32btKZB2AAx+cYMqDSRFP7r3/ZdGbjCo+c6qkyViN9ygDuBjzageuPGJtKGe5A==,
-            }
-
-    '@changesets/get-release-plan@4.0.16':
-        resolution:
-            {
-                integrity: sha512-2K5Om6CrMPm45rtvckfzWo7e9jOVCKLCnXia5eUPaURH7/LWzri7pK1TycdzAuAtehLkW7VPbWLCSExTHmiI6g==,
-            }
-
-    '@changesets/get-version-range-type@0.4.0':
-        resolution:
-            {
-                integrity: sha512-hwawtob9DryoGTpixy1D3ZXbGgJu1Rhr+ySH2PvTLHvkZuQ7sRT4oQwMh0hbqZH1weAooedEjRsbrWcGLCeyVQ==,
-            }
-
-    '@changesets/git@3.0.4':
-        resolution:
-            {
-                integrity: sha512-BXANzRFkX+XcC1q/d27NKvlJ1yf7PSAgi8JG6dt8EfbHFHi4neau7mufcSca5zRhwOL8j9s6EqsxmT+s+/E6Sw==,
-            }
-
-    '@changesets/logger@0.1.1':
-        resolution:
-            {
-                integrity: sha512-OQtR36ZlnuTxKqoW4Sv6x5YIhOmClRd5pWsjZsddYxpWs517R0HkyiefQPIytCVh4ZcC5x9XaG8KTdd5iRQUfg==,
-            }
-
-    '@changesets/parse@0.4.3':
-        resolution:
-            {
-                integrity: sha512-ZDmNc53+dXdWEv7fqIUSgRQOLYoUom5Z40gmLgmATmYR9NbL6FJJHwakcCpzaeCy+1D0m0n7mT4jj2B/MQPl7A==,
-            }
-
-    '@changesets/pre@2.0.2':
-        resolution:
-            {
-                integrity: sha512-HaL/gEyFVvkf9KFg6484wR9s0qjAXlZ8qWPDkTyKF6+zqjBe/I2mygg3MbpZ++hdi0ToqNUF8cjj7fBy0dg8Ug==,
-            }
-
-    '@changesets/read@0.6.7':
-        resolution:
-            {
-                integrity: sha512-D1G4AUYGrBEk8vj8MGwf75k9GpN6XL3wg8i42P2jZZwFLXnlr2Pn7r9yuQNbaMCarP7ZQWNJbV6XLeysAIMhTA==,
-            }
-
-    '@changesets/should-skip-package@0.1.2':
-        resolution:
-            {
-                integrity: sha512-qAK/WrqWLNCP22UDdBTMPH5f41elVDlsNyat180A33dWxuUDyNpg6fPi/FyTZwRriVjg0L8gnjJn2F9XAoF0qw==,
-            }
-
-    '@changesets/types@4.1.0':
-        resolution:
-            {
-                integrity: sha512-LDQvVDv5Kb50ny2s25Fhm3d9QSZimsoUGBsUioj6MC3qbMUCuC8GPIvk/M6IvXx3lYhAs0lwWUQLb+VIEUCECw==,
-            }
-
-    '@changesets/types@6.1.0':
-        resolution:
-            {
-                integrity: sha512-rKQcJ+o1nKNgeoYRHKOS07tAMNd3YSN0uHaJOZYjBAgxfV7TUE7JE+z4BzZdQwb5hKaYbayKN5KrYV7ODb2rAA==,
-            }
-
-    '@changesets/write@0.4.0':
-        resolution:
-            {
-                integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==,
-            }
-
-    '@chromatic-com/storybook@5.2.1':
-        resolution:
-            {
-                integrity: sha512-z6I7NJk/0VngA64y5TNYaB4Hc2X8+90n4op6lBt9PvWk5TmIlFLDqdX33rlrwbNRkkYijVgA/wO04rVYXi5Mlg==,
-            }
-        engines: { node: '>=20.0.0', yarn: '>=1.22.18' }
-        peerDependencies:
-            storybook: ^0.0.0-0 || ^10.1.0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0 || ^10.4.0-0 || ^10.5.0-0 || ^10.6.0-0
-
-    '@clack/core@1.4.3':
-        resolution:
-            {
-                integrity: sha512-/kr3UWNtdJfxZtPgDqUOmG2pvwlmcLGheex5yiZKdwbzZJxhV+HMNR9QNmyY5cGwTNV6LrR7Jtp+KjhUAP1qBQ==,
-            }
-        engines: { node: '>= 20.12.0' }
-
-    '@clack/prompts@1.7.0':
-        resolution:
-            {
-                integrity: sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A==,
-            }
-        engines: { node: '>= 20.12.0' }
-
-    '@colordx/core@5.5.0':
-        resolution:
-            {
-                integrity: sha512-3PxTH8itZzltK0U9jTwVVnjLXvnDYuq3m+QXsHkENxWiPRh4WaoLcs1SQjqgZ55kS+QyirpH5BVwzP2gMVG6EQ==,
-            }
-
-    '@ecopages/browser-router@0.2.0-beta.43':
-        resolution:
-            {
-                integrity: sha512-2gBmDUvqP82Oaec7o5/c/jIscbCdYMnjdCZvhDLZnqTb2DN/ahyDnSPeh5bsT+BK2a3xoBP5M3OTXZE4I7R2oA==,
-            }
-        peerDependencies:
-            '@ecopages/core': 0.2.0-beta.43
-
-    '@ecopages/content-processor@0.2.0-beta.43':
-        resolution:
-            {
-                integrity: sha512-19Sn9iesmma+nMCMdrEG+QX0UOSy4X6UZi7CGzpvV1KjqKRQGypW95bBfYFgTobT3bRjw/nKrN8oBzW4npm9ew==,
-            }
-        peerDependencies:
-            '@ecopages/core': 0.2.0-beta.43
-
-    '@ecopages/core@0.2.0-beta.43':
-        resolution:
-            {
-                integrity: sha512-BvBxKugEVZ4EtfpwIJmbOjdsfuuYO/1NGT0aONoELSLUdCqotVTfymqoSMPV8vRW91jY61A3RGiKQPskx8XB6g==,
-            }
-        peerDependencies:
-            '@ecopages/dev-toolbar': 0.2.0-beta.43
-        peerDependenciesMeta:
-            '@ecopages/dev-toolbar':
-                optional: true
-
-    '@ecopages/dev-toolbar@0.2.0-beta.43':
-        resolution:
-            {
-                integrity: sha512-q7T4NGRlBs/mih7jRUW76gNdeBfSorIh23DHYTblrtjdYEUGRleHA0dLyiWne6GMjwifzUqLsvsoCnA4fq9v/w==,
-            }
-
-    '@ecopages/ecopages-jsx@0.2.0-beta.43':
-        resolution:
-            {
-                integrity: sha512-HOy4Tm3H7ZZIc4L42duCgBkw9RQ5F49MHstbvA5JMjQ9GW72jRxthovKHy2kG0fOXvVxCu97SUjGEUB16JbhoA==,
-            }
-        peerDependencies:
-            '@ecopages/core': 0.2.0-beta.43
-            '@ecopages/jsx': 0.3.0-beta.6
-            '@ecopages/radiant': 0.3.0-beta.6
-
-    '@ecopages/file-system@0.2.0-beta.43':
-        resolution:
-            {
-                integrity: sha512-SMFrJhYUyohrDe2Dpa7fT15G7PtsNrPzKYRIMgvQwWNAn+fT+PUcJ/tolmu49OZzjH4zj7yexbVOx23HiRpwqQ==,
-            }
-
-    '@ecopages/jsx@0.3.0-beta.6':
-        resolution:
-            {
-                integrity: sha512-0899gAdflauLTRWX0ul5kxJUEaALOKl4JGL9Dq42xncfWVSkEVdNTl6JIl5jx/EpXInYWn4JOflhYWv+/R6OUQ==,
-            }
-        peerDependencies:
-            '@ecopages/signals': '>=0.3.0-beta.6'
-
-    '@ecopages/logger@0.2.3':
-        resolution:
-            {
-                integrity: sha512-Hkt5H9Kzv6y07aiPZPaDkJ6/Bp7+Aen5ZFuI5zQ6ON7PyeuVu1lMiQy9pL+9Wm8yeO3wnMO44Jmph84Cc0X0lQ==,
-            }
-        peerDependencies:
-            typescript: ^5.0.0
-
-    '@ecopages/mdx@0.2.0-beta.43':
-        resolution:
-            {
-                integrity: sha512-0KAalriXkrnsTV7/YKAK9mXJ503iH4CFaG/ZTbbrTwfc52nsPp42R54wVZonP4XtuhjUbMOe0Dw8bAAyYllgQA==,
-            }
-        peerDependencies:
-            '@ecopages/core': 0.2.0-beta.43
-            '@mdx-js/mdx': ^3.1.0
-
-    '@ecopages/postcss-processor@0.2.0-beta.43':
-        resolution:
-            {
-                integrity: sha512-Ng1omlA+3LtEPVOzkrNw6R2ETGLwTCxdPxybGLzS5gc3Et0fYd35I7TC14Eey29309QdmGQ1qA581rbTeIfl6g==,
-            }
-        peerDependencies:
-            '@ecopages/core': 0.2.0-beta.43
-            '@tailwindcss/postcss': '>=4'
-            tailwindcss: '>=3'
-        peerDependenciesMeta:
-            '@tailwindcss/postcss':
-                optional: true
-            tailwindcss:
-                optional: true
-
-    '@ecopages/radiant@0.3.0-beta.6':
-        resolution:
-            {
-                integrity: sha512-pXBAjkZioF8pQhBcwTpLB4AbsPRmuH228n5m4yHHK/XEVp0u69f4eEsF5RgJ5t6nFiw3h5pWmF0t4llnLHVcpg==,
-            }
-        peerDependencies:
-            '@ecopages/jsx': '>=0.3.0-beta.6'
-
-    '@ecopages/scripts-injector@0.1.5':
-        resolution:
-            {
-                integrity: sha512-4julGcmVkf4G8asK0/vAZ9o9bIWudEyGk4D/rRF/IE2J4ePT5FgmR8QdzRxD+DElzEnkJTnS7gyX2Dj7JeNtdg==,
-            }
-        peerDependencies:
-            typescript: ^5.0.0
-
-    '@ecopages/signals@0.3.0-beta.6':
-        resolution:
-            {
-                integrity: sha512-VjF9D5kiTSQGx3k3Dqe5pmvkjb8uI6Fo7+3Zw4ed9jTPEa4cnk/COhm5JGOTQnXvqg3i1zOQNVMOi+WeiMs1ng==,
-            }
-
-    '@emnapi/core@1.11.2':
-        resolution:
-            {
-                integrity: sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==,
-            }
-
-    '@emnapi/core@1.9.2':
-        resolution:
-            {
-                integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==,
-            }
-
-    '@emnapi/core@2.0.0-alpha.3':
-        resolution:
-            {
-                integrity: sha512-AZypUeJ/yByuxyS7BlSNRDOMLMlROYtjYdIAuBmJssVz1UJDSeYxLrdizhXCFYhedC5bqd/ASy8EuNXbVVXp9g==,
-            }
-
-    '@emnapi/runtime@1.11.2':
-        resolution:
-            {
-                integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==,
-            }
-
-    '@emnapi/runtime@1.9.2':
-        resolution:
-            {
-                integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==,
-            }
-
-    '@emnapi/runtime@2.0.0-alpha.3':
-        resolution:
-            {
-                integrity: sha512-hFPAhMUjJD9BSyCANEISPOogeXC9Zo9ZQl7L6vKnaVsMkCtzznaW/naYypeyl0Gv5rYfWYsZbpixTMpjDJzQeA==,
-            }
-
-    '@emnapi/wasi-threads@1.2.1':
-        resolution:
-            {
-                integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==,
-            }
-
-    '@emnapi/wasi-threads@1.2.2':
-        resolution:
-            {
-                integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==,
-            }
-
-    '@emnapi/wasi-threads@2.0.1':
-        resolution:
-            {
-                integrity: sha512-9DsSk+o5NBX0CCJT8s0EROGSGxjR/tKu6aBTaVyq+SjAEQH4XcdcRxPBRzsBLizTTJ49MJjF+jgu3qnO9GLQcQ==,
-            }
-
-    '@esbuild/aix-ppc64@0.27.7':
-        resolution:
-            {
-                integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==,
-            }
-        engines: { node: '>=18' }
-        cpu: [ppc64]
-        os: [aix]
-
-    '@esbuild/aix-ppc64@0.28.1':
-        resolution:
-            {
-                integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==,
-            }
-        engines: { node: '>=18' }
-        cpu: [ppc64]
-        os: [aix]
-
-    '@esbuild/android-arm64@0.27.7':
-        resolution:
-            {
-                integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==,
-            }
-        engines: { node: '>=18' }
-        cpu: [arm64]
-        os: [android]
-
-    '@esbuild/android-arm64@0.28.1':
-        resolution:
-            {
-                integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==,
-            }
-        engines: { node: '>=18' }
-        cpu: [arm64]
-        os: [android]
-
-    '@esbuild/android-arm@0.27.7':
-        resolution:
-            {
-                integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==,
-            }
-        engines: { node: '>=18' }
-        cpu: [arm]
-        os: [android]
-
-    '@esbuild/android-arm@0.28.1':
-        resolution:
-            {
-                integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==,
-            }
-        engines: { node: '>=18' }
-        cpu: [arm]
-        os: [android]
-
-    '@esbuild/android-x64@0.27.7':
-        resolution:
-            {
-                integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==,
-            }
-        engines: { node: '>=18' }
-        cpu: [x64]
-        os: [android]
-
-    '@esbuild/android-x64@0.28.1':
-        resolution:
-            {
-                integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==,
-            }
-        engines: { node: '>=18' }
-        cpu: [x64]
-        os: [android]
-
-    '@esbuild/darwin-arm64@0.27.7':
-        resolution:
-            {
-                integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==,
-            }
-        engines: { node: '>=18' }
-        cpu: [arm64]
-        os: [darwin]
-
-    '@esbuild/darwin-arm64@0.28.1':
-        resolution:
-            {
-                integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==,
-            }
-        engines: { node: '>=18' }
-        cpu: [arm64]
-        os: [darwin]
-
-    '@esbuild/darwin-x64@0.27.7':
-        resolution:
-            {
-                integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==,
-            }
-        engines: { node: '>=18' }
-        cpu: [x64]
-        os: [darwin]
-
-    '@esbuild/darwin-x64@0.28.1':
-        resolution:
-            {
-                integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==,
-            }
-        engines: { node: '>=18' }
-        cpu: [x64]
-        os: [darwin]
-
-    '@esbuild/freebsd-arm64@0.27.7':
-        resolution:
-            {
-                integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==,
-            }
-        engines: { node: '>=18' }
-        cpu: [arm64]
-        os: [freebsd]
-
-    '@esbuild/freebsd-arm64@0.28.1':
-        resolution:
-            {
-                integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==,
-            }
-        engines: { node: '>=18' }
-        cpu: [arm64]
-        os: [freebsd]
-
-    '@esbuild/freebsd-x64@0.27.7':
-        resolution:
-            {
-                integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==,
-            }
-        engines: { node: '>=18' }
-        cpu: [x64]
-        os: [freebsd]
-
-    '@esbuild/freebsd-x64@0.28.1':
-        resolution:
-            {
-                integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==,
-            }
-        engines: { node: '>=18' }
-        cpu: [x64]
-        os: [freebsd]
-
-    '@esbuild/linux-arm64@0.27.7':
-        resolution:
-            {
-                integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==,
-            }
-        engines: { node: '>=18' }
-        cpu: [arm64]
-        os: [linux]
-
-    '@esbuild/linux-arm64@0.28.1':
-        resolution:
-            {
-                integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==,
-            }
-        engines: { node: '>=18' }
-        cpu: [arm64]
-        os: [linux]
-
-    '@esbuild/linux-arm@0.27.7':
-        resolution:
-            {
-                integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==,
-            }
-        engines: { node: '>=18' }
-        cpu: [arm]
-        os: [linux]
-
-    '@esbuild/linux-arm@0.28.1':
-        resolution:
-            {
-                integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==,
-            }
-        engines: { node: '>=18' }
-        cpu: [arm]
-        os: [linux]
-
-    '@esbuild/linux-ia32@0.27.7':
-        resolution:
-            {
-                integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==,
-            }
-        engines: { node: '>=18' }
-        cpu: [ia32]
-        os: [linux]
-
-    '@esbuild/linux-ia32@0.28.1':
-        resolution:
-            {
-                integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==,
-            }
-        engines: { node: '>=18' }
-        cpu: [ia32]
-        os: [linux]
-
-    '@esbuild/linux-loong64@0.27.7':
-        resolution:
-            {
-                integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==,
-            }
-        engines: { node: '>=18' }
-        cpu: [loong64]
-        os: [linux]
-
-    '@esbuild/linux-loong64@0.28.1':
-        resolution:
-            {
-                integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==,
-            }
-        engines: { node: '>=18' }
-        cpu: [loong64]
-        os: [linux]
-
-    '@esbuild/linux-mips64el@0.27.7':
-        resolution:
-            {
-                integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==,
-            }
-        engines: { node: '>=18' }
-        cpu: [mips64el]
-        os: [linux]
-
-    '@esbuild/linux-mips64el@0.28.1':
-        resolution:
-            {
-                integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==,
-            }
-        engines: { node: '>=18' }
-        cpu: [mips64el]
-        os: [linux]
-
-    '@esbuild/linux-ppc64@0.27.7':
-        resolution:
-            {
-                integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==,
-            }
-        engines: { node: '>=18' }
-        cpu: [ppc64]
-        os: [linux]
-
-    '@esbuild/linux-ppc64@0.28.1':
-        resolution:
-            {
-                integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==,
-            }
-        engines: { node: '>=18' }
-        cpu: [ppc64]
-        os: [linux]
-
-    '@esbuild/linux-riscv64@0.27.7':
-        resolution:
-            {
-                integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==,
-            }
-        engines: { node: '>=18' }
-        cpu: [riscv64]
-        os: [linux]
-
-    '@esbuild/linux-riscv64@0.28.1':
-        resolution:
-            {
-                integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==,
-            }
-        engines: { node: '>=18' }
-        cpu: [riscv64]
-        os: [linux]
-
-    '@esbuild/linux-s390x@0.27.7':
-        resolution:
-            {
-                integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==,
-            }
-        engines: { node: '>=18' }
-        cpu: [s390x]
-        os: [linux]
-
-    '@esbuild/linux-s390x@0.28.1':
-        resolution:
-            {
-                integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==,
-            }
-        engines: { node: '>=18' }
-        cpu: [s390x]
-        os: [linux]
-
-    '@esbuild/linux-x64@0.27.7':
-        resolution:
-            {
-                integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==,
-            }
-        engines: { node: '>=18' }
-        cpu: [x64]
-        os: [linux]
-
-    '@esbuild/linux-x64@0.28.1':
-        resolution:
-            {
-                integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==,
-            }
-        engines: { node: '>=18' }
-        cpu: [x64]
-        os: [linux]
-
-    '@esbuild/netbsd-arm64@0.27.7':
-        resolution:
-            {
-                integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==,
-            }
-        engines: { node: '>=18' }
-        cpu: [arm64]
-        os: [netbsd]
-
-    '@esbuild/netbsd-arm64@0.28.1':
-        resolution:
-            {
-                integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==,
-            }
-        engines: { node: '>=18' }
-        cpu: [arm64]
-        os: [netbsd]
-
-    '@esbuild/netbsd-x64@0.27.7':
-        resolution:
-            {
-                integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==,
-            }
-        engines: { node: '>=18' }
-        cpu: [x64]
-        os: [netbsd]
-
-    '@esbuild/netbsd-x64@0.28.1':
-        resolution:
-            {
-                integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==,
-            }
-        engines: { node: '>=18' }
-        cpu: [x64]
-        os: [netbsd]
-
-    '@esbuild/openbsd-arm64@0.27.7':
-        resolution:
-            {
-                integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==,
-            }
-        engines: { node: '>=18' }
-        cpu: [arm64]
-        os: [openbsd]
-
-    '@esbuild/openbsd-arm64@0.28.1':
-        resolution:
-            {
-                integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==,
-            }
-        engines: { node: '>=18' }
-        cpu: [arm64]
-        os: [openbsd]
-
-    '@esbuild/openbsd-x64@0.27.7':
-        resolution:
-            {
-                integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==,
-            }
-        engines: { node: '>=18' }
-        cpu: [x64]
-        os: [openbsd]
-
-    '@esbuild/openbsd-x64@0.28.1':
-        resolution:
-            {
-                integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==,
-            }
-        engines: { node: '>=18' }
-        cpu: [x64]
-        os: [openbsd]
-
-    '@esbuild/openharmony-arm64@0.27.7':
-        resolution:
-            {
-                integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==,
-            }
-        engines: { node: '>=18' }
-        cpu: [arm64]
-        os: [openharmony]
-
-    '@esbuild/openharmony-arm64@0.28.1':
-        resolution:
-            {
-                integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==,
-            }
-        engines: { node: '>=18' }
-        cpu: [arm64]
-        os: [openharmony]
-
-    '@esbuild/sunos-x64@0.27.7':
-        resolution:
-            {
-                integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==,
-            }
-        engines: { node: '>=18' }
-        cpu: [x64]
-        os: [sunos]
-
-    '@esbuild/sunos-x64@0.28.1':
-        resolution:
-            {
-                integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==,
-            }
-        engines: { node: '>=18' }
-        cpu: [x64]
-        os: [sunos]
-
-    '@esbuild/win32-arm64@0.27.7':
-        resolution:
-            {
-                integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==,
-            }
-        engines: { node: '>=18' }
-        cpu: [arm64]
-        os: [win32]
-
-    '@esbuild/win32-arm64@0.28.1':
-        resolution:
-            {
-                integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==,
-            }
-        engines: { node: '>=18' }
-        cpu: [arm64]
-        os: [win32]
-
-    '@esbuild/win32-ia32@0.27.7':
-        resolution:
-            {
-                integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==,
-            }
-        engines: { node: '>=18' }
-        cpu: [ia32]
-        os: [win32]
-
-    '@esbuild/win32-ia32@0.28.1':
-        resolution:
-            {
-                integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==,
-            }
-        engines: { node: '>=18' }
-        cpu: [ia32]
-        os: [win32]
-
-    '@esbuild/win32-x64@0.27.7':
-        resolution:
-            {
-                integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==,
-            }
-        engines: { node: '>=18' }
-        cpu: [x64]
-        os: [win32]
-
-    '@esbuild/win32-x64@0.28.1':
-        resolution:
-            {
-                integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==,
-            }
-        engines: { node: '>=18' }
-        cpu: [x64]
-        os: [win32]
-
-    '@inquirer/external-editor@1.0.3':
-        resolution:
-            {
-                integrity: sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==,
-            }
-        engines: { node: '>=18' }
-        peerDependencies:
-            '@types/node': '>=18'
-        peerDependenciesMeta:
-            '@types/node':
-                optional: true
-
-    '@istanbuljs/schema@0.1.6':
-        resolution:
-            {
-                integrity: sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==,
-            }
-        engines: { node: '>=8' }
-
-    '@jridgewell/gen-mapping@0.3.13':
-        resolution:
-            {
-                integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==,
-            }
-
-    '@jridgewell/remapping@2.3.5':
-        resolution:
-            {
-                integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==,
-            }
-
-    '@jridgewell/resolve-uri@3.1.2':
-        resolution:
-            {
-                integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==,
-            }
-        engines: { node: '>=6.0.0' }
-
-    '@jridgewell/sourcemap-codec@1.5.5':
-        resolution:
-            {
-                integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==,
-            }
-
-    '@jridgewell/trace-mapping@0.3.31':
-        resolution:
-            {
-                integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==,
-            }
-
-    '@manypkg/find-root@1.1.0':
-        resolution:
-            {
-                integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==,
-            }
-
-    '@manypkg/get-packages@1.1.3':
-        resolution:
-            {
-                integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==,
-            }
-
-    '@mdx-js/esbuild@3.1.1':
-        resolution:
-            {
-                integrity: sha512-NS35VhTdvKNj5/B1JSD5W3kN1R0WDHgk+zCWq+tSChQw5L2Bgeiz7yyZPFrc5LWuPVOxE1xMbJr82bO9VVzmfQ==,
-            }
-        peerDependencies:
-            esbuild: '>=0.14.0'
-
-    '@mdx-js/mdx@3.1.1':
-        resolution:
-            {
-                integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==,
-            }
-
-    '@mdx-js/react@3.1.1':
-        resolution:
-            {
-                integrity: sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==,
-            }
-        peerDependencies:
-            '@types/react': '>=16'
-            react: '>=16'
-
-    '@napi-rs/lzma-linux-x64-gnu@1.5.1':
-        resolution:
-            {
-                integrity: sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==,
-            }
-        engines: { node: ^22.20 || ^24.12 || >=25 }
-        cpu: [x64]
-        os: [linux]
-        libc: [glibc]
-
-    '@napi-rs/wasm-runtime@1.2.2':
-        resolution:
-            {
-                integrity: sha512-JfB4kuJQjaoHuCTseIINHtHWeJnvgEcxjwA5t/Y00ZgaOO1Crz3fjT/p8kT28zA/Caz7oiUMn3d6H2yOVCVwuw==,
-            }
-        engines: { node: ^20.19.0 || ^22.13.0 || >=23.5.0 }
-        peerDependencies:
-            '@emnapi/core': ^1.7.1 || ^2.0.0-alpha.3
-            '@emnapi/runtime': ^1.7.1 || ^2.0.0-alpha.3
-
-    '@neoconfetti/react@1.0.0':
-        resolution:
-            {
-                integrity: sha512-klcSooChXXOzIm+SE5IISIAn3bYzYfPjbX7D7HoqZL84oAfgREeSg5vSIaSFH+DaGzzvImTyWe1OyrJ67vik4A==,
-            }
-
-    '@nodelib/fs.scandir@2.1.5':
-        resolution:
-            {
-                integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==,
-            }
-        engines: { node: '>= 8' }
-
-    '@nodelib/fs.stat@2.0.5':
-        resolution:
-            {
-                integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==,
-            }
-        engines: { node: '>= 8' }
-
-    '@nodelib/fs.walk@1.2.8':
-        resolution:
-            {
-                integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==,
-            }
-        engines: { node: '>= 8' }
-
-    '@oxc-parser/binding-android-arm-eabi@0.127.0':
-        resolution:
-            {
-                integrity: sha512-0LC7ye4hvqbIKxAzThzvswgHLFu2AURKzYLeSVvLdu2TBOYWQDmHnTqPLeA597BcUCxiLqLsS4CJ5uoI5WYWCQ==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm]
-        os: [android]
-
-    '@oxc-parser/binding-android-arm-eabi@0.141.0':
-        resolution:
-            {
-                integrity: sha512-jk7086MFvR/T4DG9IY7MKBVt1PMxvSZoz/TvnifodvS0pjghVwJHRttnAExhlwdMOgHv1TmLdENnbNpYk2zjvA==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm]
-        os: [android]
-
-    '@oxc-parser/binding-android-arm64@0.127.0':
-        resolution:
-            {
-                integrity: sha512-b5jtVTH6AU5CJXHNdj7Jj9IEiR9yVjjnwHzPJhGyHGPdcsZSzBCkS9GBbV33niRMvKthDwQRFRJfI4a+k4PvYg==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm64]
-        os: [android]
-
-    '@oxc-parser/binding-android-arm64@0.141.0':
-        resolution:
-            {
-                integrity: sha512-a4XDQ27ZT7e7zwAlxJDTiCA7IBGWDuy2+MhFq85Of7XlBSmpkfcBFml11q0Zx6f7RMuI0B4xCtt2ytBS4yOptg==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm64]
-        os: [android]
-
-    '@oxc-parser/binding-darwin-arm64@0.127.0':
-        resolution:
-            {
-                integrity: sha512-obCE8B7ISKkJidjlhv9xRGJPOSDG2Yu6PRga9Ruaz35uintHxbp1Ki/Yc71wx4rj3Edrm0a1kzG1TAwit0wFpg==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm64]
-        os: [darwin]
-
-    '@oxc-parser/binding-darwin-arm64@0.141.0':
-        resolution:
-            {
-                integrity: sha512-m/kVk6rzYmBeHYnz+1Y5fod00AVTTxMbC71azFfm/zjx1j9XxwKtA0+VfkKuVMC8rbghb9TtfevnuWZa9OuPEg==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm64]
-        os: [darwin]
-
-    '@oxc-parser/binding-darwin-x64@0.127.0':
-        resolution:
-            {
-                integrity: sha512-JL6Xb5IwPQT8rUzlpsX7E+AgfcdNklXNPFp8pjCQQ5MQOQo5rtEB2ui+3Hgg9Sn7Y9Egj6YOLLiHhLpdAe12Aw==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [x64]
-        os: [darwin]
-
-    '@oxc-parser/binding-darwin-x64@0.141.0':
-        resolution:
-            {
-                integrity: sha512-o0X+6KZlfucWU/v5oKRQPwdFXsXAjW8jmpo/Gpw/qyKsbKtlfkHoeH9Bjp/m13TwjewvJnCkwF0DWzgpC4HjTQ==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [x64]
-        os: [darwin]
-
-    '@oxc-parser/binding-freebsd-x64@0.127.0':
-        resolution:
-            {
-                integrity: sha512-SDQ/3MQFw58fqQz3Z1PhSKFF3JoCF4gmlNjziDm8X02tTahCw0qJbd7FGPDKw1i4VTBZene9JPyC3mHtSvi+wA==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [x64]
-        os: [freebsd]
-
-    '@oxc-parser/binding-freebsd-x64@0.141.0':
-        resolution:
-            {
-                integrity: sha512-W5KbTnNkTMMMylqj6dYqnsXvkmESVPodPKYLJ5zdzIPdl9fUJtolkpUeSzYEbGGYB4a4A4avl3EePnZ/wLIdJg==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [x64]
-        os: [freebsd]
-
-    '@oxc-parser/binding-linux-arm-gnueabihf@0.127.0':
-        resolution:
-            {
-                integrity: sha512-Av+D1MIqzV0YMGPT9we2SIZaMKD7Cxs4CvXSx/yxaWHewZjYEjScpOf5igc8IILASViw4WTnjlwUdI1KzVtDHQ==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm]
-        os: [linux]
-
-    '@oxc-parser/binding-linux-arm-gnueabihf@0.141.0':
-        resolution:
-            {
-                integrity: sha512-g3dtbJa8zeOGK36Sr9cQavsdi5H/ie2hVjrSjIxsNAR1qZA40ZYVXnfdfoMAlq8CmB9qFL1yhsSCUHeNmdmt8w==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm]
-        os: [linux]
-
-    '@oxc-parser/binding-linux-arm-musleabihf@0.127.0':
-        resolution:
-            {
-                integrity: sha512-Cs2fdJ8cPpFdeebj6p4dag8A4+56hPvZ0AhQQzlaLswGz1tz7bXt1nETLeorrM9+AMcWFFkqxcXwDGfTVidY8g==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm]
-        os: [linux]
-
-    '@oxc-parser/binding-linux-arm-musleabihf@0.141.0':
-        resolution:
-            {
-                integrity: sha512-e6hwQqd+3lvP13G2jxvFpoA7dzHcFLN+Mq47JCVMtdNHbbyBRo756JCtbbJH6ca8inTfyqZoqBmS3vhQlzAK2w==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm]
-        os: [linux]
-
-    '@oxc-parser/binding-linux-arm64-gnu@0.127.0':
-        resolution:
-            {
-                integrity: sha512-qdOfTcT6SY8gsJrrV92uyEUyjqMGPpIB5JZUG6QN5dukYd+7/j0kX6MwK1DgQj39jtUYixxPiaRUiEN1+0CXgQ==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm64]
-        os: [linux]
-        libc: [glibc]
-
-    '@oxc-parser/binding-linux-arm64-gnu@0.141.0':
-        resolution:
-            {
-                integrity: sha512-vXz2BLAuypA+4MLyBg94pzEo6THVnzYnCtAjXoihIIQo0t2pnp/AmW+SH1EI+4VbuJnC//KplIJ5yyaCGua4jA==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm64]
-        os: [linux]
-        libc: [glibc]
-
-    '@oxc-parser/binding-linux-arm64-musl@0.127.0':
-        resolution:
-            {
-                integrity: sha512-EoTCZneNFU/P2qrpEM+RHmQwt+CvDkyGESG6qhr7KaegXLZwePfbrkCDfAk8/rhxbDUVGsZILX+2tqPzFtoFWA==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm64]
-        os: [linux]
-        libc: [musl]
-
-    '@oxc-parser/binding-linux-arm64-musl@0.141.0':
-        resolution:
-            {
-                integrity: sha512-jMkS/EztNW34HKsXIaT/SoHcmtocq/vWhwFOVduF9kduuuRIVwfwQ6uxzIO+qPKSXdd2TXt54of0BJ2zFMXnmw==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm64]
-        os: [linux]
-        libc: [musl]
-
-    '@oxc-parser/binding-linux-ppc64-gnu@0.127.0':
-        resolution:
-            {
-                integrity: sha512-zALjmZYgxFLHjXeudcDF0xFGNydTAtkAeXAr2EuC17ywCyFxcmQra4w0BMde0Yi/re4Bi4iwEoEXtYN7l6eBLQ==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [ppc64]
-        os: [linux]
-        libc: [glibc]
-
-    '@oxc-parser/binding-linux-ppc64-gnu@0.141.0':
-        resolution:
-            {
-                integrity: sha512-vo+MR+n3zQJ6Mq92hiP084NZcgDv5iJlVR02gMf28neMvVT1tKVm7VeiW/DxhdqOi3QLeaXIk9cUcLL1qrkngw==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [ppc64]
-        os: [linux]
-        libc: [glibc]
-
-    '@oxc-parser/binding-linux-riscv64-gnu@0.127.0':
-        resolution:
-            {
-                integrity: sha512-fPP8M6zQLS7Jz7o9d5ArUSuAuSK3e+WCYVrCpdzeCOejidtZExJ9tjhDrAd3HEPqARBCPmdpqxESPFqy44vkBQ==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [riscv64]
-        os: [linux]
-        libc: [glibc]
-
-    '@oxc-parser/binding-linux-riscv64-gnu@0.141.0':
-        resolution:
-            {
-                integrity: sha512-oh80w+7RuiO5gBp9Jnoa/H8Qlt3JsHL2MkW+0dwEdlDMdslVZX/YsekSK6EeyEenY66/mhCfypsNATQ7Ph3qlQ==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [riscv64]
-        os: [linux]
-        libc: [glibc]
-
-    '@oxc-parser/binding-linux-riscv64-musl@0.127.0':
-        resolution:
-            {
-                integrity: sha512-7IcC4Ao02oGpfnjt+X/oF4U2mllo2qoSkw5xxiXNKL9MCTsTiAC6616beOuehdxGcnz1bRoPC1RQ2f1GQDdN+g==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [riscv64]
-        os: [linux]
-        libc: [musl]
-
-    '@oxc-parser/binding-linux-riscv64-musl@0.141.0':
-        resolution:
-            {
-                integrity: sha512-LOyEmFA8sCnYbEXP1+iQvCC/P1YXHMA/t6x1Ksp0Y9VwhLFsiBJFzV1zIxrOIE2LKaGGhDjQ29xq9cbq6omDXA==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [riscv64]
-        os: [linux]
-        libc: [musl]
-
-    '@oxc-parser/binding-linux-s390x-gnu@0.127.0':
-        resolution:
-            {
-                integrity: sha512-pbXIhiNFHoqWeqDNLiJ9JkpHz1IM9k4DXa66x+1GTWMG7iLxtkXgE53iiuKSXwmk3zIYmaPVfBvgcAhS583K4Q==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [s390x]
-        os: [linux]
-        libc: [glibc]
-
-    '@oxc-parser/binding-linux-s390x-gnu@0.141.0':
-        resolution:
-            {
-                integrity: sha512-3wnwk/l1CvszVE5TJR1wSl/zSEfydRqrNhn6s7Vr9IzSJpUQIroqVsIoPARHRFA+FQwkxAFDAHDAasa7v8OobQ==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [s390x]
-        os: [linux]
-        libc: [glibc]
-
-    '@oxc-parser/binding-linux-x64-gnu@0.127.0':
-        resolution:
-            {
-                integrity: sha512-MYCguB9RvBvlSd6gbuNI7QwiLoCCAlGnlRJFPrzLI6U1/9wkC/WK6LtBAUln55H1Ctqw45PWmqrobKoMhsYQzQ==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [x64]
-        os: [linux]
-        libc: [glibc]
-
-    '@oxc-parser/binding-linux-x64-gnu@0.141.0':
-        resolution:
-            {
-                integrity: sha512-qtyQVAAebFq57B2tifTlel3TgGqUtsYNI/e+p6aya9rN9lOZVTDvr215fGYSA9XWooxzMxDiVxkBLk2jQHbsOQ==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [x64]
-        os: [linux]
-        libc: [glibc]
-
-    '@oxc-parser/binding-linux-x64-musl@0.127.0':
-        resolution:
-            {
-                integrity: sha512-5eY0B/bxf1xIUxb4NOTvOI3KWtBQfPWYyKAzgcrCt0mDibSZygVpO1Pz8bkeiSZ5Jj9+M09dkggG3H8I5d0Uyg==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [x64]
-        os: [linux]
-        libc: [musl]
-
-    '@oxc-parser/binding-linux-x64-musl@0.141.0':
-        resolution:
-            {
-                integrity: sha512-SkGV1nKw40roEc94pv5EaaeH2ay14G6+roe8Q0wIUC1LcEKxzKW921h7+ZuZX0D3q2Mb/7aSFmxEVqnko3lPRw==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [x64]
-        os: [linux]
-        libc: [musl]
-
-    '@oxc-parser/binding-openharmony-arm64@0.127.0':
-        resolution:
-            {
-                integrity: sha512-Gld0ajrFTUXNtdw20fVBuTQx66FA75nIVg+//pPfR3sXkuABB4mTBhl3r9JNzrJpgW//qiwxf0nWXUWGJSL3UQ==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm64]
-        os: [openharmony]
-
-    '@oxc-parser/binding-openharmony-arm64@0.141.0':
-        resolution:
-            {
-                integrity: sha512-cVgDM7n8QziQqOaP5hNgUYfMG7S/ZeuPxFWXnnHRv7rh025COk0rfQ6eEdKG3j/GaUuyvNZN4ifF1J8KmuXLLA==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm64]
-        os: [openharmony]
-
-    '@oxc-parser/binding-wasm32-wasi@0.127.0':
-        resolution:
-            {
-                integrity: sha512-T6KVD7rhLzFlwGRXMnxUFfkCZD8FHnb968wVXW1mXzgRFc5RNXOBY2mPPDZ77x5Ln76ltLMgtPg0cOkU1NSrEQ==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [wasm32]
-
-    '@oxc-parser/binding-wasm32-wasi@0.141.0':
-        resolution:
-            {
-                integrity: sha512-HggH++Fkn3OilBn+bs3jpgIFQa34oMAyUUHy0vpGum+gt1Eb5nyLc8dNU/RAPSw6lsLrx7ncKtHSZE+3Sp0l2g==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [wasm32]
-
-    '@oxc-parser/binding-win32-arm64-msvc@0.127.0':
-        resolution:
-            {
-                integrity: sha512-Ujvw4X+LD1CCGULcsQcvb4YNVoBGqt+JHgNNzGGaCImELiZLk477ifUH53gIbE7EKd933NdTi25JWEr9K2HwXw==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm64]
-        os: [win32]
-
-    '@oxc-parser/binding-win32-arm64-msvc@0.141.0':
-        resolution:
-            {
-                integrity: sha512-KLSEH9GwgbrqbJOjtGHt9STw96s+78yDzp7IDN8Lno+7Ut9sNBfZ4jYZIz4mD50qmWUjoOI7i9I6UENbhNbMZQ==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm64]
-        os: [win32]
-
-    '@oxc-parser/binding-win32-ia32-msvc@0.127.0':
-        resolution:
-            {
-                integrity: sha512-0cwxKO7KHQQQfo4Uf4B2SQrhgm+cJaP9OvFFhx52Tkg4bezsacu83GB2/In5bC415Ueeym+kXdnge/57rbSfTw==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [ia32]
-        os: [win32]
-
-    '@oxc-parser/binding-win32-ia32-msvc@0.141.0':
-        resolution:
-            {
-                integrity: sha512-9UVWUOOCI/1YkiSSNjg2zyBJYM9E/t1A/8GNobd48JDn/fQ6mzxcVO3H08jb3rAaW/B1VBf8eCORTvSsO9T08g==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [ia32]
-        os: [win32]
-
-    '@oxc-parser/binding-win32-x64-msvc@0.127.0':
-        resolution:
-            {
-                integrity: sha512-rOrnSQSCbhI2kowr9XxE7m9a8oQXnBHjnS6j95LxxAnEZ0+Fz20WlRXG4ondQb+ejjt2KOsa65sE6++L6kUd+w==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [x64]
-        os: [win32]
-
-    '@oxc-parser/binding-win32-x64-msvc@0.141.0':
-        resolution:
-            {
-                integrity: sha512-HI/wsvbWT5RHHw5c37D0fEgeTd8/1Q4OJs5jUmEBc17VZFG6SsCIe4barq7NsAPPks/JW+3ayi3Rp+PQI5h4Kg==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [x64]
-        os: [win32]
-
-    '@oxc-project/runtime@0.141.0':
-        resolution:
-            {
-                integrity: sha512-Z/6jQ0dyvE2fVjMUO7GoD4h+3q0G4lI4BWQNjaPhC4RPxaS4hF1b7/QYKB/Tl+KAQwqqKgMF54ukR/VvV5FILg==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-
-    '@oxc-project/types@0.127.0':
-        resolution:
-            {
-                integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==,
-            }
-
-    '@oxc-project/types@0.141.0':
-        resolution:
-            {
-                integrity: sha512-S4as7z0j0xQkXcJlyY5ehntwK8/wRkQb9Cyqw+J/N2rkWGQGK0SxD6X6DhQTc7qsxVTBxXbxZtBJh3mr3PtIzQ==,
-            }
-
-    '@oxc-project/types@0.142.0':
-        resolution:
-            {
-                integrity: sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ==,
-            }
-
-    '@oxc-resolver/binding-android-arm-eabi@11.24.2':
-        resolution:
-            {
-                integrity: sha512-y09e0L0SRI2OA2tUIrjBgoV3eH5hvUKXNkJqXmNo5V2WxIjyC7I7aJfRLMEVpA8yi95f90gFDvO0VMgrDw+vwA==,
-            }
-        cpu: [arm]
-        os: [android]
-
-    '@oxc-resolver/binding-android-arm64@11.24.2':
-        resolution:
-            {
-                integrity: sha512-cl4icWaZFnLdg8m6qtnh5rBMuGbxc/ptStFHLeCNwr+2cZjkjNwQu/jYRS0CHlnPecOJMpuS5M6/BH+0J/YkEg==,
-            }
-        cpu: [arm64]
-        os: [android]
-
-    '@oxc-resolver/binding-darwin-arm64@11.24.2':
-        resolution:
-            {
-                integrity: sha512-At29QEMF6HajbQvgY8K6OXnHD1x9rad74xBEfmCB6ZqCGsdq75aK7tOYcTbOanMy8qdIBrfL3SMr3p/lfSlb9w==,
-            }
-        cpu: [arm64]
-        os: [darwin]
-
-    '@oxc-resolver/binding-darwin-x64@11.24.2':
-        resolution:
-            {
-                integrity: sha512-A5Kqr1EUj4oIL5CF4WRssq/o5P0Y11cwoFouMRmQ7YnC/A8V93nv1nb7aSU8HwcgmXropjLNkVTl4MN87cu28Q==,
-            }
-        cpu: [x64]
-        os: [darwin]
-
-    '@oxc-resolver/binding-freebsd-x64@11.24.2':
-        resolution:
-            {
-                integrity: sha512-R5xkRBRRz7ceH/P5Jrc6G7FmdUdgpLYyESFAUDVTNQ9K0sGPxcp4ljiwEwEqsvNcQ4sYbMRrWcHHBCu7ksAJVw==,
-            }
-        cpu: [x64]
-        os: [freebsd]
-
-    '@oxc-resolver/binding-linux-arm-gnueabihf@11.24.2':
-        resolution:
-            {
-                integrity: sha512-k/RuYL4L/R58IBn3wT5ma3Wh4k62bp1eYCFRWCmMsasUOqL+H6sW0VGFadEzKWXFFlz+2uIMoeMk9ySSZJHgbg==,
-            }
-        cpu: [arm]
-        os: [linux]
-
-    '@oxc-resolver/binding-linux-arm-musleabihf@11.24.2':
-        resolution:
-            {
-                integrity: sha512-bnHAak3ujYfH5pKk4NieFNbvYvernfoQDgwLddbZ3OtMYrem87/qjlA+u+aKG0oZcqSLGCful/6/CEA+aeAgaA==,
-            }
-        cpu: [arm]
-        os: [linux]
-
-    '@oxc-resolver/binding-linux-arm64-gnu@11.24.2':
-        resolution:
-            {
-                integrity: sha512-vDT3KHgzYp47gmtNOqL2VNhCyl5Zv643eyxm//A68J8DeUGXrvD1pZFiaT4jSfe+RInfnn1R2yVHye4enx6RnA==,
-            }
-        cpu: [arm64]
-        os: [linux]
-        libc: [glibc]
-
-    '@oxc-resolver/binding-linux-arm64-musl@11.24.2':
-        resolution:
-            {
-                integrity: sha512-+kMlQvbzfyEYtu5FcjE4p+ttBLpKW4d/AsAsuE69BxV6V4twZJeIQZFfD8gh/wqglY0MkPSezWXQH0jBV13MUw==,
-            }
-        cpu: [arm64]
-        os: [linux]
-        libc: [musl]
-
-    '@oxc-resolver/binding-linux-ppc64-gnu@11.24.2':
-        resolution:
-            {
-                integrity: sha512-shjfMhmZ3gq9fv/w7bi3PnZlgOPG+2QAOFf0BJF0EgBSIGZ6PMLN2zbGEblTUYB/NKVDRyYhE2ff3dJ1QqNPkA==,
-            }
-        cpu: [ppc64]
-        os: [linux]
-        libc: [glibc]
-
-    '@oxc-resolver/binding-linux-riscv64-gnu@11.24.2':
-        resolution:
-            {
-                integrity: sha512-zGelwFR5oRo+b69k8Lrzun86DyUHzfKN6cnjbR9l7Z7NIRznOE/2ZvPa1IUKqAL2PzAXOdwkfVqNvO1H2RlpAw==,
-            }
-        cpu: [riscv64]
-        os: [linux]
-        libc: [glibc]
-
-    '@oxc-resolver/binding-linux-riscv64-musl@11.24.2':
-        resolution:
-            {
-                integrity: sha512-qxZ1SWCXJY0eyhAlP6Lmo9F2Nrtx7EkYj9oCgL8apDPCwXwCEDA2U697bbT81JIc2IrVjxO4KX6WU2N+oN9Z4w==,
-            }
-        cpu: [riscv64]
-        os: [linux]
-        libc: [musl]
-
-    '@oxc-resolver/binding-linux-s390x-gnu@11.24.2':
-        resolution:
-            {
-                integrity: sha512-sGCecF3cx2DFlH4t/z7ApnOnXqN48p5p5mlHDEnHTAukQa2P+qMVE4CwyWE9W+q/m3QJ7kKfGrIjax31f44oFQ==,
-            }
-        cpu: [s390x]
-        os: [linux]
-        libc: [glibc]
-
-    '@oxc-resolver/binding-linux-x64-gnu@11.24.2':
-        resolution:
-            {
-                integrity: sha512-k/VlMMcSzMlahb3/fENM4rTlsJ0s3fFROA0KXPBmKggqmTSaE383sl8F3KCOXPLmVsYfW6hCitMhXCEtNeZxxg==,
-            }
-        cpu: [x64]
-        os: [linux]
-        libc: [glibc]
-
-    '@oxc-resolver/binding-linux-x64-musl@11.24.2':
-        resolution:
-            {
-                integrity: sha512-8hbnZyNi97b/8wapYaIF9+t9GmZKBW2vunaOc3h9HGJptH7b7XpvZqOTBSm/MpTjr7H497BlgOaSfLUdhmy2bw==,
-            }
-        cpu: [x64]
-        os: [linux]
-        libc: [musl]
-
-    '@oxc-resolver/binding-openharmony-arm64@11.24.2':
-        resolution:
-            {
-                integrity: sha512-MvyGik3a6pVgZ0t/kWlbmFxFLmXQJwgLsY2eYFHLpy0wGwRbfzeIGgDwQ3kXqE30z+kSXennRkCrT7TUvkptNg==,
-            }
-        cpu: [arm64]
-        os: [openharmony]
-
-    '@oxc-resolver/binding-wasm32-wasi@11.24.2':
-        resolution:
-            {
-                integrity: sha512-vHcssMPwO08RTvj/c0iOBz90attxyG3wQJ0dTcyEQK43LRpcdLWZlV5feBhv6Isn6ahbQIzHbCgfa81+RiML0Q==,
-            }
-        engines: { node: '>=14.0.0' }
-        cpu: [wasm32]
-
-    '@oxc-resolver/binding-win32-arm64-msvc@11.24.2':
-        resolution:
-            {
-                integrity: sha512-uokJqro2iBqkFvJdKQLP7d8/BUmFwESQFVmIJUQKj1Xn1a/LysJoe1vmeECLF5b3jsV8CAL5sEMJXX6SdK9Nhg==,
-            }
-        cpu: [arm64]
-        os: [win32]
-
-    '@oxc-resolver/binding-win32-x64-msvc@11.24.2':
-        resolution:
-            {
-                integrity: sha512-UqGPmo56KDfLlfXFAFIrNflHT8tFxWGEivWg3Zeyp4Uy2NlKN1FGPr6/BxcLGG3+kZ6Wp14g5Uj+n71boqZfiw==,
-            }
-        cpu: [x64]
-        os: [win32]
-
-    '@oxlint/binding-android-arm-eabi@1.76.0':
-        resolution:
-            {
-                integrity: sha512-ZHIE5Zt9AsPDcY4nOlofXt0YfneEeo+QrKMPcPzLf2Z6Q8VtV2W73d7SFJ920WUwyik783u/doKCs3KXdwG+7w==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm]
-        os: [android]
-
-    '@oxlint/binding-android-arm64@1.76.0':
-        resolution:
-            {
-                integrity: sha512-shm/ngQilHK6bs+ElJWa4oHfNj5vL1Gl/iVEJldTQjpr0/67oSgr0KUpbmcnLig5Fo0v/l6j2567A7TOL89ONA==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm64]
-        os: [android]
-
-    '@oxlint/binding-darwin-arm64@1.76.0':
-        resolution:
-            {
-                integrity: sha512-rvJmrAPKSQ9aWJ6wIS6CK2tJjwzfW0ApQH9qokq6sfDvmHwoyIHxHFMq7z7i7GiV6fdE6s8qvBqWKPTu8RmT6Q==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm64]
-        os: [darwin]
-
-    '@oxlint/binding-darwin-x64@1.76.0':
-        resolution:
-            {
-                integrity: sha512-U/zYdb7VYKGY6pA9Vd2rYl9O/HlCylcOlb5PGPvVLtg+oLGsk6H3XGKEMHKyqD3nmmtmlmwb/8SwU2vfSAtvMw==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [x64]
-        os: [darwin]
-
-    '@oxlint/binding-freebsd-x64@1.76.0':
-        resolution:
-            {
-                integrity: sha512-WvKG9CAriuo0XNiFzpXjDngUZcRGFNpaK2kLyMUsnJlShxkT96u+BpJQ3KqdQwGOrvI14L6V8bAwXwAYNNY6Jg==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [x64]
-        os: [freebsd]
-
-    '@oxlint/binding-linux-arm-gnueabihf@1.76.0':
-        resolution:
-            {
-                integrity: sha512-qJ5+RH99TqFRq3UCDxkW0zJJu9c+OAHFY72vGlxZLEpuO+MpKo3POgqb8sYipL9KYm8XY6ofb0HsOuvY6hQNqQ==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm]
-        os: [linux]
-
-    '@oxlint/binding-linux-arm-musleabihf@1.76.0':
-        resolution:
-            {
-                integrity: sha512-PvPCVptkgVARsucgIqFQQcSmJ6xc6GtnVB5bRBekRahTc9eObMtjHfMjy5M+C2tHt5UCMttWM9RuSk/H9NqYeg==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm]
-        os: [linux]
-
-    '@oxlint/binding-linux-arm64-gnu@1.76.0':
-        resolution:
-            {
-                integrity: sha512-3KeFDx8Bu4HPAXbuHZOr/oHvN+QT+JQhMw/NYPz7Z071xLSsG27Jfh9PIQVEY7hk1I+jr43ExqRIeJ6VKk2yLw==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm64]
-        os: [linux]
-        libc: [glibc]
-
-    '@oxlint/binding-linux-arm64-musl@1.76.0':
-        resolution:
-            {
-                integrity: sha512-oPFkkKTgl0K/EIg9fQ8oA3IGcI05/Mq1en04iFa41mmNPT+6KEiByVazTOZZJiHMBBrbsns1YJ2e1Scqwzesjw==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm64]
-        os: [linux]
-        libc: [musl]
-
-    '@oxlint/binding-linux-ppc64-gnu@1.76.0':
-        resolution:
-            {
-                integrity: sha512-gN7yZ0eqflA5Fhf1wvHxGUltIV3FsvmB1zhNMDEK9vSHhc7E6qg9CuPeBgPZab66Tjzq6w6kHAtNEvnTHf4cyw==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [ppc64]
-        os: [linux]
-        libc: [glibc]
-
-    '@oxlint/binding-linux-riscv64-gnu@1.76.0':
-        resolution:
-            {
-                integrity: sha512-S/HqMbn22mQrjtErUxEoS/a55u8kIeXvreIxiJu5G7Le3UecEd6SQZxrDIpuhtgaFnsY/nVra3ytP+pRljDilA==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [riscv64]
-        os: [linux]
-        libc: [glibc]
-
-    '@oxlint/binding-linux-riscv64-musl@1.76.0':
-        resolution:
-            {
-                integrity: sha512-ZIga3097VJZolGZk6SrIAUokIGfRkxRlhiHDUznZptGBfwrhD7pNfD1rzEzsCwvk/1DX0A1bLz+liuNh5QKIVQ==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [riscv64]
-        os: [linux]
-        libc: [musl]
-
-    '@oxlint/binding-linux-s390x-gnu@1.76.0':
-        resolution:
-            {
-                integrity: sha512-ZGiiA7pFzMJSyMWYZTVlPgbTsx+Vl8ihLGMIujPwaslUF7kIPPWAbVmAlTc+9lWDV+DCiB8Ikixu+lSHeOIIWQ==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [s390x]
-        os: [linux]
-        libc: [glibc]
-
-    '@oxlint/binding-linux-x64-gnu@1.76.0':
-        resolution:
-            {
-                integrity: sha512-JLiy5WuvEBFTT6ErIFV35SLzi0R7Iri6MKU6dZbTxfIx8pndbbPs3Mj780nMipBFcPkti+okAPOJ9POKkHFEgg==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [x64]
-        os: [linux]
-        libc: [glibc]
-
-    '@oxlint/binding-linux-x64-musl@1.76.0':
-        resolution:
-            {
-                integrity: sha512-z7lgKQtbo/I1NIe8G5NHLesxJDv0tRSUWTpXKb9Pm3E9nKFKfO4IOSDtFroKgXtOYb0jQbcdH+0wzTyMXVes+A==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [x64]
-        os: [linux]
-        libc: [musl]
-
-    '@oxlint/binding-openharmony-arm64@1.76.0':
-        resolution:
-            {
-                integrity: sha512-JOjKymIpb9QcYfEhZsN6h4V9Ivd474W38cNIBRv6bg2TbIvogbMTH0Mg6YWW9TiRDqfcX+/Hyfsbo5vcSE5guQ==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm64]
-        os: [openharmony]
-
-    '@oxlint/binding-win32-arm64-msvc@1.76.0':
-        resolution:
-            {
-                integrity: sha512-pqDWZiwcmByWUEm1NFUBNiT6aentCcaoMWJv0HbXEmuYermJ4sg8ppVrshubYP2MZ6SHccJJcpr6x469PuDFIw==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm64]
-        os: [win32]
-
-    '@oxlint/binding-win32-ia32-msvc@1.76.0':
-        resolution:
-            {
-                integrity: sha512-Ba0O659kgMv6pwO3z9PdO+K3aMxQRaw9HnG+e6AtOfgwcKFvYilciQYBoUBmxfQvOCKZe1SwjMkuB542NkuDMQ==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [ia32]
-        os: [win32]
-
-    '@oxlint/binding-win32-x64-msvc@1.76.0':
-        resolution:
-            {
-                integrity: sha512-5qcirPHO8nKfkoowEVWtpAoVTcYDy6g0UT0NGic450Qv8J2NrOqg4uQ8QppRP4MDTC7Xx47lbZnmadTH03CGGA==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [x64]
-        os: [win32]
-
-    '@polka/url@1.0.0-next.29':
-        resolution:
-            {
-                integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==,
-            }
-
-    '@rolldown/binding-android-arm64@1.2.1':
-        resolution:
-            {
-                integrity: sha512-02hOeOSryYxVrOIphmLAsqnCJWxwlzFk+pEt/N/i6OgT3lShHO7xGCU5cpgchRDHboAEbSjzgGh+O/u1GswQmA==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm64]
-        os: [android]
-
-    '@rolldown/binding-darwin-arm64@1.2.1':
-        resolution:
-            {
-                integrity: sha512-fMsTOnN0OjFm3CyppWPitKnc8UlliVARUULW6cfU6AIqjdtgmSFWSk9vecHzZduv/yMWIHDlRhM1e8Iff9uAfA==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm64]
-        os: [darwin]
-
-    '@rolldown/binding-darwin-x64@1.2.1':
-        resolution:
-            {
-                integrity: sha512-1wjKdz/XLGKHaTNHjQveQ/B23TKx4ItAqm1JbyVuvNPc4Ze0Fb48s49TAd/2zcplPl8okE/UbTgmlVfwT7eFeQ==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [x64]
-        os: [darwin]
-
-    '@rolldown/binding-freebsd-x64@1.2.1':
-        resolution:
-            {
-                integrity: sha512-Fa0jHR07E7YBN4vOEsbVf2briYNsuOowfLJaXULZM0ldMlaCaj2LJgLMbMe4iacRyZmvR8efFhgR9wKuGclQUg==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [x64]
-        os: [freebsd]
-
-    '@rolldown/binding-linux-arm-gnueabihf@1.2.1':
-        resolution:
-            {
-                integrity: sha512-pzkgu1SSHGgRRyRZ4fbmSgmajbVt+epaLP99NDjFft69v/ypfTi6swBMiVdh2EkQ0OSnHE1lZDM7DRGkyAzUpA==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm]
-        os: [linux]
-
-    '@rolldown/binding-linux-arm64-gnu@1.2.1':
-        resolution:
-            {
-                integrity: sha512-QI5SEDY8cbiYWHx0VO4vIc3UlS6a32vXHjU8Qy/17adEmZIPuByJg13UEvo9c/UCiUkdcVWY83C+b+JrwnNyUg==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm64]
-        os: [linux]
-        libc: [glibc]
-
-    '@rolldown/binding-linux-arm64-musl@1.2.1':
-        resolution:
-            {
-                integrity: sha512-Sm41FyCeXqmYcERoYOCbGIL5hNfd8w9LQ7Y61Bev48HkcjaJqV/iiVOaiDxjVTRMS+QKrZmD8cfPt4uMVnvM+A==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm64]
-        os: [linux]
-        libc: [musl]
-
-    '@rolldown/binding-linux-ppc64-gnu@1.2.1':
-        resolution:
-            {
-                integrity: sha512-2x+WhXTGl9yJYPbltW/BSEPTVz9OIWQyER4N+gJEDWkkn904eRcBzELqh/Hf7K0w/ubGbKNMv0ZC+94QK/IFEg==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [ppc64]
-        os: [linux]
-        libc: [glibc]
-
-    '@rolldown/binding-linux-s390x-gnu@1.2.1':
-        resolution:
-            {
-                integrity: sha512-eEjmQpuRQayHPWWnywaWHkFT3ToPbP3RYy42VVd/B9aBGDA+Ol25EIWHxKQST3IiWJjikCWUF7KtbfqwZrzVwQ==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [s390x]
-        os: [linux]
-        libc: [glibc]
-
-    '@rolldown/binding-linux-x64-gnu@1.2.1':
-        resolution:
-            {
-                integrity: sha512-/Orga1fZYkLc/56jBICcHrKchl8Z2UKdDSr3LG9ToWO1lQ6a4Livk9Xz+9WN91zsz5QR3XQz2NNoSDEvP6qadw==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [x64]
-        os: [linux]
-        libc: [glibc]
-
-    '@rolldown/binding-linux-x64-musl@1.2.1':
-        resolution:
-            {
-                integrity: sha512-xxBJRL+0q0Kce7orznGWLuylHDY65vuARXZRpX+hPdv+DqK2c3NlCsVA98tlWzWNEE7yPqA/1NQ5nnCrj49Y5A==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [x64]
-        os: [linux]
-        libc: [musl]
-
-    '@rolldown/binding-openharmony-arm64@1.2.1':
-        resolution:
-            {
-                integrity: sha512-M6AdXIXw3s+/8XpKMzdGDEXGS1S7kwUsy+rcTIUIOx5Ge4nXKCtAFHFV9YKkXvGcC5WMoTjAteLzlsQROVI0Yw==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm64]
-        os: [openharmony]
-
-    '@rolldown/binding-wasm32-wasi@1.2.1':
-        resolution:
-            {
-                integrity: sha512-/TX0SoRGojHzSAHpfVBbavRVSazg5U3h3Y3VXfcc0cdugq6kxdqw8LPGFiPr+/7gE/60zRcsOY2Vi9b9eT0jww==,
-            }
-        engines: { node: ^20.19.0 || ^22.13.0 || >=23.5.0 }
-
-    '@rolldown/binding-win32-arm64-msvc@1.2.1':
-        resolution:
-            {
-                integrity: sha512-EvRrivJieyHG+AO9lleZWgq+g0+S7oV2C51yuqlcyU/R9net+sI4Pj0F+lUoP2bEr6TWX3SqFaaS0SzfLxSzkw==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [arm64]
-        os: [win32]
-
-    '@rolldown/binding-win32-x64-msvc@1.2.1':
-        resolution:
-            {
-                integrity: sha512-Z4eCmn5QJ/5+azF9knpLWKfVd9aidn0mAe9TpJgvBLId9Ax3t0+JVxBmT25Bv7NBbVW1TZyKjQjQReouMeH5UQ==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        cpu: [x64]
-        os: [win32]
-
-    '@rolldown/plugin-babel@0.2.3':
-        resolution:
-            {
-                integrity: sha512-+zEk16yGlz1F9STiRr6uG9hmIXb6nprjLczV/htGptYuLoCuxb+itZ03RKCEeOhBpDDd1NU7qF6x1VLMUp62bw==,
-            }
-        engines: { node: '>=22.12.0 || ^24.0.0' }
-        peerDependencies:
-            '@babel/core': ^7.29.0 || ^8.0.0-rc.1
-            '@babel/plugin-transform-runtime': ^7.29.0 || ^8.0.0-rc.1
-            '@babel/runtime': ^7.27.0 || ^8.0.0-rc.1
-            rolldown: ^1.0.0-rc.5
-            vite: ^8.0.0
-        peerDependenciesMeta:
-            '@babel/plugin-transform-runtime':
-                optional: true
-            '@babel/runtime':
-                optional: true
-            vite:
-                optional: true
-
-    '@rolldown/pluginutils@1.0.1':
-        resolution:
-            {
-                integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==,
-            }
-
-    '@rollup/rollup-android-arm-eabi@4.62.4':
-        resolution:
-            {
-                integrity: sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==,
-            }
-        cpu: [arm]
-        os: [android]
-
-    '@rollup/rollup-android-arm64@4.62.4':
-        resolution:
-            {
-                integrity: sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==,
-            }
-        cpu: [arm64]
-        os: [android]
-
-    '@rollup/rollup-darwin-arm64@4.62.4':
-        resolution:
-            {
-                integrity: sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==,
-            }
-        cpu: [arm64]
-        os: [darwin]
-
-    '@rollup/rollup-darwin-x64@4.62.4':
-        resolution:
-            {
-                integrity: sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==,
-            }
-        cpu: [x64]
-        os: [darwin]
-
-    '@rollup/rollup-freebsd-arm64@4.62.4':
-        resolution:
-            {
-                integrity: sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==,
-            }
-        cpu: [arm64]
-        os: [freebsd]
-
-    '@rollup/rollup-freebsd-x64@4.62.4':
-        resolution:
-            {
-                integrity: sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==,
-            }
-        cpu: [x64]
-        os: [freebsd]
-
-    '@rollup/rollup-linux-arm-gnueabihf@4.62.4':
-        resolution:
-            {
-                integrity: sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==,
-            }
-        cpu: [arm]
-        os: [linux]
-        libc: [glibc]
-
-    '@rollup/rollup-linux-arm-musleabihf@4.62.4':
-        resolution:
-            {
-                integrity: sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==,
-            }
-        cpu: [arm]
-        os: [linux]
-        libc: [musl]
-
-    '@rollup/rollup-linux-arm64-gnu@4.62.4':
-        resolution:
-            {
-                integrity: sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==,
-            }
-        cpu: [arm64]
-        os: [linux]
-        libc: [glibc]
-
-    '@rollup/rollup-linux-arm64-musl@4.62.4':
-        resolution:
-            {
-                integrity: sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==,
-            }
-        cpu: [arm64]
-        os: [linux]
-        libc: [musl]
-
-    '@rollup/rollup-linux-loong64-gnu@4.62.4':
-        resolution:
-            {
-                integrity: sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==,
-            }
-        cpu: [loong64]
-        os: [linux]
-        libc: [glibc]
-
-    '@rollup/rollup-linux-loong64-musl@4.62.4':
-        resolution:
-            {
-                integrity: sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==,
-            }
-        cpu: [loong64]
-        os: [linux]
-        libc: [musl]
-
-    '@rollup/rollup-linux-ppc64-gnu@4.62.4':
-        resolution:
-            {
-                integrity: sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==,
-            }
-        cpu: [ppc64]
-        os: [linux]
-        libc: [glibc]
-
-    '@rollup/rollup-linux-ppc64-musl@4.62.4':
-        resolution:
-            {
-                integrity: sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==,
-            }
-        cpu: [ppc64]
-        os: [linux]
-        libc: [musl]
-
-    '@rollup/rollup-linux-riscv64-gnu@4.62.4':
-        resolution:
-            {
-                integrity: sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==,
-            }
-        cpu: [riscv64]
-        os: [linux]
-        libc: [glibc]
-
-    '@rollup/rollup-linux-riscv64-musl@4.62.4':
-        resolution:
-            {
-                integrity: sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==,
-            }
-        cpu: [riscv64]
-        os: [linux]
-        libc: [musl]
-
-    '@rollup/rollup-linux-s390x-gnu@4.62.4':
-        resolution:
-            {
-                integrity: sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==,
-            }
-        cpu: [s390x]
-        os: [linux]
-        libc: [glibc]
-
-    '@rollup/rollup-linux-x64-gnu@4.62.4':
-        resolution:
-            {
-                integrity: sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==,
-            }
-        cpu: [x64]
-        os: [linux]
-        libc: [glibc]
-
-    '@rollup/rollup-linux-x64-musl@4.62.4':
-        resolution:
-            {
-                integrity: sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==,
-            }
-        cpu: [x64]
-        os: [linux]
-        libc: [musl]
-
-    '@rollup/rollup-openbsd-x64@4.62.4':
-        resolution:
-            {
-                integrity: sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==,
-            }
-        cpu: [x64]
-        os: [openbsd]
-
-    '@rollup/rollup-openharmony-arm64@4.62.4':
-        resolution:
-            {
-                integrity: sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==,
-            }
-        cpu: [arm64]
-        os: [openharmony]
-
-    '@rollup/rollup-win32-arm64-msvc@4.62.4':
-        resolution:
-            {
-                integrity: sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==,
-            }
-        cpu: [arm64]
-        os: [win32]
-
-    '@rollup/rollup-win32-ia32-msvc@4.62.4':
-        resolution:
-            {
-                integrity: sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==,
-            }
-        cpu: [ia32]
-        os: [win32]
-
-    '@rollup/rollup-win32-x64-gnu@4.62.4':
-        resolution:
-            {
-                integrity: sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==,
-            }
-        cpu: [x64]
-        os: [win32]
-
-    '@rollup/rollup-win32-x64-msvc@4.62.4':
-        resolution:
-            {
-                integrity: sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==,
-            }
-        cpu: [x64]
-        os: [win32]
-
-    '@shikijs/core@3.23.0':
-        resolution:
-            {
-                integrity: sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==,
-            }
-
-    '@shikijs/engine-javascript@3.23.0':
-        resolution:
-            {
-                integrity: sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA==,
-            }
-
-    '@shikijs/engine-oniguruma@3.23.0':
-        resolution:
-            {
-                integrity: sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==,
-            }
-
-    '@shikijs/langs@3.23.0':
-        resolution:
-            {
-                integrity: sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==,
-            }
-
-    '@shikijs/themes@3.23.0':
-        resolution:
-            {
-                integrity: sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==,
-            }
-
-    '@shikijs/types@3.23.0':
-        resolution:
-            {
-                integrity: sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==,
-            }
-
-    '@shikijs/vscode-textmate@10.0.2':
-        resolution:
-            {
-                integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==,
-            }
-
-    '@standard-schema/spec@1.1.0':
-        resolution:
-            {
-                integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==,
-            }
-
-    '@standard-schema/utils@0.3.0':
-        resolution:
-            {
-                integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==,
-            }
-
-    '@stardazed/streams-compression@1.0.0':
-        resolution:
-            {
-                integrity: sha512-SQCiwxdIVJ5xxUBYptN+fc+tJpSDbxQuJ0+3u2SmHjIzr6JIRZ28AVFtFnGy6x6j3UBlaLx73w9rC6UAFxnd1g==,
-            }
-
-    '@stardazed/zlib@1.0.1':
-        resolution:
-            {
-                integrity: sha512-MS6PCYiRNJ32c69+3NPyL+bu7LpiFDvMcBXnlhQnF8CKMG0R/xRVCCo422NPkQ0+Cox3xKpk5Lc1LfWFS4b3cw==,
-            }
-
-    '@storybook/addon-a11y@10.5.5':
-        resolution:
-            {
-                integrity: sha512-nsMnSRe7pzepXIkUUqI/rL7sp8juXOluyypU4Dz0UuYHhw/cKaxfzuO+3WJN5EtEr/gcnKYb4awxH/duPGavUw==,
-            }
-        peerDependencies:
-            storybook: ^10.5.5
-
-    '@storybook/addon-docs@10.5.5':
-        resolution:
-            {
-                integrity: sha512-0YpKlimS4XE0kQ8Maa5coeefQxdyDrBHg1wOP3WTPuBe4FolFSCDveR0ge2+vuUBk+fZfn2+l+3Q2jmAWaRGDg==,
-            }
-        peerDependencies:
-            '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-            storybook: ^10.5.5
-        peerDependenciesMeta:
-            '@types/react':
-                optional: true
-
-    '@storybook/addon-vitest@10.5.5':
-        resolution:
-            {
-                integrity: sha512-Ymq9ErkSkYiIDuqpJ2+hE5GCQ5J6TCLOWhutqArvwaeAO+HAibM82XNExpJ1/kvPqk9y961GDPkv2W15I88JIw==,
-            }
-        peerDependencies:
-            '@vitest/browser': ^3.0.0 || ^4.0.0
-            '@vitest/browser-playwright': ^4.0.0
-            '@vitest/runner': ^3.0.0 || ^4.0.0
-            storybook: ^10.5.5
-            vitest: ^3.0.0 || ^4.0.0
-        peerDependenciesMeta:
-            '@vitest/browser':
-                optional: true
-            '@vitest/browser-playwright':
-                optional: true
-            '@vitest/runner':
-                optional: true
-            vitest:
-                optional: true
-
-    '@storybook/builder-vite@10.5.5':
-        resolution:
-            {
-                integrity: sha512-dQoJ7gUl8y0z5rV9cE0mz6qTBNmN9R4GOLIZk98rJ8CwduNJOb9eGZXusDzzvnYcp8TnNkqDtyx4tXQSUDInPQ==,
-            }
-        peerDependencies:
-            storybook: ^10.5.5
-            vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
-
-    '@storybook/csf-plugin@10.5.5':
-        resolution:
-            {
-                integrity: sha512-/euibhRFqklYCZqUseokojmfYcQpXshVY2QmA1qCuxMz9SzVFD3iSTw+aFLTxpsJGGdcZJk8fnm/rEthLzZ9jA==,
-            }
-        peerDependencies:
-            esbuild: '*'
-            rollup: '*'
-            storybook: ^10.5.5
-            vite: '*'
-            webpack: '*'
-        peerDependenciesMeta:
-            esbuild:
-                optional: true
-            rollup:
-                optional: true
-            vite:
-                optional: true
-            webpack:
-                optional: true
-
-    '@storybook/global@5.0.0':
-        resolution:
-            {
-                integrity: sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ==,
-            }
-
-    '@storybook/icons@2.1.0':
-        resolution:
-            {
-                integrity: sha512-Fxh9vYpX9bQqFeHRiY8h2ApeRGDzRSMLwJwNZ/AIRqnyOKHxRKL+yFe+ctEkVJmuptRE9u1Hrn8ZZNHyfDKKNg==,
-            }
-        peerDependencies:
-            react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
-    '@storybook/react-dom-shim@10.5.5':
-        resolution:
-            {
-                integrity: sha512-PIk7N3LLrZIxfNxmkvmQN1d5UQ70XEedT8n0GhBiXnM6XL09xPGB8n8TZXeJBRYluKhDQcAyQeT0/OZmcDVQJg==,
-            }
-        peerDependencies:
-            '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-            '@types/react-dom': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-            react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-            react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-            storybook: ^10.5.5
-        peerDependenciesMeta:
-            '@types/react':
-                optional: true
-            '@types/react-dom':
-                optional: true
-
-    '@tailwindcss/node@4.3.3':
-        resolution:
-            {
-                integrity: sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==,
-            }
-
-    '@tailwindcss/oxide-android-arm64@4.3.3':
-        resolution:
-            {
-                integrity: sha512-Y85A2gmPSkl5Ve5qR86GL4HT509cFqQh1aes9p3sSkyTPwt0Pppf3GkwGe4JPACcRYjgJIEhQgM6dBClnr0NYw==,
-            }
-        engines: { node: '>= 20' }
-        cpu: [arm64]
-        os: [android]
-
-    '@tailwindcss/oxide-darwin-arm64@4.3.3':
-        resolution:
-            {
-                integrity: sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw==,
-            }
-        engines: { node: '>= 20' }
-        cpu: [arm64]
-        os: [darwin]
-
-    '@tailwindcss/oxide-darwin-x64@4.3.3':
-        resolution:
-            {
-                integrity: sha512-fAeUqfV5ndhxRwai8cXGzdLvul9utWOmeTkv69unv4ZXixjn61Z+p9lCWdwOwA3TYboG3BwdVuN/RDjhBRl0mw==,
-            }
-        engines: { node: '>= 20' }
-        cpu: [x64]
-        os: [darwin]
-
-    '@tailwindcss/oxide-freebsd-x64@4.3.3':
-        resolution:
-            {
-                integrity: sha512-iyf5bV6+wnAlflVeEy7R25dupxTNECZN5QMI0qNT6eT+EgaGdZcKhGkr5SdoaWiLJ3spLqIY9VCeSGrwmtg4kw==,
-            }
-        engines: { node: '>= 20' }
-        cpu: [x64]
-        os: [freebsd]
-
-    '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.3':
-        resolution:
-            {
-                integrity: sha512-aAYUprJAJQWWbRrPvtjdroZ56Md+JM8pMiopS6xGEwDfLhqj+2ver2p4nU4Mb3CRqcMmNBjo8KkUgcxhkzVQGQ==,
-            }
-        engines: { node: '>= 20' }
-        cpu: [arm]
-        os: [linux]
-
-    '@tailwindcss/oxide-linux-arm64-gnu@4.3.3':
-        resolution:
-            {
-                integrity: sha512-nDxldcEENOxZRzC2uu9jrutZdAAQtb+8WWDCSnWL1zvBk1+FN+x6MtDViPB5AJMfttVCUhehGWus3XBPgatM/w==,
-            }
-        engines: { node: '>= 20' }
-        cpu: [arm64]
-        os: [linux]
-        libc: [glibc]
-
-    '@tailwindcss/oxide-linux-arm64-musl@4.3.3':
-        resolution:
-            {
-                integrity: sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==,
-            }
-        engines: { node: '>= 20' }
-        cpu: [arm64]
-        os: [linux]
-        libc: [musl]
-
-    '@tailwindcss/oxide-linux-x64-gnu@4.3.3':
-        resolution:
-            {
-                integrity: sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==,
-            }
-        engines: { node: '>= 20' }
-        cpu: [x64]
-        os: [linux]
-        libc: [glibc]
-
-    '@tailwindcss/oxide-linux-x64-musl@4.3.3':
-        resolution:
-            {
-                integrity: sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==,
-            }
-        engines: { node: '>= 20' }
-        cpu: [x64]
-        os: [linux]
-        libc: [musl]
-
-    '@tailwindcss/oxide-wasm32-wasi@4.3.3':
-        resolution:
-            {
-                integrity: sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==,
-            }
-        engines: { node: '>=14.0.0' }
-        cpu: [wasm32]
-        bundledDependencies:
-            - '@napi-rs/wasm-runtime'
-            - '@emnapi/core'
-            - '@emnapi/runtime'
-            - '@tybys/wasm-util'
-            - '@emnapi/wasi-threads'
-            - tslib
-
-    '@tailwindcss/oxide-win32-arm64-msvc@4.3.3':
-        resolution:
-            {
-                integrity: sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ==,
-            }
-        engines: { node: '>= 20' }
-        cpu: [arm64]
-        os: [win32]
-
-    '@tailwindcss/oxide-win32-x64-msvc@4.3.3':
-        resolution:
-            {
-                integrity: sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw==,
-            }
-        engines: { node: '>= 20' }
-        cpu: [x64]
-        os: [win32]
-
-    '@tailwindcss/oxide@4.3.3':
-        resolution:
-            {
-                integrity: sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA==,
-            }
-        engines: { node: '>= 20' }
-
-    '@tailwindcss/postcss@4.3.3':
-        resolution:
-            {
-                integrity: sha512-JTSZZGQi1AyKirbLN3azmjVzef92tcX7h+iSqPdaeStyFpGpDlKvvpxeOE8njhbUanbRwr3z8DyzhICWnMtQeg==,
-            }
-
-    '@tailwindcss/vite@4.3.3':
-        resolution:
-            {
-                integrity: sha512-yYU8cogLeSh/ms2jh8Fj7jaba/EWa7Ja6GoUqYZaraEuCI5YS6ms6ObZgjjedm+jm6XZjdNRWBpPP6Z86oOxcw==,
-            }
-        peerDependencies:
-            vite: ^5.2.0 || ^6 || ^7 || ^8
-
-    '@testing-library/dom@10.4.1':
-        resolution:
-            {
-                integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==,
-            }
-        engines: { node: '>=18' }
-
-    '@testing-library/jest-dom@6.9.1':
-        resolution:
-            {
-                integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==,
-            }
-        engines: { node: '>=14', npm: '>=6', yarn: '>=1' }
-
-    '@testing-library/user-event@14.6.1':
-        resolution:
-            {
-                integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==,
-            }
-        engines: { node: '>=12', npm: '>=6' }
-        peerDependencies:
-            '@testing-library/dom': '>=7.21.4'
-
-    '@tybys/wasm-util@0.10.3':
-        resolution:
-            {
-                integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==,
-            }
-
-    '@types/aria-query@5.0.4':
-        resolution:
-            {
-                integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==,
-            }
-
-    '@types/babel__traverse@7.28.0':
-        resolution:
-            {
-                integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==,
-            }
-
-    '@types/chai@5.2.3':
-        resolution:
-            {
-                integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==,
-            }
-
-    '@types/debug@4.1.13':
-        resolution:
-            {
-                integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==,
-            }
-
-    '@types/deep-eql@4.0.2':
-        resolution:
-            {
-                integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==,
-            }
-
-    '@types/estree-jsx@1.0.5':
-        resolution:
-            {
-                integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==,
-            }
-
-    '@types/estree@1.0.9':
-        resolution:
-            {
-                integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==,
-            }
-
-    '@types/hast@3.0.5':
-        resolution:
-            {
-                integrity: sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==,
-            }
-
-    '@types/mdast@4.0.4':
-        resolution:
-            {
-                integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==,
-            }
-
-    '@types/mdx@2.0.14':
-        resolution:
-            {
-                integrity: sha512-T48PeuJtvLosNTPVhfnIp3i/n3a4g4Bad7YCq5k64D4u7NwDrAotikQ+5+sjtUvBmxCMlbo3dVL+C2dP0rWHzg==,
-            }
-
-    '@types/ms@2.1.0':
-        resolution:
-            {
-                integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==,
-            }
-
-    '@types/node@12.20.55':
-        resolution:
-            {
-                integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==,
-            }
-
-    '@types/node@24.13.3':
-        resolution:
-            {
-                integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==,
-            }
-
-    '@types/picomatch@4.0.3':
-        resolution:
-            {
-                integrity: sha512-iG0T6+nYJ9FAPmx9SsUlnwcq1ZVRuCXcVEvWnntoPlrOpwtSTKNDC9uVAxTsC3PUvJ+99n4RpAcNgBbHX3JSnQ==,
-            }
-
-    '@types/react@19.2.18':
-        resolution:
-            {
-                integrity: sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==,
-            }
-
-    '@types/unist@2.0.11':
-        resolution:
-            {
-                integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==,
-            }
-
-    '@types/unist@3.0.3':
-        resolution:
-            {
-                integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==,
-            }
-
-    '@types/whatwg-mimetype@3.0.2':
-        resolution:
-            {
-                integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==,
-            }
-
-    '@types/ws@8.18.1':
-        resolution:
-            {
-                integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==,
-            }
-
-    '@typescript/typescript-aix-ppc64@7.0.2':
-        resolution:
-            {
-                integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==,
-            }
-        engines: { node: '>=16.20.0' }
-        cpu: [ppc64]
-        os: [aix]
-
-    '@typescript/typescript-darwin-arm64@7.0.2':
-        resolution:
-            {
-                integrity: sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==,
-            }
-        engines: { node: '>=16.20.0' }
-        cpu: [arm64]
-        os: [darwin]
-
-    '@typescript/typescript-darwin-x64@7.0.2':
-        resolution:
-            {
-                integrity: sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==,
-            }
-        engines: { node: '>=16.20.0' }
-        cpu: [x64]
-        os: [darwin]
-
-    '@typescript/typescript-freebsd-arm64@7.0.2':
-        resolution:
-            {
-                integrity: sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==,
-            }
-        engines: { node: '>=16.20.0' }
-        cpu: [arm64]
-        os: [freebsd]
-
-    '@typescript/typescript-freebsd-x64@7.0.2':
-        resolution:
-            {
-                integrity: sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==,
-            }
-        engines: { node: '>=16.20.0' }
-        cpu: [x64]
-        os: [freebsd]
-
-    '@typescript/typescript-linux-arm64@7.0.2':
-        resolution:
-            {
-                integrity: sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==,
-            }
-        engines: { node: '>=16.20.0' }
-        cpu: [arm64]
-        os: [linux]
-
-    '@typescript/typescript-linux-arm@7.0.2':
-        resolution:
-            {
-                integrity: sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==,
-            }
-        engines: { node: '>=16.20.0' }
-        cpu: [arm]
-        os: [linux]
-
-    '@typescript/typescript-linux-loong64@7.0.2':
-        resolution:
-            {
-                integrity: sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==,
-            }
-        engines: { node: '>=16.20.0' }
-        cpu: [loong64]
-        os: [linux]
-
-    '@typescript/typescript-linux-mips64el@7.0.2':
-        resolution:
-            {
-                integrity: sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==,
-            }
-        engines: { node: '>=16.20.0' }
-        cpu: [mips64el]
-        os: [linux]
-
-    '@typescript/typescript-linux-ppc64@7.0.2':
-        resolution:
-            {
-                integrity: sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==,
-            }
-        engines: { node: '>=16.20.0' }
-        cpu: [ppc64]
-        os: [linux]
-
-    '@typescript/typescript-linux-riscv64@7.0.2':
-        resolution:
-            {
-                integrity: sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==,
-            }
-        engines: { node: '>=16.20.0' }
-        cpu: [riscv64]
-        os: [linux]
-
-    '@typescript/typescript-linux-s390x@7.0.2':
-        resolution:
-            {
-                integrity: sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==,
-            }
-        engines: { node: '>=16.20.0' }
-        cpu: [s390x]
-        os: [linux]
-
-    '@typescript/typescript-linux-x64@7.0.2':
-        resolution:
-            {
-                integrity: sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==,
-            }
-        engines: { node: '>=16.20.0' }
-        cpu: [x64]
-        os: [linux]
-
-    '@typescript/typescript-netbsd-arm64@7.0.2':
-        resolution:
-            {
-                integrity: sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==,
-            }
-        engines: { node: '>=16.20.0' }
-        cpu: [arm64]
-        os: [netbsd]
-
-    '@typescript/typescript-netbsd-x64@7.0.2':
-        resolution:
-            {
-                integrity: sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==,
-            }
-        engines: { node: '>=16.20.0' }
-        cpu: [x64]
-        os: [netbsd]
-
-    '@typescript/typescript-openbsd-arm64@7.0.2':
-        resolution:
-            {
-                integrity: sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==,
-            }
-        engines: { node: '>=16.20.0' }
-        cpu: [arm64]
-        os: [openbsd]
-
-    '@typescript/typescript-openbsd-x64@7.0.2':
-        resolution:
-            {
-                integrity: sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==,
-            }
-        engines: { node: '>=16.20.0' }
-        cpu: [x64]
-        os: [openbsd]
-
-    '@typescript/typescript-sunos-x64@7.0.2':
-        resolution:
-            {
-                integrity: sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==,
-            }
-        engines: { node: '>=16.20.0' }
-        cpu: [x64]
-        os: [sunos]
-
-    '@typescript/typescript-win32-arm64@7.0.2':
-        resolution:
-            {
-                integrity: sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==,
-            }
-        engines: { node: '>=16.20.0' }
-        cpu: [arm64]
-        os: [win32]
-
-    '@typescript/typescript-win32-x64@7.0.2':
-        resolution:
-            {
-                integrity: sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==,
-            }
-        engines: { node: '>=16.20.0' }
-        cpu: [x64]
-        os: [win32]
-
-    '@ungap/structured-clone@1.3.3':
-        resolution:
-            {
-                integrity: sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==,
-            }
-
-    '@vitest/browser-playwright@4.1.10':
-        resolution:
-            {
-                integrity: sha512-nMoXGEiRpT7m3W7NsbvrM2aKNwiNHZf+zEpUCvMteGjZFvfT96Q9fh7QyB98dvDWXiKvrLxA7bJ1mCOOv+JQPw==,
-            }
-        peerDependencies:
-            playwright: '*'
-            vitest: 4.1.10
-
-    '@vitest/browser@4.1.10':
-        resolution:
-            {
-                integrity: sha512-UDwuWGwXj646CBx/bQHOaJSX7np0I8JL/UKQYa1e4QrVHH8VdWtx8eaOuf8sy0ShwDgR6NjJAsp5eF6vjF6qng==,
-            }
-        peerDependencies:
-            vitest: 4.1.10
-
-    '@vitest/coverage-istanbul@4.1.10':
-        resolution:
-            {
-                integrity: sha512-AyNJ5pQRFqCX7pwB9PSTmoVKPaZ4H5IEVJfJsT+q1DYkXvZMEFYgJlyk5sfStmt9rVYRyYYRRsuBeImCOc39ww==,
-            }
-        peerDependencies:
-            vitest: 4.1.10
-
-    '@vitest/coverage-v8@4.1.10':
-        resolution:
-            {
-                integrity: sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==,
-            }
-        peerDependencies:
-            '@vitest/browser': 4.1.10
-            vitest: 4.1.10
-        peerDependenciesMeta:
-            '@vitest/browser':
-                optional: true
-
-    '@vitest/expect@3.2.4':
-        resolution:
-            {
-                integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==,
-            }
-
-    '@vitest/expect@4.1.10':
-        resolution:
-            {
-                integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==,
-            }
-
-    '@vitest/mocker@4.1.10':
-        resolution:
-            {
-                integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==,
-            }
-        peerDependencies:
-            msw: ^2.4.9
-            vite: ^6.0.0 || ^7.0.0 || ^8.0.0
-        peerDependenciesMeta:
-            msw:
-                optional: true
-            vite:
-                optional: true
-
-    '@vitest/pretty-format@3.2.4':
-        resolution:
-            {
-                integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==,
-            }
-
-    '@vitest/pretty-format@4.1.10':
-        resolution:
-            {
-                integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==,
-            }
-
-    '@vitest/runner@4.1.10':
-        resolution:
-            {
-                integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==,
-            }
-
-    '@vitest/snapshot@4.1.10':
-        resolution:
-            {
-                integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==,
-            }
-
-    '@vitest/spy@3.2.4':
-        resolution:
-            {
-                integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==,
-            }
-
-    '@vitest/spy@4.1.10':
-        resolution:
-            {
-                integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==,
-            }
-
-    '@vitest/utils@3.2.4':
-        resolution:
-            {
-                integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==,
-            }
-
-    '@vitest/utils@4.1.10':
-        resolution:
-            {
-                integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==,
-            }
-
-    '@webcontainer/env@1.1.1':
-        resolution:
-            {
-                integrity: sha512-6aN99yL695Hi9SuIk1oC88l9o0gmxL1nGWWQ/kNy81HigJ0FoaoTXpytCj6ItzgyCEwA9kF1wixsTuv5cjsgng==,
-            }
-
-    '@worker-tools/html-rewriter@0.1.0-pre.19':
-        resolution:
-            {
-                integrity: sha512-IUbEZwvSdp8vtaB1LAZ/sBRJGNycd9a8cbkqO05rMEPm5MC59Sb+wiGCWaaRXrwQLDAyWeod4QC/q0TuSUI5EA==,
-            }
-
-    '@worker-tools/resolvable-promise@0.2.0-pre.6':
-        resolution:
-            {
-                integrity: sha512-+5RcuruCLB/P3FYYb376RgyImXaq9BBQoOskUbgPyNK3O0AXPakrXUj1EELv+lcnUSdFws/ufdrrWODLJyoTmg==,
-            }
-
-    acorn-jsx@5.3.2:
-        resolution:
-            {
-                integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==,
-            }
-        peerDependencies:
-            acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
-
-    acorn@8.18.0:
-        resolution:
-            {
-                integrity: sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==,
-            }
-        engines: { node: '>=0.4.0' }
-        hasBin: true
-
-    ansi-colors@4.1.3:
-        resolution:
-            {
-                integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==,
-            }
-        engines: { node: '>=6' }
-
-    ansi-regex@5.0.1:
-        resolution:
-            {
-                integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==,
-            }
-        engines: { node: '>=8' }
-
-    ansi-regex@6.2.2:
-        resolution:
-            {
-                integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==,
-            }
-        engines: { node: '>=12' }
-
-    ansi-styles@5.2.0:
-        resolution:
-            {
-                integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==,
-            }
-        engines: { node: '>=10' }
-
-    any-promise@1.3.0:
-        resolution:
-            {
-                integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==,
-            }
-
-    anymatch@3.1.3:
-        resolution:
-            {
-                integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==,
-            }
-        engines: { node: '>= 8' }
-
-    argparse@1.0.10:
-        resolution:
-            {
-                integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==,
-            }
-
-    argparse@2.0.1:
-        resolution:
-            {
-                integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==,
-            }
-
-    aria-query@5.3.0:
-        resolution:
-            {
-                integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==,
-            }
-
-    aria-query@5.3.2:
-        resolution:
-            {
-                integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==,
-            }
-        engines: { node: '>= 0.4' }
-
-    array-union@2.1.0:
-        resolution:
-            {
-                integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==,
-            }
-        engines: { node: '>=8' }
-
-    assertion-error@2.0.1:
-        resolution:
-            {
-                integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==,
-            }
-        engines: { node: '>=12' }
-
-    ast-types@0.16.1:
-        resolution:
-            {
-                integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==,
-            }
-        engines: { node: '>=4' }
-
-    ast-v8-to-istanbul@1.0.5:
-        resolution:
-            {
-                integrity: sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==,
-            }
-
-    astring@1.9.0:
-        resolution:
-            {
-                integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==,
-            }
-        hasBin: true
-
-    atomically@2.1.1:
-        resolution:
-            {
-                integrity: sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ==,
-            }
-
-    autoprefixer@10.5.4:
-        resolution:
-            {
-                integrity: sha512-MaU0U/za7N3r6brxD4YB/l4NSrFzLPlANv6wEuQVaIPlD3L4W9rFcQPbL/EilY9BHhHvhfcz3gInDLrEtWT4EA==,
-            }
-        engines: { node: ^10 || ^12 || >=14 }
-        hasBin: true
-        peerDependencies:
-            postcss: ^8.1.0
-
-    axe-core@4.12.1:
-        resolution:
-            {
-                integrity: sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==,
-            }
-        engines: { node: '>=4' }
-
-    bail@2.0.2:
-        resolution:
-            {
-                integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==,
-            }
-
-    baseline-browser-mapping@2.11.10:
-        resolution:
-            {
-                integrity: sha512-35JEvJ5/KKlbCHjMCsONI2w6HE88STjVdHk+C7d8LtcFxUjZR1KeLP9izofn2qs0KUxX5r4z73bwH/rd+JHacw==,
-            }
-        engines: { node: '>=6.0.0' }
-        hasBin: true
-
-    better-commits@1.24.0:
-        resolution:
-            {
-                integrity: sha512-Vkr/gLvNSLyfRmS4N/9EVc65vImcqNZe42DudlPBXsfNqW8RhYMAzuUjAgupunDpFloYkkoChkKQnQSuotcqkA==,
-            }
-        engines: { node: '>=20.19.0' }
-        hasBin: true
-
-    better-path-resolve@1.0.0:
-        resolution:
-            {
-                integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==,
-            }
-        engines: { node: '>=4' }
-
-    binary-extensions@2.3.0:
-        resolution:
-            {
-                integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==,
-            }
-        engines: { node: '>=8' }
-
-    boolbase@1.0.0:
-        resolution:
-            {
-                integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==,
-            }
-
-    braces@3.0.3:
-        resolution:
-            {
-                integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==,
-            }
-        engines: { node: '>=8' }
-
-    browserslist@4.28.7:
-        resolution:
-            {
-                integrity: sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==,
-            }
-        engines: { node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7 }
-        hasBin: true
-
-    buffer-image-size@0.6.4:
-        resolution:
-            {
-                integrity: sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==,
-            }
-        engines: { node: '>=4.0' }
-
-    bun-types@1.3.14:
-        resolution:
-            {
-                integrity: sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ==,
-            }
-
-    bundle-name@4.1.0:
-        resolution:
-            {
-                integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==,
-            }
-        engines: { node: '>=18' }
-
-    bundle-require@5.1.0:
-        resolution:
-            {
-                integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==,
-            }
-        engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
-        peerDependencies:
-            esbuild: '>=0.18'
-
-    cac@6.7.14:
-        resolution:
-            {
-                integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==,
-            }
-        engines: { node: '>=8' }
-
-    caniuse-api@4.0.0:
-        resolution:
-            {
-                integrity: sha512-B0hQ1OLyJuHTQSOWXvwibWqM6DCoqJdvBA6X1S/53bd4XU7LJ1yurIPlrsouol3mw1jh9pGI4ivubSpmJeIqCA==,
-            }
-
-    caniuse-lite@1.0.30001806:
-        resolution:
-            {
-                integrity: sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==,
-            }
-
-    ccount@2.0.1:
-        resolution:
-            {
-                integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==,
-            }
-
-    chai@5.3.3:
-        resolution:
-            {
-                integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==,
-            }
-        engines: { node: '>=18' }
-
-    chai@6.2.2:
-        resolution:
-            {
-                integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==,
-            }
-        engines: { node: '>=18' }
-
-    character-entities-html4@2.1.0:
-        resolution:
-            {
-                integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==,
-            }
-
-    character-entities-legacy@3.0.0:
-        resolution:
-            {
-                integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==,
-            }
-
-    character-entities@2.0.2:
-        resolution:
-            {
-                integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==,
-            }
-
-    character-reference-invalid@2.0.1:
-        resolution:
-            {
-                integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==,
-            }
-
-    chardet@2.2.0:
-        resolution:
-            {
-                integrity: sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==,
-            }
-
-    check-error@2.1.3:
-        resolution:
-            {
-                integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==,
-            }
-        engines: { node: '>= 16' }
-
-    chokidar@3.6.0:
-        resolution:
-            {
-                integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==,
-            }
-        engines: { node: '>= 8.10.0' }
-
-    chokidar@4.0.3:
-        resolution:
-            {
-                integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==,
-            }
-        engines: { node: '>= 14.16.0' }
-
-    chokidar@5.0.0:
-        resolution:
-            {
-                integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==,
-            }
-        engines: { node: '>= 20.19.0' }
-
-    chromatic@16.10.0:
-        resolution:
-            {
-                integrity: sha512-nFsztmnu7rFiGafUJgXvLUNpqmRylz92eNvzBoJNTKKQj4EQUyxznwnfpf1dTs7hXtWD8JwcH92jADydaHA1sw==,
-            }
-        hasBin: true
-        peerDependencies:
-            '@chromatic-com/cypress': ^0.*.* || ^1.0.0
-            '@chromatic-com/playwright': ^0.*.* || ^1.0.0
-            '@chromatic-com/vitest': ^0.*.* || ^1.0.0
-        peerDependenciesMeta:
-            '@chromatic-com/cypress':
-                optional: true
-            '@chromatic-com/playwright':
-                optional: true
-            '@chromatic-com/vitest':
-                optional: true
-
-    citty@0.1.6:
-        resolution:
-            {
-                integrity: sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==,
-            }
-
-    citty@0.2.2:
-        resolution:
-            {
-                integrity: sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==,
-            }
-
-    collapse-white-space@2.1.0:
-        resolution:
-            {
-                integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==,
-            }
-
-    comma-separated-tokens@2.0.3:
-        resolution:
-            {
-                integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==,
-            }
-
-    commander@11.1.0:
-        resolution:
-            {
-                integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==,
-            }
-        engines: { node: '>=16' }
-
-    commander@4.1.1:
-        resolution:
-            {
-                integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==,
-            }
-        engines: { node: '>= 6' }
-
-    commander@9.5.0:
-        resolution:
-            {
-                integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==,
-            }
-        engines: { node: ^12.20.0 || >=14 }
-
-    confbox@0.1.8:
-        resolution:
-            {
-                integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==,
-            }
-
-    configstore@8.0.0:
-        resolution:
-            {
-                integrity: sha512-U51WPZg+o6FDFhBCV6yYFEspGMCoHvCgJSGFw9AwsW2u75gYBPoDlYca5XfDs4TdMUu3/y0R6FFdvvgyH31mKQ==,
-            }
-        engines: { node: '>=20' }
-
-    consola@3.4.2:
-        resolution:
-            {
-                integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==,
-            }
-        engines: { node: ^14.18.0 || >=16.10.0 }
-
-    convert-source-map@2.0.0:
-        resolution:
-            {
-                integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==,
-            }
-
-    cross-spawn@7.0.6:
-        resolution:
-            {
-                integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==,
-            }
-        engines: { node: '>= 8' }
-
-    crossws@0.4.10:
-        resolution:
-            {
-                integrity: sha512-pz3oubH/dt12KjqsUB0IuXW4nwRDQ583iDsP4555Cpdqx0NoU7pGlWBcayyFI8f/l/idRpgjMEfwuOxSWJYlIA==,
-            }
-        peerDependencies:
-            srvx: '>=0.11.5'
-        peerDependenciesMeta:
-            srvx:
-                optional: true
-
-    css-select@5.2.2:
-        resolution:
-            {
-                integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==,
-            }
-
-    css-tree@2.2.1:
-        resolution:
-            {
-                integrity: sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==,
-            }
-        engines: { node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0, npm: '>=7.0.0' }
-
-    css-tree@3.2.1:
-        resolution:
-            {
-                integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==,
-            }
-        engines: { node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0 }
-
-    css-what@6.2.2:
-        resolution:
-            {
-                integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==,
-            }
-        engines: { node: '>= 6' }
-
-    css.escape@1.5.1:
-        resolution:
-            {
-                integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==,
-            }
-
-    cssesc@3.0.0:
-        resolution:
-            {
-                integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==,
-            }
-        engines: { node: '>=4' }
-        hasBin: true
-
-    cssnano-preset-default@8.0.2:
-        resolution:
-            {
-                integrity: sha512-+jQAqIKCqMmBjZs7741XkilU93ITZ/EW8gjAkMmujdCzfDkfjrDBv2VqkSu29Fzeig/0rZ3S9IAwfPLlmXEUfQ==,
-            }
-        engines: { node: ^22.11.0 || ^24.11.0 || >=26.0 }
-        peerDependencies:
-            postcss: ^8.5.15
-
-    cssnano-utils@6.0.1:
-        resolution:
-            {
-                integrity: sha512-zk65GIxA8tCjqVk7nTm1mE+ZKxtnxAvU5JSUaBLXbAr3ZF7IOvz3fbPOnEDvZKhnS7GOIitXTS5BgehLzNoc8Q==,
-            }
-        engines: { node: ^22.11.0 || ^24.11.0 || >=26.0 }
-        peerDependencies:
-            postcss: ^8.5.15
-
-    cssnano@8.0.2:
-        resolution:
-            {
-                integrity: sha512-K+a76gA1v0/CsYgcsE95HGGyIuPKxpQSetwSwz4nHEM8fFXqSkzq2JzEXFL8v5+CCjxzVVVhPcTK3Oo8SaF/xA==,
-            }
-        engines: { node: ^22.11.0 || ^24.11.0 || >=26.0 }
-        peerDependencies:
-            postcss: ^8.5.15
-
-    csso@5.0.5:
-        resolution:
-            {
-                integrity: sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==,
-            }
-        engines: { node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0, npm: '>=7.0.0' }
-
-    csstype@3.2.3:
-        resolution:
-            {
-                integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==,
-            }
-
-    dataloader@1.4.0:
-        resolution:
-            {
-                integrity: sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==,
-            }
-
-    db0@0.3.4:
-        resolution:
-            {
-                integrity: sha512-RiXXi4WaNzPTHEOu8UPQKMooIbqOEyqA1t7Z6MsdxSCeb8iUC9ko3LcmsLmeUt2SM5bctfArZKkRQggKZz7JNw==,
-            }
-        peerDependencies:
-            '@electric-sql/pglite': '*'
-            '@libsql/client': '*'
-            better-sqlite3: '*'
-            drizzle-orm: '*'
-            mysql2: '*'
-            sqlite3: '*'
-        peerDependenciesMeta:
-            '@electric-sql/pglite':
-                optional: true
-            '@libsql/client':
-                optional: true
-            better-sqlite3:
-                optional: true
-            drizzle-orm:
-                optional: true
-            mysql2:
-                optional: true
-            sqlite3:
-                optional: true
-
-    debug@4.4.3:
-        resolution:
-            {
-                integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==,
-            }
-        engines: { node: '>=6.0' }
-        peerDependencies:
-            supports-color: '*'
-        peerDependenciesMeta:
-            supports-color:
-                optional: true
-
-    decode-named-character-reference@1.3.0:
-        resolution:
-            {
-                integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==,
-            }
-
-    deep-eql@5.0.2:
-        resolution:
-            {
-                integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==,
-            }
-        engines: { node: '>=6' }
-
-    default-browser-id@5.0.1:
-        resolution:
-            {
-                integrity: sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==,
-            }
-        engines: { node: '>=18' }
-
-    default-browser@5.5.0:
-        resolution:
-            {
-                integrity: sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==,
-            }
-        engines: { node: '>=18' }
-
-    define-lazy-prop@3.0.0:
-        resolution:
-            {
-                integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==,
-            }
-        engines: { node: '>=12' }
-
-    defu@6.1.7:
-        resolution:
-            {
-                integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==,
-            }
-
-    dequal@2.0.3:
-        resolution:
-            {
-                integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==,
-            }
-        engines: { node: '>=6' }
-
-    detect-indent@6.1.0:
-        resolution:
-            {
-                integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==,
-            }
-        engines: { node: '>=8' }
-
-    detect-libc@2.1.2:
-        resolution:
-            {
-                integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==,
-            }
-        engines: { node: '>=8' }
-
-    devlop@1.1.0:
-        resolution:
-            {
-                integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==,
-            }
-
-    dir-glob@3.0.1:
-        resolution:
-            {
-                integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==,
-            }
-        engines: { node: '>=8' }
-
-    dom-accessibility-api@0.5.16:
-        resolution:
-            {
-                integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==,
-            }
-
-    dom-accessibility-api@0.6.3:
-        resolution:
-            {
-                integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==,
-            }
-
-    dom-serializer@2.0.0:
-        resolution:
-            {
-                integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==,
-            }
-
-    domelementtype@2.3.0:
-        resolution:
-            {
-                integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==,
-            }
-
-    domhandler@5.0.3:
-        resolution:
-            {
-                integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==,
-            }
-        engines: { node: '>= 4' }
-
-    domutils@3.2.2:
-        resolution:
-            {
-                integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==,
-            }
-
-    dot-prop@10.2.0:
-        resolution:
-            {
-                integrity: sha512-BTJ9aZYL3vCfZlZOBLy9v8TUqWGQ0pzFnygKwFZt5udj6viBoFIBviKPUoZLDCPn1FoXffv6McQFDenrm5Krfw==,
-            }
-        engines: { node: '>=20' }
-
-    dotenv@8.6.0:
-        resolution:
-            {
-                integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==,
-            }
-        engines: { node: '>=10' }
-
-    ecopages@0.2.0-beta.43:
-        resolution:
-            {
-                integrity: sha512-pnjefjdb6Vs1QMniwfJpoy75bRuktUXmOKLIW38LTLowr0TxBDGSg27tezi7Wrgy62FIENf8/q17OIa7SPs4HA==,
-            }
-        engines: { node: '>=24.0.0' }
-        hasBin: true
-        peerDependencies:
-            bun-types: '*'
-            typescript: ^5
-
-    electron-to-chromium@1.5.399:
-        resolution:
-            {
-                integrity: sha512-lEcqhErbHjXRvd41rnWLpzbyU/IXfIYo7QwaFWmxGeLiLyY2TBCdHnWY88vB+p3ubnihRypDm66panXl7TylLA==,
-            }
-
-    enhanced-resolve@5.24.5:
-        resolution:
-            {
-                integrity: sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==,
-            }
-        engines: { node: '>=10.13.0' }
-
-    enquirer@2.4.1:
-        resolution:
-            {
-                integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==,
-            }
-        engines: { node: '>=8.6' }
-
-    entities@4.5.0:
-        resolution:
-            {
-                integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==,
-            }
-        engines: { node: '>=0.12' }
-
-    entities@6.0.1:
-        resolution:
-            {
-                integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==,
-            }
-        engines: { node: '>=0.12' }
-
-    entities@7.0.1:
-        resolution:
-            {
-                integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==,
-            }
-        engines: { node: '>=0.12' }
-
-    env-runner@0.1.16:
-        resolution:
-            {
-                integrity: sha512-2LRJM4P2KLX6J83QZZrMqvgCDt/D5ea7wPcI3yYiy5cG/9rX5QwdwZFx0D7ktWnjdRyZxYjttGGorb5nFqb1CA==,
-            }
-        hasBin: true
-        peerDependencies:
-            '@netlify/runtime': ^4.1.23
-            '@vercel/queue': '>=0.2.0'
-            miniflare: ^4.20260515.0
-            wrangler: ^4.0.0
-        peerDependenciesMeta:
-            '@netlify/runtime':
-                optional: true
-            '@vercel/queue':
-                optional: true
-            miniflare:
-                optional: true
-            wrangler:
-                optional: true
-
-    es-errors@1.3.0:
-        resolution:
-            {
-                integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==,
-            }
-        engines: { node: '>= 0.4' }
-
-    es-module-lexer@2.3.1:
-        resolution:
-            {
-                integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==,
-            }
-
-    esast-util-from-estree@2.0.0:
-        resolution:
-            {
-                integrity: sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==,
-            }
-
-    esast-util-from-js@2.0.1:
-        resolution:
-            {
-                integrity: sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==,
-            }
-
-    esbuild@0.27.7:
-        resolution:
-            {
-                integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==,
-            }
-        engines: { node: '>=18' }
-        hasBin: true
-
-    esbuild@0.28.1:
-        resolution:
-            {
-                integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==,
-            }
-        engines: { node: '>=18' }
-        hasBin: true
-
-    escalade@3.2.0:
-        resolution:
-            {
-                integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==,
-            }
-        engines: { node: '>=6' }
-
-    escape-string-regexp@5.0.0:
-        resolution:
-            {
-                integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==,
-            }
-        engines: { node: '>=12' }
-
-    esprima@4.0.1:
-        resolution:
-            {
-                integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==,
-            }
-        engines: { node: '>=4' }
-        hasBin: true
-
-    estree-util-attach-comments@3.0.0:
-        resolution:
-            {
-                integrity: sha512-cKUwm/HUcTDsYh/9FgnuFqpfquUbwIqwKM26BVCGDPVgvaCl/nDCCjUfiLlx6lsEZ3Z4RFxNbOQ60pkaEwFxGw==,
-            }
-
-    estree-util-build-jsx@3.0.1:
-        resolution:
-            {
-                integrity: sha512-8U5eiL6BTrPxp/CHbs2yMgP8ftMhR5ww1eIKoWRMlqvltHF8fZn5LRDvTKuxD3DUn+shRbLGqXemcP51oFCsGQ==,
-            }
-
-    estree-util-is-identifier-name@3.0.0:
-        resolution:
-            {
-                integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==,
-            }
-
-    estree-util-scope@1.0.0:
-        resolution:
-            {
-                integrity: sha512-2CAASclonf+JFWBNJPndcOpA8EMJwa0Q8LUFJEKqXLW6+qBvbFZuF5gItbQOs/umBUkjviCSDCbBwU2cXbmrhQ==,
-            }
-
-    estree-util-to-js@2.0.0:
-        resolution:
-            {
-                integrity: sha512-WDF+xj5rRWmD5tj6bIqRi6CkLIXbbNQUcxQHzGysQzvHmdYG2G7p/Tf0J0gpxGgkeMZNTIjT/AoSvC9Xehcgdg==,
-            }
-
-    estree-util-visit@2.0.0:
-        resolution:
-            {
-                integrity: sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==,
-            }
-
-    estree-walker@3.0.3:
-        resolution:
-            {
-                integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==,
-            }
-
-    expect-type@1.4.0:
-        resolution:
-            {
-                integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==,
-            }
-        engines: { node: '>=12.0.0' }
-
-    exsolve@1.1.1:
-        resolution:
-            {
-                integrity: sha512-9U/jZUgjnSGyntRr6y5Muu1MJcwFl6kPu7k8qLF0IMNfLqvw0NZ4nnVDq0RVoZ0RvCyumib4Ez3KYrVfilrw+g==,
-            }
-
-    extend@3.0.2:
-        resolution:
-            {
-                integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==,
-            }
-
-    extendable-error@0.1.7:
-        resolution:
-            {
-                integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==,
-            }
-
-    fast-glob@3.3.3:
-        resolution:
-            {
-                integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==,
-            }
-        engines: { node: '>=8.6.0' }
-
-    fast-string-truncated-width@3.0.3:
-        resolution:
-            {
-                integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==,
-            }
-
-    fast-string-width@3.0.2:
-        resolution:
-            {
-                integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==,
-            }
-
-    fast-wrap-ansi@0.2.2:
-        resolution:
-            {
-                integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==,
-            }
-
-    fastq@1.20.1:
-        resolution:
-            {
-                integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==,
-            }
-
-    fault@2.0.1:
-        resolution:
-            {
-                integrity: sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==,
-            }
-
-    fdir@6.5.0:
-        resolution:
-            {
-                integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==,
-            }
-        engines: { node: '>=12.0.0' }
-        peerDependencies:
-            picomatch: ^3 || ^4
-        peerDependenciesMeta:
-            picomatch:
-                optional: true
-
-    fill-range@7.1.1:
-        resolution:
-            {
-                integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==,
-            }
-        engines: { node: '>=8' }
-
-    find-up@4.1.0:
-        resolution:
-            {
-                integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==,
-            }
-        engines: { node: '>=8' }
-
-    fix-dts-default-cjs-exports@1.0.1:
-        resolution:
-            {
-                integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==,
-            }
-
-    format@0.2.2:
-        resolution:
-            {
-                integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==,
-            }
-        engines: { node: '>=0.4.x' }
-
-    fraction.js@5.3.4:
-        resolution:
-            {
-                integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==,
-            }
-
-    fs-extra@7.0.1:
-        resolution:
-            {
-                integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==,
-            }
-        engines: { node: '>=6 <7 || >=8' }
-
-    fs-extra@8.1.0:
-        resolution:
-            {
-                integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==,
-            }
-        engines: { node: '>=6 <7 || >=8' }
-
-    fsevents@2.3.2:
-        resolution:
-            {
-                integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==,
-            }
-        engines: { node: ^8.16.0 || ^10.6.0 || >=11.0.0 }
-        os: [darwin]
-
-    fsevents@2.3.3:
-        resolution:
-            {
-                integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==,
-            }
-        engines: { node: ^8.16.0 || ^10.6.0 || >=11.0.0 }
-        os: [darwin]
-
-    function-bind@1.1.2:
-        resolution:
-            {
-                integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==,
-            }
-
-    gensync@1.0.0-beta.2:
-        resolution:
-            {
-                integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==,
-            }
-        engines: { node: '>=6.9.0' }
-
-    ghtml@4.0.2:
-        resolution:
-            {
-                integrity: sha512-ymJljsiXUc6hrq2407EnkyCQ8dk5NVEvpAbB4fhnZ+oqP0u9Aq/YWsNkDh+Ew5lBz2uGqyLfzCBdE8J8g4NNgg==,
-            }
-        engines: { node: '>=18' }
-
-    giget@2.0.0:
-        resolution:
-            {
-                integrity: sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==,
-            }
-        hasBin: true
-
-    glob-parent@5.1.2:
-        resolution:
-            {
-                integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==,
-            }
-        engines: { node: '>= 6' }
-
-    globby@11.1.0:
-        resolution:
-            {
-                integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==,
-            }
-        engines: { node: '>=10' }
-
-    graceful-fs@4.2.11:
-        resolution:
-            {
-                integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==,
-            }
-
-    h3@2.0.1-rc.26:
-        resolution:
-            {
-                integrity: sha512-GDxlvDsKxgjRvG5UBRJYyGJTMWLV30CJ4cV+e7QCTgftDHihrvio1fVPbNembhEr6J4WNm8IWy3fookgyTweLw==,
-            }
-        engines: { node: '>=20.11.1' }
-        hasBin: true
-        peerDependencies:
-            crossws: ^0.4.9
-        peerDependenciesMeta:
-            crossws:
-                optional: true
-
-    happy-dom@20.11.1:
-        resolution:
-            {
-                integrity: sha512-XSt8tMzbW9ymE7687xztkO1ckR7qJNQ3LywY9vlYGhGi3zXrGBHuUo2Cl1ztZaICW+1eAGdkLbj6iwVqDT33kg==,
-            }
-        engines: { node: '>=20.0.0' }
-
-    has-flag@4.0.0:
-        resolution:
-            {
-                integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==,
-            }
-        engines: { node: '>=8' }
-
-    hasown@2.0.4:
-        resolution:
-            {
-                integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==,
-            }
-        engines: { node: '>= 0.4' }
-
-    hast-util-from-html@2.0.3:
-        resolution:
-            {
-                integrity: sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==,
-            }
-
-    hast-util-from-parse5@8.0.3:
-        resolution:
-            {
-                integrity: sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==,
-            }
-
-    hast-util-parse-selector@4.0.0:
-        resolution:
-            {
-                integrity: sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==,
-            }
-
-    hast-util-to-estree@3.1.3:
-        resolution:
-            {
-                integrity: sha512-48+B/rJWAp0jamNbAAf9M7Uf//UVqAoMmgXhBdxTDJLGKY+LRnZ99qcG+Qjl5HfMpYNzS5v4EAwVEF34LeAj7w==,
-            }
-
-    hast-util-to-html@9.0.5:
-        resolution:
-            {
-                integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==,
-            }
-
-    hast-util-to-jsx-runtime@2.3.6:
-        resolution:
-            {
-                integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==,
-            }
-
-    hast-util-to-string@3.0.1:
-        resolution:
-            {
-                integrity: sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==,
-            }
-
-    hast-util-whitespace@3.0.0:
-        resolution:
-            {
-                integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==,
-            }
-
-    hastscript@9.0.1:
-        resolution:
-            {
-                integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==,
-            }
-
-    hookable@6.1.1:
-        resolution:
-            {
-                integrity: sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==,
-            }
-
-    html-escaper@2.0.2:
-        resolution:
-            {
-                integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==,
-            }
-
-    html-void-elements@3.0.0:
-        resolution:
-            {
-                integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==,
-            }
-
-    httpxy@0.5.5:
-        resolution:
-            {
-                integrity: sha512-uDjmnPyp1q4Sgzf3w+J/Fc6UqcCEj0x4Wjp7OqK5dGhNeDgpyrAmnS6ey8QWrX3SWDon2DMKf9sBa5X9+CVyMA==,
-            }
-
-    human-id@4.2.0:
-        resolution:
-            {
-                integrity: sha512-K3GbkIWqyvvlpfhBPlbEvD97TtqBpAYA4kt+cn2lD2x2HuohzZCibcA2nOlnJT6exqvJLggoB5nv2dNf192nEA==,
-            }
-        hasBin: true
-
-    iconv-lite@0.7.3:
-        resolution:
-            {
-                integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==,
-            }
-        engines: { node: '>=0.10.0' }
-
-    ignore@5.3.2:
-        resolution:
-            {
-                integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==,
-            }
-        engines: { node: '>= 4' }
-
-    indent-string@4.0.0:
-        resolution:
-            {
-                integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==,
-            }
-        engines: { node: '>=8' }
-
-    inline-style-parser@0.2.7:
-        resolution:
-            {
-                integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==,
-            }
-
-    is-alphabetical@2.0.1:
-        resolution:
-            {
-                integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==,
-            }
-
-    is-alphanumerical@2.0.1:
-        resolution:
-            {
-                integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==,
-            }
-
-    is-binary-path@2.1.0:
-        resolution:
-            {
-                integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==,
-            }
-        engines: { node: '>=8' }
-
-    is-core-module@2.16.2:
-        resolution:
-            {
-                integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==,
-            }
-        engines: { node: '>= 0.4' }
-
-    is-decimal@2.0.1:
-        resolution:
-            {
-                integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==,
-            }
-
-    is-docker@3.0.0:
-        resolution:
-            {
-                integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==,
-            }
-        engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
-        hasBin: true
-
-    is-extglob@2.1.1:
-        resolution:
-            {
-                integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==,
-            }
-        engines: { node: '>=0.10.0' }
-
-    is-glob@4.0.3:
-        resolution:
-            {
-                integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==,
-            }
-        engines: { node: '>=0.10.0' }
-
-    is-hexadecimal@2.0.1:
-        resolution:
-            {
-                integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==,
-            }
-
-    is-inside-container@1.0.0:
-        resolution:
-            {
-                integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==,
-            }
-        engines: { node: '>=14.16' }
-        hasBin: true
-
-    is-number@7.0.0:
-        resolution:
-            {
-                integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==,
-            }
-        engines: { node: '>=0.12.0' }
-
-    is-plain-obj@4.1.0:
-        resolution:
-            {
-                integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==,
-            }
-        engines: { node: '>=12' }
-
-    is-safe-filename@0.1.1:
-        resolution:
-            {
-                integrity: sha512-4SrR7AdnY11LHfDKTZY1u6Ga3RuxZdl3YKWWShO5iyuG5h8QS4GD2tOb04peBJ5I7pXbR+CGBNEhTcwK+FzN3g==,
-            }
-        engines: { node: '>=20' }
-
-    is-subdir@1.2.0:
-        resolution:
-            {
-                integrity: sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==,
-            }
-        engines: { node: '>=4' }
-
-    is-windows@1.0.2:
-        resolution:
-            {
-                integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==,
-            }
-        engines: { node: '>=0.10.0' }
-
-    is-wsl@3.1.1:
-        resolution:
-            {
-                integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==,
-            }
-        engines: { node: '>=16' }
-
-    isexe@2.0.0:
-        resolution:
-            {
-                integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==,
-            }
-
-    istanbul-lib-coverage@3.2.2:
-        resolution:
-            {
-                integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==,
-            }
-        engines: { node: '>=8' }
-
-    istanbul-lib-report@3.0.1:
-        resolution:
-            {
-                integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==,
-            }
-        engines: { node: '>=10' }
-
-    istanbul-reports@3.2.0:
-        resolution:
-            {
-                integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==,
-            }
-        engines: { node: '>=8' }
-
-    jiti@2.7.0:
-        resolution:
-            {
-                integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==,
-            }
-        hasBin: true
-
-    joycon@3.1.1:
-        resolution:
-            {
-                integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==,
-            }
-        engines: { node: '>=10' }
-
-    js-tokens@10.0.0:
-        resolution:
-            {
-                integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==,
-            }
-
-    js-tokens@4.0.0:
-        resolution:
-            {
-                integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==,
-            }
-
-    js-yaml@3.15.1:
-        resolution:
-            {
-                integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==,
-            }
-        hasBin: true
-
-    js-yaml@4.3.1:
-        resolution:
-            {
-                integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==,
-            }
-        hasBin: true
-
-    jsesc@3.1.0:
-        resolution:
-            {
-                integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==,
-            }
-        engines: { node: '>=6' }
-        hasBin: true
-
-    json5@2.2.3:
-        resolution:
-            {
-                integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==,
-            }
-        engines: { node: '>=6' }
-        hasBin: true
-
-    jsonc-parser@3.3.1:
-        resolution:
-            {
-                integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==,
-            }
-
-    jsonfile@4.0.0:
-        resolution:
-            {
-                integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==,
-            }
-
-    jsonfile@6.2.1:
-        resolution:
-            {
-                integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==,
-            }
-
-    lightningcss-android-arm64@1.32.0:
-        resolution:
-            {
-                integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==,
-            }
-        engines: { node: '>= 12.0.0' }
-        cpu: [arm64]
-        os: [android]
-
-    lightningcss-android-arm64@1.33.0:
-        resolution:
-            {
-                integrity: sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==,
-            }
-        engines: { node: '>= 12.0.0' }
-        cpu: [arm64]
-        os: [android]
-
-    lightningcss-darwin-arm64@1.32.0:
-        resolution:
-            {
-                integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==,
-            }
-        engines: { node: '>= 12.0.0' }
-        cpu: [arm64]
-        os: [darwin]
-
-    lightningcss-darwin-arm64@1.33.0:
-        resolution:
-            {
-                integrity: sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==,
-            }
-        engines: { node: '>= 12.0.0' }
-        cpu: [arm64]
-        os: [darwin]
-
-    lightningcss-darwin-x64@1.32.0:
-        resolution:
-            {
-                integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==,
-            }
-        engines: { node: '>= 12.0.0' }
-        cpu: [x64]
-        os: [darwin]
-
-    lightningcss-darwin-x64@1.33.0:
-        resolution:
-            {
-                integrity: sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==,
-            }
-        engines: { node: '>= 12.0.0' }
-        cpu: [x64]
-        os: [darwin]
-
-    lightningcss-freebsd-x64@1.32.0:
-        resolution:
-            {
-                integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==,
-            }
-        engines: { node: '>= 12.0.0' }
-        cpu: [x64]
-        os: [freebsd]
-
-    lightningcss-freebsd-x64@1.33.0:
-        resolution:
-            {
-                integrity: sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==,
-            }
-        engines: { node: '>= 12.0.0' }
-        cpu: [x64]
-        os: [freebsd]
-
-    lightningcss-linux-arm-gnueabihf@1.32.0:
-        resolution:
-            {
-                integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==,
-            }
-        engines: { node: '>= 12.0.0' }
-        cpu: [arm]
-        os: [linux]
-
-    lightningcss-linux-arm-gnueabihf@1.33.0:
-        resolution:
-            {
-                integrity: sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==,
-            }
-        engines: { node: '>= 12.0.0' }
-        cpu: [arm]
-        os: [linux]
-
-    lightningcss-linux-arm64-gnu@1.32.0:
-        resolution:
-            {
-                integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==,
-            }
-        engines: { node: '>= 12.0.0' }
-        cpu: [arm64]
-        os: [linux]
-        libc: [glibc]
-
-    lightningcss-linux-arm64-gnu@1.33.0:
-        resolution:
-            {
-                integrity: sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==,
-            }
-        engines: { node: '>= 12.0.0' }
-        cpu: [arm64]
-        os: [linux]
-        libc: [glibc]
-
-    lightningcss-linux-arm64-musl@1.32.0:
-        resolution:
-            {
-                integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==,
-            }
-        engines: { node: '>= 12.0.0' }
-        cpu: [arm64]
-        os: [linux]
-        libc: [musl]
-
-    lightningcss-linux-arm64-musl@1.33.0:
-        resolution:
-            {
-                integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==,
-            }
-        engines: { node: '>= 12.0.0' }
-        cpu: [arm64]
-        os: [linux]
-        libc: [musl]
-
-    lightningcss-linux-x64-gnu@1.32.0:
-        resolution:
-            {
-                integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==,
-            }
-        engines: { node: '>= 12.0.0' }
-        cpu: [x64]
-        os: [linux]
-        libc: [glibc]
-
-    lightningcss-linux-x64-gnu@1.33.0:
-        resolution:
-            {
-                integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==,
-            }
-        engines: { node: '>= 12.0.0' }
-        cpu: [x64]
-        os: [linux]
-        libc: [glibc]
-
-    lightningcss-linux-x64-musl@1.32.0:
-        resolution:
-            {
-                integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==,
-            }
-        engines: { node: '>= 12.0.0' }
-        cpu: [x64]
-        os: [linux]
-        libc: [musl]
-
-    lightningcss-linux-x64-musl@1.33.0:
-        resolution:
-            {
-                integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==,
-            }
-        engines: { node: '>= 12.0.0' }
-        cpu: [x64]
-        os: [linux]
-        libc: [musl]
-
-    lightningcss-win32-arm64-msvc@1.32.0:
-        resolution:
-            {
-                integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==,
-            }
-        engines: { node: '>= 12.0.0' }
-        cpu: [arm64]
-        os: [win32]
-
-    lightningcss-win32-arm64-msvc@1.33.0:
-        resolution:
-            {
-                integrity: sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==,
-            }
-        engines: { node: '>= 12.0.0' }
-        cpu: [arm64]
-        os: [win32]
-
-    lightningcss-win32-x64-msvc@1.32.0:
-        resolution:
-            {
-                integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==,
-            }
-        engines: { node: '>= 12.0.0' }
-        cpu: [x64]
-        os: [win32]
-
-    lightningcss-win32-x64-msvc@1.33.0:
-        resolution:
-            {
-                integrity: sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==,
-            }
-        engines: { node: '>= 12.0.0' }
-        cpu: [x64]
-        os: [win32]
-
-    lightningcss@1.32.0:
-        resolution:
-            {
-                integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==,
-            }
-        engines: { node: '>= 12.0.0' }
-
-    lightningcss@1.33.0:
-        resolution:
-            {
-                integrity: sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==,
-            }
-        engines: { node: '>= 12.0.0' }
-
-    lilconfig@3.1.3:
-        resolution:
-            {
-                integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==,
-            }
-        engines: { node: '>=14' }
-
-    lines-and-columns@1.2.4:
-        resolution:
-            {
-                integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==,
-            }
-
-    load-tsconfig@0.2.5:
-        resolution:
-            {
-                integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==,
-            }
-        engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
-
-    locate-path@5.0.0:
-        resolution:
-            {
-                integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==,
-            }
-        engines: { node: '>=8' }
-
-    lodash.startcase@4.4.0:
-        resolution:
-            {
-                integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==,
-            }
-
-    longest-streak@3.1.0:
-        resolution:
-            {
-                integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==,
-            }
-
-    loupe@3.2.1:
-        resolution:
-            {
-                integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==,
-            }
-
-    lru-cache@5.1.1:
-        resolution:
-            {
-                integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==,
-            }
-
-    lz-string@1.5.0:
-        resolution:
-            {
-                integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==,
-            }
-        hasBin: true
-
-    magic-string@0.30.21:
-        resolution:
-            {
-                integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==,
-            }
-
-    magicast@0.5.4:
-        resolution:
-            {
-                integrity: sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==,
-            }
-
-    make-dir@4.0.0:
-        resolution:
-            {
-                integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==,
-            }
-        engines: { node: '>=10' }
-
-    markdown-extensions@2.0.0:
-        resolution:
-            {
-                integrity: sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==,
-            }
-        engines: { node: '>=16' }
-
-    markdown-table@3.0.4:
-        resolution:
-            {
-                integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==,
-            }
-
-    mdast-util-find-and-replace@3.0.2:
-        resolution:
-            {
-                integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==,
-            }
-
-    mdast-util-from-markdown@2.0.3:
-        resolution:
-            {
-                integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==,
-            }
-
-    mdast-util-frontmatter@2.0.1:
-        resolution:
-            {
-                integrity: sha512-LRqI9+wdgC25P0URIJY9vwocIzCcksduHQ9OF2joxQoyTNVduwLAFUzjoopuRJbJAReaKrNQKAZKL3uCMugWJA==,
-            }
-
-    mdast-util-gfm-autolink-literal@2.0.1:
-        resolution:
-            {
-                integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==,
-            }
-
-    mdast-util-gfm-footnote@2.1.0:
-        resolution:
-            {
-                integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==,
-            }
-
-    mdast-util-gfm-strikethrough@2.0.0:
-        resolution:
-            {
-                integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==,
-            }
-
-    mdast-util-gfm-table@2.0.0:
-        resolution:
-            {
-                integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==,
-            }
-
-    mdast-util-gfm-task-list-item@2.0.0:
-        resolution:
-            {
-                integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==,
-            }
-
-    mdast-util-gfm@3.1.0:
-        resolution:
-            {
-                integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==,
-            }
-
-    mdast-util-mdx-expression@2.0.1:
-        resolution:
-            {
-                integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==,
-            }
-
-    mdast-util-mdx-jsx@3.2.0:
-        resolution:
-            {
-                integrity: sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==,
-            }
-
-    mdast-util-mdx@3.0.0:
-        resolution:
-            {
-                integrity: sha512-JfbYLAW7XnYTTbUsmpu0kdBUVe+yKVJZBItEjwyYJiDJuZ9w4eeaqks4HQO+R7objWgS2ymV60GYpI14Ug554w==,
-            }
-
-    mdast-util-mdxjs-esm@2.0.1:
-        resolution:
-            {
-                integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==,
-            }
-
-    mdast-util-phrasing@4.1.0:
-        resolution:
-            {
-                integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==,
-            }
-
-    mdast-util-to-hast@13.2.1:
-        resolution:
-            {
-                integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==,
-            }
-
-    mdast-util-to-markdown@2.1.2:
-        resolution:
-            {
-                integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==,
-            }
-
-    mdast-util-to-string@4.0.0:
-        resolution:
-            {
-                integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==,
-            }
-
-    mdn-data@2.0.28:
-        resolution:
-            {
-                integrity: sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==,
-            }
-
-    mdn-data@2.27.1:
-        resolution:
-            {
-                integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==,
-            }
-
-    merge2@1.4.1:
-        resolution:
-            {
-                integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==,
-            }
-        engines: { node: '>= 8' }
-
-    micromark-core-commonmark@2.0.3:
-        resolution:
-            {
-                integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==,
-            }
-
-    micromark-extension-frontmatter@2.0.0:
-        resolution:
-            {
-                integrity: sha512-C4AkuM3dA58cgZha7zVnuVxBhDsbttIMiytjgsM2XbHAB2faRVaHRle40558FBN+DJcrLNCoqG5mlrpdU4cRtg==,
-            }
-
-    micromark-extension-gfm-autolink-literal@2.1.0:
-        resolution:
-            {
-                integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==,
-            }
-
-    micromark-extension-gfm-footnote@2.1.0:
-        resolution:
-            {
-                integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==,
-            }
-
-    micromark-extension-gfm-strikethrough@2.1.0:
-        resolution:
-            {
-                integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==,
-            }
-
-    micromark-extension-gfm-table@2.1.1:
-        resolution:
-            {
-                integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==,
-            }
-
-    micromark-extension-gfm-tagfilter@2.0.0:
-        resolution:
-            {
-                integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==,
-            }
-
-    micromark-extension-gfm-task-list-item@2.1.0:
-        resolution:
-            {
-                integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==,
-            }
-
-    micromark-extension-gfm@3.0.0:
-        resolution:
-            {
-                integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==,
-            }
-
-    micromark-extension-mdx-expression@3.0.1:
-        resolution:
-            {
-                integrity: sha512-dD/ADLJ1AeMvSAKBwO22zG22N4ybhe7kFIZ3LsDI0GlsNr2A3KYxb0LdC1u5rj4Nw+CHKY0RVdnHX8vj8ejm4Q==,
-            }
-
-    micromark-extension-mdx-jsx@3.0.2:
-        resolution:
-            {
-                integrity: sha512-e5+q1DjMh62LZAJOnDraSSbDMvGJ8x3cbjygy2qFEi7HCeUT4BDKCvMozPozcD6WmOt6sVvYDNBKhFSz3kjOVQ==,
-            }
-
-    micromark-extension-mdx-md@2.0.0:
-        resolution:
-            {
-                integrity: sha512-EpAiszsB3blw4Rpba7xTOUptcFeBFi+6PY8VnJ2hhimH+vCQDirWgsMpz7w1XcZE7LVrSAUGb9VJpG9ghlYvYQ==,
-            }
-
-    micromark-extension-mdxjs-esm@3.0.0:
-        resolution:
-            {
-                integrity: sha512-DJFl4ZqkErRpq/dAPyeWp15tGrcrrJho1hKK5uBS70BCtfrIFg81sqcTVu3Ta+KD1Tk5vAtBNElWxtAa+m8K9A==,
-            }
-
-    micromark-extension-mdxjs@3.0.0:
-        resolution:
-            {
-                integrity: sha512-A873fJfhnJ2siZyUrJ31l34Uqwy4xIFmvPY1oj+Ean5PHcPBYzEsvqvWGaWcfEIr11O5Dlw3p2y0tZWpKHDejQ==,
-            }
-
-    micromark-factory-destination@2.0.1:
-        resolution:
-            {
-                integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==,
-            }
-
-    micromark-factory-label@2.0.1:
-        resolution:
-            {
-                integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==,
-            }
-
-    micromark-factory-mdx-expression@2.0.3:
-        resolution:
-            {
-                integrity: sha512-kQnEtA3vzucU2BkrIa8/VaSAsP+EJ3CKOvhMuJgOEGg9KDC6OAY6nSnNDVRiVNRqj7Y4SlSzcStaH/5jge8JdQ==,
-            }
-
-    micromark-factory-space@2.0.1:
-        resolution:
-            {
-                integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==,
-            }
-
-    micromark-factory-title@2.0.1:
-        resolution:
-            {
-                integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==,
-            }
-
-    micromark-factory-whitespace@2.0.1:
-        resolution:
-            {
-                integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==,
-            }
-
-    micromark-util-character@2.1.1:
-        resolution:
-            {
-                integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==,
-            }
-
-    micromark-util-chunked@2.0.1:
-        resolution:
-            {
-                integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==,
-            }
-
-    micromark-util-classify-character@2.0.1:
-        resolution:
-            {
-                integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==,
-            }
-
-    micromark-util-combine-extensions@2.0.1:
-        resolution:
-            {
-                integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==,
-            }
-
-    micromark-util-decode-numeric-character-reference@2.0.2:
-        resolution:
-            {
-                integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==,
-            }
-
-    micromark-util-decode-string@2.0.1:
-        resolution:
-            {
-                integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==,
-            }
-
-    micromark-util-encode@2.0.1:
-        resolution:
-            {
-                integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==,
-            }
-
-    micromark-util-events-to-acorn@2.0.3:
-        resolution:
-            {
-                integrity: sha512-jmsiEIiZ1n7X1Rr5k8wVExBQCg5jy4UXVADItHmNk1zkwEVhBuIUKRu3fqv+hs4nxLISi2DQGlqIOGiFxgbfHg==,
-            }
-
-    micromark-util-html-tag-name@2.0.1:
-        resolution:
-            {
-                integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==,
-            }
-
-    micromark-util-normalize-identifier@2.0.1:
-        resolution:
-            {
-                integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==,
-            }
-
-    micromark-util-resolve-all@2.0.1:
-        resolution:
-            {
-                integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==,
-            }
-
-    micromark-util-sanitize-uri@2.0.1:
-        resolution:
-            {
-                integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==,
-            }
-
-    micromark-util-subtokenize@2.1.0:
-        resolution:
-            {
-                integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==,
-            }
-
-    micromark-util-symbol@2.0.1:
-        resolution:
-            {
-                integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==,
-            }
-
-    micromark-util-types@2.0.2:
-        resolution:
-            {
-                integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==,
-            }
-
-    micromark@4.0.2:
-        resolution:
-            {
-                integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==,
-            }
-
-    micromatch@4.0.8:
-        resolution:
-            {
-                integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==,
-            }
-        engines: { node: '>=8.6' }
-
-    min-indent@1.0.1:
-        resolution:
-            {
-                integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==,
-            }
-        engines: { node: '>=4' }
-
-    mitata@1.0.34:
-        resolution:
-            {
-                integrity: sha512-Mc3zrtNBKIMeHSCQ0XqRLo1vbdIx1wvFV9c8NJAiyho6AjNfMY8bVhbS12bwciUdd1t4rj8099CH3N3NFahaUA==,
-            }
-
-    mlly@1.8.2:
-        resolution:
-            {
-                integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==,
-            }
-
-    morphdom@2.7.8:
-        resolution:
-            {
-                integrity: sha512-D/fR4xgGUyVRbdMGU6Nejea1RFzYxYtyurG4Fbv2Fi/daKlWKuXGLOdXtl+3eIwL110cI2hz1ZojGICjjFLgTg==,
-            }
-
-    mri@1.2.0:
-        resolution:
-            {
-                integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==,
-            }
-        engines: { node: '>=4' }
-
-    mrmime@2.0.1:
-        resolution:
-            {
-                integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==,
-            }
-        engines: { node: '>=10' }
-
-    ms@2.1.3:
-        resolution:
-            {
-                integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==,
-            }
-
-    mylas@2.1.14:
-        resolution:
-            {
-                integrity: sha512-BzQguy9W9NJgoVn2mRWzbFrFWWztGCcng2QI9+41frfk+Athwgx3qhqhvStz7ExeUUu7Kzw427sNzHpEZNINog==,
-            }
-        engines: { node: '>=16.0.0' }
-
-    mz@2.7.0:
-        resolution:
-            {
-                integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==,
-            }
-
-    nanoid@3.3.16:
-        resolution:
-            {
-                integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==,
-            }
-        engines: { node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1 }
-        hasBin: true
-
-    nf3@0.3.23:
-        resolution:
-            {
-                integrity: sha512-RWVLAWozmVD3AaDmaU3qMGB3v+yNlH5d9qqStI4e/WLlNQVnJ4YErGDbYCIrGFyrHdbF6I6Baf0Ae6c7tFYmSg==,
-            }
-
-    nitro@3.0.260311-beta:
-        resolution:
-            {
-                integrity: sha512-0o0fJ9LUh4WKUqJNX012jyieUOtMCnadkNDWr0mHzdraoHpJP/1CGNefjRyZyMXSpoJfwoWdNEZu2iGf35TUvQ==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        hasBin: true
-        peerDependencies:
-            dotenv: '*'
-            giget: '*'
-            jiti: ^2.6.1
-            rollup: ^4.59.0
-            vite: ^7 || ^8 || >=8.0.0-0
-            xml2js: ^0.6.2
-            zephyr-agent: ^0.1.15
-        peerDependenciesMeta:
-            dotenv:
-                optional: true
-            giget:
-                optional: true
-            jiti:
-                optional: true
-            rollup:
-                optional: true
-            vite:
-                optional: true
-            xml2js:
-                optional: true
-            zephyr-agent:
-                optional: true
-
-    node-fetch-native@1.6.7:
-        resolution:
-            {
-                integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==,
-            }
-
-    node-fetch@2.7.0:
-        resolution:
-            {
-                integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==,
-            }
-        engines: { node: 4.x || >=6.0.0 }
-        peerDependencies:
-            encoding: ^0.1.0
-        peerDependenciesMeta:
-            encoding:
-                optional: true
-
-    node-releases@2.0.51:
-        resolution:
-            {
-                integrity: sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==,
-            }
-        engines: { node: '>=18' }
-
-    normalize-path@3.0.0:
-        resolution:
-            {
-                integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==,
-            }
-        engines: { node: '>=0.10.0' }
-
-    nth-check@2.1.1:
-        resolution:
-            {
-                integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==,
-            }
-
-    nypm@0.6.9:
-        resolution:
-            {
-                integrity: sha512-zxlE2yvSWZWmHcNdT3+5zV2lrCogeE9YOklHrR3dFjqutq5wO7GFDYLFDRXLsYnJzwvy/im9fYoxePvS0VTW0w==,
-            }
-        engines: { node: '>=18' }
-        hasBin: true
-
-    object-assign@4.1.1:
-        resolution:
-            {
-                integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==,
-            }
-        engines: { node: '>=0.10.0' }
-
-    obug@2.1.4:
-        resolution:
-            {
-                integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==,
-            }
-        engines: { node: '>=12.20.0' }
-
-    ocache@0.1.5:
-        resolution:
-            {
-                integrity: sha512-kNNnkkVQup/QDvmTz8Q84wc2ntiyoVHDxa6eHWKt5qdGAmFRBIxy83rxgCYEjW0x06UJ9E3P6VgM2yY4rOBH4w==,
-            }
-
-    ofetch@2.0.0-alpha.3:
-        resolution:
-            {
-                integrity: sha512-zpYTCs2byOuft65vI3z43Dd6iSdFbOZZLb9/d21aCpx2rGastVU9dOCv0lu4ykc1Ur1anAYjDi3SUvR0vq50JA==,
-            }
-
-    ohash@2.0.11:
-        resolution:
-            {
-                integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==,
-            }
-
-    oniguruma-parser@0.12.2:
-        resolution:
-            {
-                integrity: sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==,
-            }
-
-    oniguruma-to-es@4.3.6:
-        resolution:
-            {
-                integrity: sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==,
-            }
-
-    open@10.2.0:
-        resolution:
-            {
-                integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==,
-            }
-        engines: { node: '>=18' }
-
-    outdent@0.5.0:
-        resolution:
-            {
-                integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==,
-            }
-
-    oxc-parser@0.127.0:
-        resolution:
-            {
-                integrity: sha512-bkgD4qHlN7WxLdX8bLXdaU54TtQtAIg/ZBAfm0aje/mo3MRDo3P0hZSgr4U7O3xfX+fQmR5AP04JS/TGcZLcFA==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-
-    oxc-parser@0.141.0:
-        resolution:
-            {
-                integrity: sha512-uFkGGr1KMWd6aWv9UAqooYrN78trw8MWWmoPvgWokfBEUq1+eiIQ+qfj3wokhy0fxtZWZk+0dHoS7/yRTJtd6w==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-
-    oxc-resolver@11.24.2:
-        resolution:
-            {
-                integrity: sha512-FY91FiDBj7ls5MsFS9jN3tjz2o0/zsdSsymlakySaBwVJZorHhkWyICLZMKxlu1R9vYo+sd3z1jwb4J8x7bNDw==,
-            }
-
-    oxlint@1.76.0:
-        resolution:
-            {
-                integrity: sha512-6QoFioEU4fNdiUx/2Eo6TRd6NG7H7njnRCz8rhB66cZmMHDTqcm1Rjvl8Wry+ZTQMBAmyb4Mlf62Mk5X+eHSOw==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        hasBin: true
-        peerDependencies:
-            oxlint-tsgolint: '>=7.0.2001'
-            vite-plus: '*'
-        peerDependenciesMeta:
-            oxlint-tsgolint:
-                optional: true
-            vite-plus:
-                optional: true
-
-    p-filter@2.1.0:
-        resolution:
-            {
-                integrity: sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==,
-            }
-        engines: { node: '>=8' }
-
-    p-limit@2.3.0:
-        resolution:
-            {
-                integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==,
-            }
-        engines: { node: '>=6' }
-
-    p-locate@4.1.0:
-        resolution:
-            {
-                integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==,
-            }
-        engines: { node: '>=8' }
-
-    p-map@2.1.0:
-        resolution:
-            {
-                integrity: sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==,
-            }
-        engines: { node: '>=6' }
-
-    p-try@2.2.0:
-        resolution:
-            {
-                integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==,
-            }
-        engines: { node: '>=6' }
-
-    package-manager-detector@0.2.11:
-        resolution:
-            {
-                integrity: sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==,
-            }
-
-    parse-entities@4.0.2:
-        resolution:
-            {
-                integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==,
-            }
-
-    parse-numeric-range@1.3.0:
-        resolution:
-            {
-                integrity: sha512-twN+njEipszzlMJd4ONUYgSfZPDxgHhT9Ahed5uTigpQn90FggW4SA/AIPq/6a149fTbE9qBEcSwE3FAEp6wQQ==,
-            }
-
-    parse5@7.3.0:
-        resolution:
-            {
-                integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==,
-            }
-
-    path-exists@4.0.0:
-        resolution:
-            {
-                integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==,
-            }
-        engines: { node: '>=8' }
-
-    path-key@3.1.1:
-        resolution:
-            {
-                integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==,
-            }
-        engines: { node: '>=8' }
-
-    path-parse@1.0.7:
-        resolution:
-            {
-                integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==,
-            }
-
-    path-type@4.0.0:
-        resolution:
-            {
-                integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==,
-            }
-        engines: { node: '>=8' }
-
-    pathe@2.0.3:
-        resolution:
-            {
-                integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==,
-            }
-
-    pathval@2.0.1:
-        resolution:
-            {
-                integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==,
-            }
-        engines: { node: '>= 14.16' }
-
-    picocolors@1.1.1:
-        resolution:
-            {
-                integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==,
-            }
-
-    picomatch@2.3.2:
-        resolution:
-            {
-                integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==,
-            }
-        engines: { node: '>=8.6' }
-
-    picomatch@4.0.5:
-        resolution:
-            {
-                integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==,
-            }
-        engines: { node: '>=12' }
-
-    pify@2.3.0:
-        resolution:
-            {
-                integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==,
-            }
-        engines: { node: '>=0.10.0' }
-
-    pify@4.0.1:
-        resolution:
-            {
-                integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==,
-            }
-        engines: { node: '>=6' }
-
-    pirates@4.0.7:
-        resolution:
-            {
-                integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==,
-            }
-        engines: { node: '>= 6' }
-
-    pkg-types@1.3.1:
-        resolution:
-            {
-                integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==,
-            }
-
-    playwright-core@1.62.1:
-        resolution:
-            {
-                integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==,
-            }
-        engines: { node: '>=20' }
-        hasBin: true
-
-    playwright@1.62.1:
-        resolution:
-            {
-                integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==,
-            }
-        engines: { node: '>=20' }
-        hasBin: true
-
-    plimit-lit@1.6.1:
-        resolution:
-            {
-                integrity: sha512-B7+VDyb8Tl6oMJT9oSO2CW8XC/T4UcJGrwOVoNGwOQsQYhlpfajmrMj5xeejqaASq3V/EqThyOeATEOMuSEXiA==,
-            }
-        engines: { node: '>=12' }
-
-    pngjs@7.0.0:
-        resolution:
-            {
-                integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==,
-            }
-        engines: { node: '>=14.19.0' }
-
-    postcss-calc@10.1.1:
-        resolution:
-            {
-                integrity: sha512-NYEsLHh8DgG/PRH2+G9BTuUdtf9ViS+vdoQ0YA5OQdGsfN4ztiwtDWNtBl9EKeqNMFnIu8IKZ0cLxEQ5r5KVMw==,
-            }
-        engines: { node: ^18.12 || ^20.9 || >=22.0 }
-        peerDependencies:
-            postcss: ^8.4.38
-
-    postcss-colormin@8.0.1:
-        resolution:
-            {
-                integrity: sha512-qBY4ABQ6d8/mk5RRZHwMllrZMxeMey3azVY2dZUEk+RgiUC4ARdPR3/AITzNqqKTbvW/3y/MJKinDrzwqn8RDQ==,
-            }
-        engines: { node: ^22.11.0 || ^24.11.0 || >=26.0 }
-        peerDependencies:
-            postcss: ^8.5.15
-
-    postcss-convert-values@8.0.1:
-        resolution:
-            {
-                integrity: sha512-IdOSIX3BzfMvCc1TAHIha2gfy17xnb5vfML8e2BIKARnFOghksESfaSAB/3CXgyLfMozZAbTRPVQF5dbuKOidw==,
-            }
-        engines: { node: ^22.11.0 || ^24.11.0 || >=26.0 }
-        peerDependencies:
-            postcss: ^8.5.15
-
-    postcss-discard-comments@8.0.1:
-        resolution:
-            {
-                integrity: sha512-FDvzm3tXlEsQBO2XQgnta5ugsAqwBrgWH+j5QgXpegEIDYA0VPnZg2aP7LtmWtC49POskeIhXesFiU/k3NyFHA==,
-            }
-        engines: { node: ^22.11.0 || ^24.11.0 || >=26.0 }
-        peerDependencies:
-            postcss: ^8.5.15
-
-    postcss-discard-duplicates@8.0.1:
-        resolution:
-            {
-                integrity: sha512-stTDXkI8YkCUfADurQhp03oq5ynsgSx6Qrw5B1swds6oTHtAeOZ9I0SHGK8cY/VpWUsIYFDWMs3IWf9jIEfFvA==,
-            }
-        engines: { node: ^22.11.0 || ^24.11.0 || >=26.0 }
-        peerDependencies:
-            postcss: ^8.5.15
-
-    postcss-discard-empty@8.0.1:
-        resolution:
-            {
-                integrity: sha512-Zv4fM1Yfhk71tbt6gfiptbL6jDHi+7apSnaMeaO9n1uET+1embrXQw5m93Zp5x28UyQSuv+AVkFY193jdwZ33w==,
-            }
-        engines: { node: ^22.11.0 || ^24.11.0 || >=26.0 }
-        peerDependencies:
-            postcss: ^8.5.15
-
-    postcss-discard-overridden@8.0.1:
-        resolution:
-            {
-                integrity: sha512-ykt4fvrC7yYGzbxKyqBVjDCbsjF/11JgWK8enrdkobRyqqEtb/uDUCbKOGdvrK8X7BrShW8Lv5cCRNbdkNHGkQ==,
-            }
-        engines: { node: ^22.11.0 || ^24.11.0 || >=26.0 }
-        peerDependencies:
-            postcss: ^8.5.15
-
-    postcss-import@16.1.1:
-        resolution:
-            {
-                integrity: sha512-2xVS1NCZAfjtVdvXiyegxzJ447GyqCeEI5V7ApgQVOWnros1p5lGNovJNapwPpMombyFBfqDwt7AD3n2l0KOfQ==,
-            }
-        engines: { node: '>=18.0.0' }
-        peerDependencies:
-            postcss: ^8.0.0
-
-    postcss-load-config@6.0.1:
-        resolution:
-            {
-                integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==,
-            }
-        engines: { node: '>= 18' }
-        peerDependencies:
-            jiti: '>=1.21.0'
-            postcss: '>=8.0.9'
-            tsx: ^4.8.1
-            yaml: ^2.4.2
-        peerDependenciesMeta:
-            jiti:
-                optional: true
-            postcss:
-                optional: true
-            tsx:
-                optional: true
-            yaml:
-                optional: true
-
-    postcss-merge-longhand@8.0.1:
-        resolution:
-            {
-                integrity: sha512-huTfSYgQ13O81SFvAuOi7GWnO48vvybjj3xF+X3qUoPjzvvaLpJH5DcUqqXcwOEulZUcvaV4s0V9WtWs+IAQPA==,
-            }
-        engines: { node: ^22.11.0 || ^24.11.0 || >=26.0 }
-        peerDependencies:
-            postcss: ^8.5.15
-
-    postcss-merge-rules@8.0.1:
-        resolution:
-            {
-                integrity: sha512-o3rk4UpnPNg469tklYwbR/NtvKc/f/wJiVDTnNQ/EFPw/LeiPOHUCvV1GIBQIZHGrBAYdPjToK6a+ojYprsrxQ==,
-            }
-        engines: { node: ^22.11.0 || ^24.11.0 || >=26.0 }
-        peerDependencies:
-            postcss: ^8.5.15
-
-    postcss-minify-font-values@8.0.1:
-        resolution:
-            {
-                integrity: sha512-L8Nzs/PRlBSPrLdY/7rAiU5ZN5800+2J/4LRbfyG8SJnPljmgMaXVmQiCklvRS+yObfVRNtvmk/Ean/eoYcSeg==,
-            }
-        engines: { node: ^22.11.0 || ^24.11.0 || >=26.0 }
-        peerDependencies:
-            postcss: ^8.5.15
-
-    postcss-minify-gradients@8.0.1:
-        resolution:
-            {
-                integrity: sha512-qf+4s/hZMqTwpWN2teqf6+1yvR/SZK5HgHqXYuACeJXV7ABe7AXtBEomgxagUzcN4bSnmqBh5vnIml0dYqykYg==,
-            }
-        engines: { node: ^22.11.0 || ^24.11.0 || >=26.0 }
-        peerDependencies:
-            postcss: ^8.5.15
-
-    postcss-minify-params@8.0.1:
-        resolution:
-            {
-                integrity: sha512-L0h3H59deFfFg0wQN1NVaS/8E/LfGvaMuZKGO7siwlG995zo3OshtQyRkqKdVqcBwAORBvZ1nDZrKPLRapYkQw==,
-            }
-        engines: { node: ^22.11.0 || ^24.11.0 || >=26.0 }
-        peerDependencies:
-            postcss: ^8.5.15
-
-    postcss-minify-selectors@8.0.2:
-        resolution:
-            {
-                integrity: sha512-3icdxc/zght5UAizdwqZBDE2KOWHf1jMQCxET6iLACeNlRxfTPyXS0/COpGk8CQ2cECyaEKTRUd/i/k8Gxmz4g==,
-            }
-        engines: { node: ^22.11.0 || ^24.11.0 || >=26.0 }
-        peerDependencies:
-            postcss: ^8.5.15
-
-    postcss-nested@8.0.1:
-        resolution:
-            {
-                integrity: sha512-PvSIwDVh1NTw939iu4FBK+oeZfSm0cbErFAjXCTPiStammzobBNE2SiQNezy8Xp+Oud2uLXaLpTauv3UdxWjbQ==,
-            }
-        engines: { node: ^22.0.0 || ^24.0.0 || >= 26.0.0 }
-        peerDependencies:
-            postcss: ^8.2.14
-
-    postcss-normalize-charset@8.0.1:
-        resolution:
-            {
-                integrity: sha512-xzqr36F8UeIZOvOHsf3aul+RVJCADvSwuwpMLgizqKjisHZpBfztgW0XFLBfJvz9pJgaStaOXAtGb0zLqT6B0w==,
-            }
-        engines: { node: ^22.11.0 || ^24.11.0 || >=26.0 }
-        peerDependencies:
-            postcss: ^8.5.15
-
-    postcss-normalize-display-values@8.0.1:
-        resolution:
-            {
-                integrity: sha512-ZDWOijOK1FFMlpgiQCUO9fCNKd7HJ9L7z9HWEq4iyubnUFWzdTSwm/LcrMbNW6iZ1oAtqeLYA0WA3xHszOI08g==,
-            }
-        engines: { node: ^22.11.0 || ^24.11.0 || >=26.0 }
-        peerDependencies:
-            postcss: ^8.5.15
-
-    postcss-normalize-positions@8.0.1:
-        resolution:
-            {
-                integrity: sha512-uuivan2poSqbE48ST4do20dGaFUeXey9/H8rhHzoyVHB2I6BmkoVLZ/C9+BRjUlpaAFYVOoDY7epkiidzaYbvA==,
-            }
-        engines: { node: ^22.11.0 || ^24.11.0 || >=26.0 }
-        peerDependencies:
-            postcss: ^8.5.15
-
-    postcss-normalize-repeat-style@8.0.1:
-        resolution:
-            {
-                integrity: sha512-q2hq5fmKxk29K6DjKA3nZ17Q2dtjhLYFNmFweKALmooUqx6UWAHF1bBoWTu/EqlJ88josb82A/J0Atj9LJUmpQ==,
-            }
-        engines: { node: ^22.11.0 || ^24.11.0 || >=26.0 }
-        peerDependencies:
-            postcss: ^8.5.15
-
-    postcss-normalize-string@8.0.1:
-        resolution:
-            {
-                integrity: sha512-+Wf+kQJhm1WgSGEAuUaswE9rdpR9QbrKRVemcVHs6rhOoOTVIdAbgaicftfYA6vLM346P8onRzkEVbFN29ktKQ==,
-            }
-        engines: { node: ^22.11.0 || ^24.11.0 || >=26.0 }
-        peerDependencies:
-            postcss: ^8.5.15
-
-    postcss-normalize-timing-functions@8.0.1:
-        resolution:
-            {
-                integrity: sha512-W8/tvwRlm3T+yjGkg0IRTF4bvHj0vILYr/LOogCrJKHz2ey2HFRwfsAA8Bk9N4BGR7z7WmmDu/KzzwhJ6FoGPQ==,
-            }
-        engines: { node: ^22.11.0 || ^24.11.0 || >=26.0 }
-        peerDependencies:
-            postcss: ^8.5.15
-
-    postcss-normalize-unicode@8.0.1:
-        resolution:
-            {
-                integrity: sha512-Ad0YHNRBp4WHEOYUM/4wL/8MoL2fimEF8se/0q+Rt/owMzYpbxsypC1P8fN/oluwoRmRKdNVX7X2oycEobPWcQ==,
-            }
-        engines: { node: ^22.11.0 || ^24.11.0 || >=26.0 }
-        peerDependencies:
-            postcss: ^8.5.15
-
-    postcss-normalize-url@8.0.1:
-        resolution:
-            {
-                integrity: sha512-tkYcip6pCDY806xuxpJYqMW2M3/623jzGFJmz3m5Us47q8P28+gbRZxaea3Rr/CmwwLUiVlh+BTGYwQ6gvaP8A==,
-            }
-        engines: { node: ^22.11.0 || ^24.11.0 || >=26.0 }
-        peerDependencies:
-            postcss: ^8.5.15
-
-    postcss-normalize-whitespace@8.0.1:
-        resolution:
-            {
-                integrity: sha512-XzORadNfSrKWDZZpgAEHPKINKx8r9r9RIfE9c70g/HThdpbmPHhDYCodHSVESDxmKeySAYw1p4liuBCf7j6LyA==,
-            }
-        engines: { node: ^22.11.0 || ^24.11.0 || >=26.0 }
-        peerDependencies:
-            postcss: ^8.5.15
-
-    postcss-ordered-values@8.0.1:
-        resolution:
-            {
-                integrity: sha512-OLXq5lR1yk3KWQ1FPK6aWjFFdktHE9f9kb8cnt4LmIw7w30DnzgD9+sOVYJc5HenkWCX8i1MJhhFwmqc/GYqLg==,
-            }
-        engines: { node: ^22.11.0 || ^24.11.0 || >=26.0 }
-        peerDependencies:
-            postcss: ^8.5.15
-
-    postcss-reduce-initial@8.0.1:
-        resolution:
-            {
-                integrity: sha512-+aQsR6+61KRoIfcFNLP3v9RM7+0iYOTtPnjl1wr6JqMW1zx6S+t2ktHRefXwacFdHIDj5+ETG0KY7K3+SGQ4Nw==,
-            }
-        engines: { node: ^22.11.0 || ^24.11.0 || >=26.0 }
-        peerDependencies:
-            postcss: ^8.5.15
-
-    postcss-reduce-transforms@8.0.1:
-        resolution:
-            {
-                integrity: sha512-x71slHVykiFi5RuKEXM0wgYpY2PngC78x6R8TnZhHF3lhqt+u/w3MGwYLX+2t5O87ssRiMfEAhQH+3J4QwVzCw==,
-            }
-        engines: { node: ^22.11.0 || ^24.11.0 || >=26.0 }
-        peerDependencies:
-            postcss: ^8.5.15
-
-    postcss-selector-parser@7.1.4:
-        resolution:
-            {
-                integrity: sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==,
-            }
-        engines: { node: '>=4' }
-
-    postcss-svgo@8.0.1:
-        resolution:
-            {
-                integrity: sha512-HpnvWii7W0/FPrsejJa6ZTi0kNtTJP/Iba7CUMPX0xPV6QpnndOp+SDP74tFtgjA2cYKYNWJPOlmLXMsvi/9yA==,
-            }
-        engines: { node: ^22.11.0 || ^24.11.0 || >=26.0 }
-        peerDependencies:
-            postcss: ^8.5.15
-
-    postcss-unique-selectors@8.0.1:
-        resolution:
-            {
-                integrity: sha512-+xvKI5+/Cl8yYQwxDV39Uhuc4WV951xngFvPPjiPj2NIbIfm6vbbRTXblyw0FioLkIoGlw+7qUcY1h2YhaZYgw==,
-            }
-        engines: { node: ^22.11.0 || ^24.11.0 || >=26.0 }
-        peerDependencies:
-            postcss: ^8.5.15
-
-    postcss-value-parser@4.2.0:
-        resolution:
-            {
-                integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==,
-            }
-
-    postcss@8.5.25:
-        resolution:
-            {
-                integrity: sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==,
-            }
-        engines: { node: ^10 || ^12 || >=14 }
-
-    prettier@2.8.8:
-        resolution:
-            {
-                integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==,
-            }
-        engines: { node: '>=10.13.0' }
-        hasBin: true
-
-    prettier@3.9.6:
-        resolution:
-            {
-                integrity: sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==,
-            }
-        engines: { node: '>=14' }
-        hasBin: true
-
-    pretty-format@27.5.1:
-        resolution:
-            {
-                integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==,
-            }
-        engines: { node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0 }
-
-    property-information@7.2.0:
-        resolution:
-            {
-                integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==,
-            }
-
-    quansync@0.2.11:
-        resolution:
-            {
-                integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==,
-            }
-
-    queue-lit@1.5.2:
-        resolution:
-            {
-                integrity: sha512-tLc36IOPeMAubu8BkW8YDBV+WyIgKlYU7zUNs0J5Vk9skSZ4JfGlPOqplP0aHdfv7HL0B2Pg6nwiq60Qc6M2Hw==,
-            }
-        engines: { node: '>=12' }
-
-    queue-microtask@1.2.3:
-        resolution:
-            {
-                integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==,
-            }
-
-    react-dom@19.2.8:
-        resolution:
-            {
-                integrity: sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==,
-            }
-        peerDependencies:
-            react: ^19.2.8
-
-    react-is@17.0.2:
-        resolution:
-            {
-                integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==,
-            }
-
-    react@19.2.8:
-        resolution:
-            {
-                integrity: sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==,
-            }
-        engines: { node: '>=0.10.0' }
-
-    read-cache@1.0.0:
-        resolution:
-            {
-                integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==,
-            }
-
-    read-yaml-file@1.1.0:
-        resolution:
-            {
-                integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==,
-            }
-        engines: { node: '>=6' }
-
-    readdirp@3.6.0:
-        resolution:
-            {
-                integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==,
-            }
-        engines: { node: '>=8.10.0' }
-
-    readdirp@4.1.2:
-        resolution:
-            {
-                integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==,
-            }
-        engines: { node: '>= 14.18.0' }
-
-    readdirp@5.0.0:
-        resolution:
-            {
-                integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==,
-            }
-        engines: { node: '>= 20.19.0' }
-
-    recast@0.23.19:
-        resolution:
-            {
-                integrity: sha512-T98lym7kH+pnZmRaD8yDRdaNqyUbwnbEBx0MuchrzMFOEMray4AO3ZJoTUZ5r78Ao78X/OhzW0DL8GB85w/I2w==,
-            }
-        engines: { node: '>= 4' }
-
-    recma-build-jsx@1.0.0:
-        resolution:
-            {
-                integrity: sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew==,
-            }
-
-    recma-jsx@1.0.1:
-        resolution:
-            {
-                integrity: sha512-huSIy7VU2Z5OLv6oFLosQGGDqPqdO1iq6bWNAdhzMxSJP7RAso4fCZ1cKu8j9YHCZf3TPrq4dw3okhrylgcd7w==,
-            }
-        peerDependencies:
-            acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
-
-    recma-parse@1.0.0:
-        resolution:
-            {
-                integrity: sha512-OYLsIGBB5Y5wjnSnQW6t3Xg7q3fQ7FWbw/vcXtORTnyaSFscOtABg+7Pnz6YZ6c27fG1/aN8CjfwoUEUIdwqWQ==,
-            }
-
-    recma-stringify@1.0.0:
-        resolution:
-            {
-                integrity: sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g==,
-            }
-
-    redent@3.0.0:
-        resolution:
-            {
-                integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==,
-            }
-        engines: { node: '>=8' }
-
-    regex-recursion@6.0.2:
-        resolution:
-            {
-                integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==,
-            }
-
-    regex-utilities@2.3.0:
-        resolution:
-            {
-                integrity: sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==,
-            }
-
-    regex@6.1.0:
-        resolution:
-            {
-                integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==,
-            }
-
-    rehype-parse@9.0.1:
-        resolution:
-            {
-                integrity: sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==,
-            }
-
-    rehype-pretty-code@0.14.5:
-        resolution:
-            {
-                integrity: sha512-+DhMMNMgOwmE0xu2RmagN63nR0GRObPIQ9TuoNdUYYIDcCr8nWXU1CJUG6yca7vg99Gp5d+62A/+ZvksmsQXjA==,
-            }
-        engines: { node: '>=18' }
-        peerDependencies:
-            shiki: ^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0
-
-    rehype-recma@1.0.0:
-        resolution:
-            {
-                integrity: sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw==,
-            }
-
-    remark-frontmatter@5.0.0:
-        resolution:
-            {
-                integrity: sha512-XTFYvNASMe5iPN0719nPrdItC9aU0ssC4v14mH1BCi1u0n1gAocqcujWUrByftZTbLhRtiKRyjYTSIOcr69UVQ==,
-            }
-
-    remark-gfm@4.0.1:
-        resolution:
-            {
-                integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==,
-            }
-
-    remark-mdx@3.1.1:
-        resolution:
-            {
-                integrity: sha512-Pjj2IYlUY3+D8x00UJsIOg5BEvfMyeI+2uLPn9VO9Wg4MEtN/VTIq2NEJQfde9PnX15KgtHyl9S0BcTnWrIuWg==,
-            }
-
-    remark-parse@11.0.0:
-        resolution:
-            {
-                integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==,
-            }
-
-    remark-rehype@11.1.2:
-        resolution:
-            {
-                integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==,
-            }
-
-    remark-stringify@11.0.0:
-        resolution:
-            {
-                integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==,
-            }
-
-    resolve-from@5.0.0:
-        resolution:
-            {
-                integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==,
-            }
-        engines: { node: '>=8' }
-
-    resolve@1.22.12:
-        resolution:
-            {
-                integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==,
-            }
-        engines: { node: '>= 0.4' }
-        hasBin: true
-
-    reusify@1.1.0:
-        resolution:
-            {
-                integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==,
-            }
-        engines: { iojs: '>=1.0.0', node: '>=0.10.0' }
-
-    rolldown@1.2.1:
-        resolution:
-            {
-                integrity: sha512-4FKJhg8d3OiyQOA6Q1Q0hoFFpW9/OoX+VsHzpECsdsIZoOArrAK90gl59YK/Z+gnDel45bgJZK03ozH/9bCqEw==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        hasBin: true
-
-    rollup@4.62.4:
-        resolution:
-            {
-                integrity: sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==,
-            }
-        engines: { node: '>=18.0.0', npm: '>=8.0.0' }
-        hasBin: true
-
-    rou3@0.9.1:
-        resolution:
-            {
-                integrity: sha512-z/sSmzvtwMDDnxsPVhfWMuG6F6mbmhFDXoVqLmMfbpDD9qfV3GDmSQpf0+W296/ZDIpW2wcMmBfpVFzcnOi/nA==,
-            }
-
-    run-applescript@7.1.0:
-        resolution:
-            {
-                integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==,
-            }
-        engines: { node: '>=18' }
-
-    run-parallel@1.2.0:
-        resolution:
-            {
-                integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==,
-            }
-
-    safer-buffer@2.1.2:
-        resolution:
-            {
-                integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==,
-            }
-
-    sax@1.6.1:
-        resolution:
-            {
-                integrity: sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==,
-            }
-        engines: { node: '>=11.0.0' }
-
-    scheduler@0.27.0:
-        resolution:
-            {
-                integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==,
-            }
-
-    semver@6.3.1:
-        resolution:
-            {
-                integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==,
-            }
-        hasBin: true
-
-    semver@7.8.5:
-        resolution:
-            {
-                integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==,
-            }
-        engines: { node: '>=10' }
-        hasBin: true
-
-    shebang-command@2.0.0:
-        resolution:
-            {
-                integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==,
-            }
-        engines: { node: '>=8' }
-
-    shebang-regex@3.0.0:
-        resolution:
-            {
-                integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==,
-            }
-        engines: { node: '>=8' }
-
-    shiki@3.23.0:
-        resolution:
-            {
-                integrity: sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==,
-            }
-
-    siginfo@2.0.0:
-        resolution:
-            {
-                integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==,
-            }
-
-    signal-exit@4.1.0:
-        resolution:
-            {
-                integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==,
-            }
-        engines: { node: '>=14' }
-
-    sirv@3.0.2:
-        resolution:
-            {
-                integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==,
-            }
-        engines: { node: '>=18' }
-
-    sisteransi@1.0.5:
-        resolution:
-            {
-                integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==,
-            }
-
-    slash@3.0.0:
-        resolution:
-            {
-                integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==,
-            }
-        engines: { node: '>=8' }
-
-    source-map-js@1.2.1:
-        resolution:
-            {
-                integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==,
-            }
-        engines: { node: '>=0.10.0' }
-
-    source-map@0.6.1:
-        resolution:
-            {
-                integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==,
-            }
-        engines: { node: '>=0.10.0' }
-
-    source-map@0.7.6:
-        resolution:
-            {
-                integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==,
-            }
-        engines: { node: '>= 12' }
-
-    source-map@0.8.0:
-        resolution:
-            {
-                integrity: sha512-d8EqvL+k/SOXCreS/SUzg2ciyHqBBLcN/yuRjFsbvVhHTE2pgei7oAhmPM7kWFbkX6OSMQfUq4KbkF3au9lhYQ==,
-            }
-        engines: { node: '>= 12' }
-
-    space-separated-tokens@2.0.2:
-        resolution:
-            {
-                integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==,
-            }
-
-    spawndamnit@3.0.1:
-        resolution:
-            {
-                integrity: sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==,
-            }
-
-    sprintf-js@1.0.3:
-        resolution:
-            {
-                integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==,
-            }
-
-    srvx@0.11.22:
-        resolution:
-            {
-                integrity: sha512-LqZxxBDMKuMAZzFzJnDCkFOrs9MZQZr0LvHiO/SuSZVdQaXD7xQ5UWTUxheJrQPve1qk9MG2B/yttUvJxw8egQ==,
-            }
-        engines: { node: '>=20.16.0' }
-        hasBin: true
-
-    srvx@0.12.5:
-        resolution:
-            {
-                integrity: sha512-IuvtDNQg5EIwv3c6dleyau7u8hCyGQ7D6+V/QM799Aud07z0wCUcurKLTRfyG33C8oUY+UWcVBFkfHMcbtmRLA==,
-            }
-        engines: { node: '>=20.16.0' }
-        hasBin: true
-
-    stackback@0.0.2:
-        resolution:
-            {
-                integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==,
-            }
-
-    std-env@4.2.0:
-        resolution:
-            {
-                integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==,
-            }
-
-    storybook@10.5.5:
-        resolution:
-            {
-                integrity: sha512-UscBIBJDloUeqntukHOhP1a5W/vouePDJbzPSxj466WK801FZtzQiMffMtkjzJiWSuj20wfaYlB2QQKh9aOYAg==,
-            }
-        hasBin: true
-        peerDependencies:
-            '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-            prettier: ^2 || ^3
-            vite-plus: ^0.1.15 || ^0.2.0
-        peerDependenciesMeta:
-            '@types/react':
-                optional: true
-            prettier:
-                optional: true
-            vite-plus:
-                optional: true
-
-    stringify-entities@4.0.4:
-        resolution:
-            {
-                integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==,
-            }
-
-    strip-ansi@6.0.1:
-        resolution:
-            {
-                integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==,
-            }
-        engines: { node: '>=8' }
-
-    strip-ansi@7.2.0:
-        resolution:
-            {
-                integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==,
-            }
-        engines: { node: '>=12' }
-
-    strip-bom@3.0.0:
-        resolution:
-            {
-                integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==,
-            }
-        engines: { node: '>=4' }
-
-    strip-indent@3.0.0:
-        resolution:
-            {
-                integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==,
-            }
-        engines: { node: '>=8' }
-
-    stubborn-fs@2.0.0:
-        resolution:
-            {
-                integrity: sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==,
-            }
-
-    stubborn-utils@1.0.2:
-        resolution:
-            {
-                integrity: sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==,
-            }
-
-    style-to-js@1.1.21:
-        resolution:
-            {
-                integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==,
-            }
-
-    style-to-object@1.0.14:
-        resolution:
-            {
-                integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==,
-            }
-
-    stylehacks@8.0.1:
-        resolution:
-            {
-                integrity: sha512-Gv095oTD0N+BdJALNFDsxZpETHZLTxbOl5RyIO7y6VAE6sR3z0MnV3Nix7N0IATNldNTrkvSASp2KR1Yt526HA==,
-            }
-        engines: { node: ^22.11.0 || ^24.11.0 || >=26.0 }
-        peerDependencies:
-            postcss: ^8.5.15
-
-    sucrase@3.35.1:
-        resolution:
-            {
-                integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==,
-            }
-        engines: { node: '>=16 || 14 >=14.17' }
-        hasBin: true
-
-    supports-color@7.2.0:
-        resolution:
-            {
-                integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==,
-            }
-        engines: { node: '>=8' }
-
-    supports-preserve-symlinks-flag@1.0.0:
-        resolution:
-            {
-                integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==,
-            }
-        engines: { node: '>= 0.4' }
-
-    svgo@4.0.2:
-        resolution:
-            {
-                integrity: sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng==,
-            }
-        engines: { node: '>=16' }
-        hasBin: true
-
-    tagged-tag@1.0.0:
-        resolution:
-            {
-                integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==,
-            }
-        engines: { node: '>=20' }
-
-    tailwindcss@4.3.3:
-        resolution:
-            {
-                integrity: sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==,
-            }
-
-    tapable@2.3.3:
-        resolution:
-            {
-                integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==,
-            }
-        engines: { node: '>=6' }
-
-    term-size@2.2.1:
-        resolution:
-            {
-                integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==,
-            }
-        engines: { node: '>=8' }
-
-    thenify-all@1.6.0:
-        resolution:
-            {
-                integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==,
-            }
-        engines: { node: '>=0.8' }
-
-    thenify@3.3.1:
-        resolution:
-            {
-                integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==,
-            }
-
-    tiny-invariant@1.3.3:
-        resolution:
-            {
-                integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==,
-            }
-
-    tinybench@2.9.0:
-        resolution:
-            {
-                integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==,
-            }
-
-    tinyexec@0.3.2:
-        resolution:
-            {
-                integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==,
-            }
-
-    tinyexec@1.3.0:
-        resolution:
-            {
-                integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==,
-            }
-        engines: { node: '>=18' }
-
-    tinyglobby@0.2.17:
-        resolution:
-            {
-                integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==,
-            }
-        engines: { node: '>=12.0.0' }
-
-    tinyrainbow@2.0.0:
-        resolution:
-            {
-                integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==,
-            }
-        engines: { node: '>=14.0.0' }
-
-    tinyrainbow@3.1.1:
-        resolution:
-            {
-                integrity: sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==,
-            }
-        engines: { node: '>=14.0.0' }
-
-    tinyspy@4.0.4:
-        resolution:
-            {
-                integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==,
-            }
-        engines: { node: '>=14.0.0' }
-
-    to-regex-range@5.0.1:
-        resolution:
-            {
-                integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==,
-            }
-        engines: { node: '>=8.0' }
-
-    totalist@3.0.1:
-        resolution:
-            {
-                integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==,
-            }
-        engines: { node: '>=6' }
-
-    tr46@0.0.3:
-        resolution:
-            {
-                integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==,
-            }
-
-    tree-kill@1.2.2:
-        resolution:
-            {
-                integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==,
-            }
-        hasBin: true
-
-    trim-lines@3.0.1:
-        resolution:
-            {
-                integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==,
-            }
-
-    trough@2.2.0:
-        resolution:
-            {
-                integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==,
-            }
-
-    ts-dedent@2.3.0:
-        resolution:
-            {
-                integrity: sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==,
-            }
-        engines: { node: '>=6.10' }
-
-    ts-interface-checker@0.1.13:
-        resolution:
-            {
-                integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==,
-            }
-
-    tsc-alias@1.8.10:
-        resolution:
-            {
-                integrity: sha512-Ibv4KAWfFkFdKJxnWfVtdOmB0Zi1RJVxcbPGiCDsFpCQSsmpWyuzHG3rQyI5YkobWwxFPEyQfu1hdo4qLG2zPw==,
-            }
-        hasBin: true
-
-    tslib@2.8.1:
-        resolution:
-            {
-                integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==,
-            }
-
-    tsup@8.5.1:
-        resolution:
-            {
-                integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==,
-            }
-        engines: { node: '>=18' }
-        hasBin: true
-        peerDependencies:
-            '@microsoft/api-extractor': ^7.36.0
-            '@swc/core': ^1
-            postcss: ^8.4.12
-            typescript: '>=4.5.0'
-        peerDependenciesMeta:
-            '@microsoft/api-extractor':
-                optional: true
-            '@swc/core':
-                optional: true
-            postcss:
-                optional: true
-            typescript:
-                optional: true
-
-    tsx@4.23.1:
-        resolution:
-            {
-                integrity: sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==,
-            }
-        engines: { node: '>=18.0.0' }
-        hasBin: true
-
-    type-fest@5.8.0:
-        resolution:
-            {
-                integrity: sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==,
-            }
-        engines: { node: '>=20' }
-
-    typescript@7.0.2:
-        resolution:
-            {
-                integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==,
-            }
-        engines: { node: '>=16.20.0' }
-        hasBin: true
-
-    ufo@1.6.4:
-        resolution:
-            {
-                integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==,
-            }
-
-    undici-types@7.18.2:
-        resolution:
-            {
-                integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==,
-            }
-
-    unenv@2.0.0-rc.24:
-        resolution:
-            {
-                integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==,
-            }
-
-    unified@11.0.5:
-        resolution:
-            {
-                integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==,
-            }
-
-    unist-util-is@6.0.1:
-        resolution:
-            {
-                integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==,
-            }
-
-    unist-util-position-from-estree@2.0.0:
-        resolution:
-            {
-                integrity: sha512-KaFVRjoqLyF6YXCbVLNad/eS4+OfPQQn2yOd7zF/h5T/CSL2v8NpN6a5TPvtbXthAGw5nG+PuTtq+DdIZr+cRQ==,
-            }
-
-    unist-util-position@5.0.0:
-        resolution:
-            {
-                integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==,
-            }
-
-    unist-util-stringify-position@4.0.0:
-        resolution:
-            {
-                integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==,
-            }
-
-    unist-util-visit-parents@6.0.2:
-        resolution:
-            {
-                integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==,
-            }
-
-    unist-util-visit@5.1.0:
-        resolution:
-            {
-                integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==,
-            }
-
-    universalify@0.1.2:
-        resolution:
-            {
-                integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==,
-            }
-        engines: { node: '>= 4.0.0' }
-
-    universalify@2.0.1:
-        resolution:
-            {
-                integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==,
-            }
-        engines: { node: '>= 10.0.0' }
-
-    unplugin@2.3.11:
-        resolution:
-            {
-                integrity: sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==,
-            }
-        engines: { node: '>=18.12.0' }
-
-    unstorage@2.0.0-alpha.7:
-        resolution:
-            {
-                integrity: sha512-ELPztchk2zgFJnakyodVY3vJWGW9jy//keJ32IOJVGUMyaPydwcA1FtVvWqT0TNRch9H+cMNEGllfVFfScImog==,
-            }
-        peerDependencies:
-            '@azure/app-configuration': ^1.11.0
-            '@azure/cosmos': ^4.9.1
-            '@azure/data-tables': ^13.3.2
-            '@azure/identity': ^4.13.0
-            '@azure/keyvault-secrets': ^4.10.0
-            '@azure/storage-blob': ^12.31.0
-            '@capacitor/preferences': ^6 || ^7 || ^8
-            '@deno/kv': '>=0.13.0'
-            '@netlify/blobs': ^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0
-            '@planetscale/database': ^1.19.0
-            '@upstash/redis': ^1.36.2
-            '@vercel/blob': '>=0.27.3'
-            '@vercel/functions': ^2.2.12 || ^3.0.0
-            '@vercel/kv': ^1.0.1
-            aws4fetch: ^1.0.20
-            chokidar: ^4 || ^5
-            db0: '>=0.3.4'
-            idb-keyval: ^6.2.2
-            ioredis: ^5.9.3
-            lru-cache: ^11.2.6
-            mongodb: ^6 || ^7
-            ofetch: '*'
-            uploadthing: ^7.7.4
-        peerDependenciesMeta:
-            '@azure/app-configuration':
-                optional: true
-            '@azure/cosmos':
-                optional: true
-            '@azure/data-tables':
-                optional: true
-            '@azure/identity':
-                optional: true
-            '@azure/keyvault-secrets':
-                optional: true
-            '@azure/storage-blob':
-                optional: true
-            '@capacitor/preferences':
-                optional: true
-            '@deno/kv':
-                optional: true
-            '@netlify/blobs':
-                optional: true
-            '@planetscale/database':
-                optional: true
-            '@upstash/redis':
-                optional: true
-            '@vercel/blob':
-                optional: true
-            '@vercel/functions':
-                optional: true
-            '@vercel/kv':
-                optional: true
-            aws4fetch:
-                optional: true
-            chokidar:
-                optional: true
-            db0:
-                optional: true
-            idb-keyval:
-                optional: true
-            ioredis:
-                optional: true
-            lru-cache:
-                optional: true
-            mongodb:
-                optional: true
-            ofetch:
-                optional: true
-            uploadthing:
-                optional: true
-
-    update-browserslist-db@1.2.3:
-        resolution:
-            {
-                integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==,
-            }
-        hasBin: true
-        peerDependencies:
-            browserslist: '>= 4.21.0'
-
-    use-sync-external-store@1.6.0:
-        resolution:
-            {
-                integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==,
-            }
-        peerDependencies:
-            react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
-    util-deprecate@1.0.2:
-        resolution:
-            {
-                integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==,
-            }
-
-    valibot@1.4.2:
-        resolution:
-            {
-                integrity: sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==,
-            }
-        peerDependencies:
-            typescript: '>=5'
-        peerDependenciesMeta:
-            typescript:
-                optional: true
-
-    vfile-location@5.0.3:
-        resolution:
-            {
-                integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==,
-            }
-
-    vfile-matter@5.0.1:
-        resolution:
-            {
-                integrity: sha512-o6roP82AiX0XfkyTHyRCMXgHfltUNlXSEqCIS80f+mbAyiQBE2fxtDVMtseyytGx75sihiJFo/zR6r/4LTs2Cw==,
-            }
-
-    vfile-message@4.0.3:
-        resolution:
-            {
-                integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==,
-            }
-
-    vfile@6.0.3:
-        resolution:
-            {
-                integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==,
-            }
-
-    vite@8.2.0:
-        resolution:
-            {
-                integrity: sha512-pn+CFpM0lwDeKwmOq1ZaBK/9sjorZcgqxki6MbY/jPEVd9vichIlmlD4HmQ5wdP5EgqQCFRaACBxMC7uEGc6lQ==,
-            }
-        engines: { node: ^20.19.0 || >=22.12.0 }
-        hasBin: true
-        peerDependencies:
-            '@types/node': ^20.19.0 || >=22.12.0
-            '@vitejs/devtools': ^0.4.0
-            esbuild: ^0.27.0 || ^0.28.0
-            jiti: '>=1.21.0'
-            less: ^4.0.0
-            sass: ^1.70.0
-            sass-embedded: ^1.70.0
-            stylus: '>=0.54.8'
-            sugarss: ^5.0.0
-            terser: ^5.16.0
-            tsx: ^4.8.1
-            yaml: ^2.4.2
-        peerDependenciesMeta:
-            '@types/node':
-                optional: true
-            '@vitejs/devtools':
-                optional: true
-            esbuild:
-                optional: true
-            jiti:
-                optional: true
-            less:
-                optional: true
-            sass:
-                optional: true
-            sass-embedded:
-                optional: true
-            stylus:
-                optional: true
-            sugarss:
-                optional: true
-            terser:
-                optional: true
-            tsx:
-                optional: true
-            yaml:
-                optional: true
-
-    vitest@4.1.10:
-        resolution:
-            {
-                integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==,
-            }
-        engines: { node: ^20.0.0 || ^22.0.0 || >=24.0.0 }
-        hasBin: true
-        peerDependencies:
-            '@edge-runtime/vm': '*'
-            '@opentelemetry/api': ^1.9.0
-            '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-            '@vitest/browser-playwright': 4.1.10
-            '@vitest/browser-preview': 4.1.10
-            '@vitest/browser-webdriverio': 4.1.10
-            '@vitest/coverage-istanbul': 4.1.10
-            '@vitest/coverage-v8': 4.1.10
-            '@vitest/ui': 4.1.10
-            happy-dom: '*'
-            jsdom: '*'
-            vite: ^6.0.0 || ^7.0.0 || ^8.0.0
-        peerDependenciesMeta:
-            '@edge-runtime/vm':
-                optional: true
-            '@opentelemetry/api':
-                optional: true
-            '@types/node':
-                optional: true
-            '@vitest/browser-playwright':
-                optional: true
-            '@vitest/browser-preview':
-                optional: true
-            '@vitest/browser-webdriverio':
-                optional: true
-            '@vitest/coverage-istanbul':
-                optional: true
-            '@vitest/coverage-v8':
-                optional: true
-            '@vitest/ui':
-                optional: true
-            happy-dom:
-                optional: true
-            jsdom:
-                optional: true
-
-    web-namespaces@2.0.1:
-        resolution:
-            {
-                integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==,
-            }
-
-    webidl-conversions@3.0.1:
-        resolution:
-            {
-                integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==,
-            }
-
-    webpack-virtual-modules@0.6.2:
-        resolution:
-            {
-                integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==,
-            }
-
-    whatwg-mimetype@3.0.0:
-        resolution:
-            {
-                integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==,
-            }
-        engines: { node: '>=12' }
-
-    whatwg-url@5.0.0:
-        resolution:
-            {
-                integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==,
-            }
-
-    when-exit@2.1.5:
-        resolution:
-            {
-                integrity: sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==,
-            }
-
-    which@2.0.2:
-        resolution:
-            {
-                integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==,
-            }
-        engines: { node: '>= 8' }
-        hasBin: true
-
-    why-is-node-running@2.3.0:
-        resolution:
-            {
-                integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==,
-            }
-        engines: { node: '>=8' }
-        hasBin: true
-
-    ws@8.21.1:
-        resolution:
-            {
-                integrity: sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==,
-            }
-        engines: { node: '>=10.0.0' }
-        peerDependencies:
-            bufferutil: ^4.0.1
-            utf-8-validate: '>=5.0.2'
-        peerDependenciesMeta:
-            bufferutil:
-                optional: true
-            utf-8-validate:
-                optional: true
-
-    wsl-utils@0.1.0:
-        resolution:
-            {
-                integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==,
-            }
-        engines: { node: '>=18' }
-
-    xdg-basedir@5.1.0:
-        resolution:
-            {
-                integrity: sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ==,
-            }
-        engines: { node: '>=12' }
-
-    yallist@3.1.1:
-        resolution:
-            {
-                integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==,
-            }
-
-    yaml@2.9.0:
-        resolution:
-            {
-                integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==,
-            }
-        engines: { node: '>= 14.6' }
-        hasBin: true
-
-    zod@4.4.3:
-        resolution:
-            {
-                integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==,
-            }
-
-    zwitch@2.0.4:
-        resolution:
-            {
-                integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==,
-            }
+
+  '@adobe/css-tools@4.5.0':
+    resolution: {integrity: sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==}
+
+  '@alloc/quick-lru@5.2.0':
+    resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
+    engines: {node: '>=10'}
+
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.29.7':
+    resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.7':
+    resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.8':
+    resolution: {integrity: sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-annotate-as-pure@7.29.7':
+    resolution: {integrity: sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.29.7':
+    resolution: {integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-create-class-features-plugin@7.29.7':
+    resolution: {integrity: sha512-IY3ZD9Tmooqr3TUhc3DUWxiuo8xx1DWLhd5M7hQ+ZWJamqM2BbalrBJb2MisSLoYorOj75U03qULCxQTY9r3hg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-globals@7.29.7':
+    resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-member-expression-to-functions@7.29.7':
+    resolution: {integrity: sha512-j+7JYmk1JYDtACIGj0QJqqWZjoUpMoEikQGADMaHgCMCSDqd2+P32rfcibUNrGOMWrlzK1WJBdxrB3JJQZwWtg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.29.7':
+    resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.29.7':
+    resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-optimise-call-expression@7.29.7':
+    resolution: {integrity: sha512-+kmGVjcT9RGYzoDwdwEqEvGgKe3BYq+O1iGzjFubaNgZHwYHP6lsF2Yghf4kEuv9BV7tYDZ913aBW9am6YKong==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-plugin-utils@7.29.7':
+    resolution: {integrity: sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-replace-supers@7.29.7':
+    resolution: {integrity: sha512-atfGXWSeCiF4DnKZIfmJfQRkSw9b9gNNXR1kqKjbhG4pGYCOnkp8OcTB8E3NXjBu8NpheSnOeNKz8KT7UNFTmQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-skip-transparent-expression-wrappers@7.29.7':
+    resolution: {integrity: sha512-brcMGQaVzIeUb+6/bs1Av0f8YuNNjKY2JyvfRCsFuFsdKccEQ5Ges2y74D74NZ1Rz8lKJ9ksJkfqwQFJ/iNEyQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-string-parser@8.0.0':
+    resolution: {integrity: sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@8.0.4':
+    resolution: {integrity: sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
+  '@babel/helper-validator-option@7.29.7':
+    resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.29.7':
+    resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.8':
+    resolution: {integrity: sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/plugin-proposal-decorators@7.29.7':
+    resolution: {integrity: sha512-EtU0Hi3GvrTqD56xKmZvV/uCXK2ZbwVNPNLAquVItcAZpUhkXwWlo3Fmj0c2LxgSf2I8IDULeAepwNP1OefLXg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-decorators@7.29.7':
+    resolution: {integrity: sha512-9MTTLbF39X6sqM92JPEsoI7++26hjZvzkxKZy64aMhWLH2mPkJ/Q3AV4QLmls3R14FpSpkOwQQfUh962JGQxxg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-typescript@7.29.7':
+    resolution: {integrity: sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-class-properties@7.29.7':
+    resolution: {integrity: sha512-GtcpjFvanPfzNQi3eTitsCqtRRmmqzpy/A+yhTR1HaZo1Ly3EA8ZXxlPyHdR8/IuRMYc3E4wdGBewB2QKQjAaA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/template@7.29.7':
+    resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.8':
+    resolution: {integrity: sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.8':
+    resolution: {integrity: sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@8.0.4':
+    resolution: {integrity: sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
+
+  '@blazediff/core@1.9.1':
+    resolution: {integrity: sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA==}
+
+  '@bomb.sh/args@0.3.1':
+    resolution: {integrity: sha512-CwxKrfgcorUPP6KfYD59aRdBYWBTsfsxT+GmoLVnKo5Tmyoqbpo0UNcjngRMyU+6tiPbd18RuIYxhgAn44wU/Q==}
+
+  '@changesets/apply-release-plan@7.1.1':
+    resolution: {integrity: sha512-9qPCm/rLx/xoOFXIHGB229+4GOL76S4MC+7tyOuTsR6+1jYlfFDQORdvwR5hDA6y4FL2BPt3qpbcQIS+dW85LA==}
+
+  '@changesets/assemble-release-plan@6.0.10':
+    resolution: {integrity: sha512-rSDcqdJ9KbVyjpBIuCidhvZNIiVt1XaIYp73ycVQRIA5n/j6wQaEk0ChRLMUQ1vkxZe51PTQ9OIhbg6HQMW45A==}
+
+  '@changesets/changelog-git@0.2.1':
+    resolution: {integrity: sha512-x/xEleCFLH28c3bQeQIyeZf8lFXyDFVn1SgcBiR2Tw/r4IAWlk1fzxCEZ6NxQAjF2Nwtczoen3OA2qR+UawQ8Q==}
+
+  '@changesets/changelog-github@0.5.2':
+    resolution: {integrity: sha512-HeGeDl8HaIGj9fQHo/tv5XKQ2SNEi9+9yl1Bss1jttPqeiASRXhfi0A2wv8yFKCp07kR1gpOI5ge6+CWNm1jPw==}
+
+  '@changesets/cli@2.31.1':
+    resolution: {integrity: sha512-uO05WTcRBwuVOJVSW8Cmpqw6q0WDL53ajGCMyszutvOe5toOnunbpM4jZzf+qxBOz7i0AzopZ8diBuewjmF40w==}
+    hasBin: true
+
+  '@changesets/config@3.1.4':
+    resolution: {integrity: sha512-pf0bvD/v6WI2cRlZ6hzpjtZdSlXDXMAJ+Iz7xfFzV4ZxJ8OGGAON+1qYc99ZPrijnt4xp3VGG7eNvAOGS24V1Q==}
+
+  '@changesets/errors@0.2.0':
+    resolution: {integrity: sha512-6BLOQUscTpZeGljvyQXlWOItQyU71kCdGz7Pi8H8zdw6BI0g3m43iL4xKUVPWtG+qrrL9DTjpdn8eYuCQSRpow==}
+
+  '@changesets/get-dependents-graph@2.1.4':
+    resolution: {integrity: sha512-ZsS00x6WvmHq3sQv8oCMwL0f/z3wbXCVuSVTJwCnnmbC/iBdNJGFx1EcbMG4PC6sXRyH69liM4A2WKXzn/kRPg==}
+
+  '@changesets/get-github-info@0.7.0':
+    resolution: {integrity: sha512-+i67Bmhfj9V4KfDeS1+Tz3iF32btKZB2AAx+cYMqDSRFP7r3/ZdGbjCo+c6qkyViN9ygDuBjzageuPGJtKGe5A==}
+
+  '@changesets/get-release-plan@4.0.16':
+    resolution: {integrity: sha512-2K5Om6CrMPm45rtvckfzWo7e9jOVCKLCnXia5eUPaURH7/LWzri7pK1TycdzAuAtehLkW7VPbWLCSExTHmiI6g==}
+
+  '@changesets/get-version-range-type@0.4.0':
+    resolution: {integrity: sha512-hwawtob9DryoGTpixy1D3ZXbGgJu1Rhr+ySH2PvTLHvkZuQ7sRT4oQwMh0hbqZH1weAooedEjRsbrWcGLCeyVQ==}
+
+  '@changesets/git@3.0.4':
+    resolution: {integrity: sha512-BXANzRFkX+XcC1q/d27NKvlJ1yf7PSAgi8JG6dt8EfbHFHi4neau7mufcSca5zRhwOL8j9s6EqsxmT+s+/E6Sw==}
+
+  '@changesets/logger@0.1.1':
+    resolution: {integrity: sha512-OQtR36ZlnuTxKqoW4Sv6x5YIhOmClRd5pWsjZsddYxpWs517R0HkyiefQPIytCVh4ZcC5x9XaG8KTdd5iRQUfg==}
+
+  '@changesets/parse@0.4.3':
+    resolution: {integrity: sha512-ZDmNc53+dXdWEv7fqIUSgRQOLYoUom5Z40gmLgmATmYR9NbL6FJJHwakcCpzaeCy+1D0m0n7mT4jj2B/MQPl7A==}
+
+  '@changesets/pre@2.0.2':
+    resolution: {integrity: sha512-HaL/gEyFVvkf9KFg6484wR9s0qjAXlZ8qWPDkTyKF6+zqjBe/I2mygg3MbpZ++hdi0ToqNUF8cjj7fBy0dg8Ug==}
+
+  '@changesets/read@0.6.7':
+    resolution: {integrity: sha512-D1G4AUYGrBEk8vj8MGwf75k9GpN6XL3wg8i42P2jZZwFLXnlr2Pn7r9yuQNbaMCarP7ZQWNJbV6XLeysAIMhTA==}
+
+  '@changesets/should-skip-package@0.1.2':
+    resolution: {integrity: sha512-qAK/WrqWLNCP22UDdBTMPH5f41elVDlsNyat180A33dWxuUDyNpg6fPi/FyTZwRriVjg0L8gnjJn2F9XAoF0qw==}
+
+  '@changesets/types@4.1.0':
+    resolution: {integrity: sha512-LDQvVDv5Kb50ny2s25Fhm3d9QSZimsoUGBsUioj6MC3qbMUCuC8GPIvk/M6IvXx3lYhAs0lwWUQLb+VIEUCECw==}
+
+  '@changesets/types@6.1.0':
+    resolution: {integrity: sha512-rKQcJ+o1nKNgeoYRHKOS07tAMNd3YSN0uHaJOZYjBAgxfV7TUE7JE+z4BzZdQwb5hKaYbayKN5KrYV7ODb2rAA==}
+
+  '@changesets/write@0.4.0':
+    resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
+
+  '@chromatic-com/storybook@5.3.0':
+    resolution: {integrity: sha512-gMAfVYJnF/tjdY8C3Q54KYz/low2NFjPIZMpCqSFuMUiTJ2DNWCTb7mFhuuzZ1iduWFDhewlJyilFmvKcEDYRA==}
+    engines: {node: '>=20.0.0', yarn: '>=1.22.18'}
+    peerDependencies:
+      storybook: ^0.0.0-0 || ^10.1.0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0 || ^10.4.0-0 || ^10.5.0-0 || ^10.6.0-0
+
+  '@clack/core@1.4.3':
+    resolution: {integrity: sha512-/kr3UWNtdJfxZtPgDqUOmG2pvwlmcLGheex5yiZKdwbzZJxhV+HMNR9QNmyY5cGwTNV6LrR7Jtp+KjhUAP1qBQ==}
+    engines: {node: '>= 20.12.0'}
+
+  '@clack/prompts@1.7.0':
+    resolution: {integrity: sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A==}
+    engines: {node: '>= 20.12.0'}
+
+  '@colordx/core@5.5.0':
+    resolution: {integrity: sha512-3PxTH8itZzltK0U9jTwVVnjLXvnDYuq3m+QXsHkENxWiPRh4WaoLcs1SQjqgZ55kS+QyirpH5BVwzP2gMVG6EQ==}
+
+  '@ecopages/browser-router@0.2.0-beta.43':
+    resolution: {integrity: sha512-2gBmDUvqP82Oaec7o5/c/jIscbCdYMnjdCZvhDLZnqTb2DN/ahyDnSPeh5bsT+BK2a3xoBP5M3OTXZE4I7R2oA==}
+    peerDependencies:
+      '@ecopages/core': 0.2.0-beta.43
+
+  '@ecopages/content-processor@0.2.0-beta.43':
+    resolution: {integrity: sha512-19Sn9iesmma+nMCMdrEG+QX0UOSy4X6UZi7CGzpvV1KjqKRQGypW95bBfYFgTobT3bRjw/nKrN8oBzW4npm9ew==}
+    peerDependencies:
+      '@ecopages/core': 0.2.0-beta.43
+
+  '@ecopages/core@0.2.0-beta.43':
+    resolution: {integrity: sha512-BvBxKugEVZ4EtfpwIJmbOjdsfuuYO/1NGT0aONoELSLUdCqotVTfymqoSMPV8vRW91jY61A3RGiKQPskx8XB6g==}
+    peerDependencies:
+      '@ecopages/dev-toolbar': 0.2.0-beta.43
+    peerDependenciesMeta:
+      '@ecopages/dev-toolbar':
+        optional: true
+
+  '@ecopages/dev-toolbar@0.2.0-beta.43':
+    resolution: {integrity: sha512-q7T4NGRlBs/mih7jRUW76gNdeBfSorIh23DHYTblrtjdYEUGRleHA0dLyiWne6GMjwifzUqLsvsoCnA4fq9v/w==}
+
+  '@ecopages/ecopages-jsx@0.2.0-beta.43':
+    resolution: {integrity: sha512-HOy4Tm3H7ZZIc4L42duCgBkw9RQ5F49MHstbvA5JMjQ9GW72jRxthovKHy2kG0fOXvVxCu97SUjGEUB16JbhoA==}
+    peerDependencies:
+      '@ecopages/core': 0.2.0-beta.43
+      '@ecopages/jsx': 0.3.0-beta.6
+      '@ecopages/radiant': 0.3.0-beta.6
+
+  '@ecopages/file-system@0.2.0-beta.43':
+    resolution: {integrity: sha512-SMFrJhYUyohrDe2Dpa7fT15G7PtsNrPzKYRIMgvQwWNAn+fT+PUcJ/tolmu49OZzjH4zj7yexbVOx23HiRpwqQ==}
+
+  '@ecopages/jsx@0.3.0-beta.6':
+    resolution: {integrity: sha512-0899gAdflauLTRWX0ul5kxJUEaALOKl4JGL9Dq42xncfWVSkEVdNTl6JIl5jx/EpXInYWn4JOflhYWv+/R6OUQ==}
+    peerDependencies:
+      '@ecopages/signals': '>=0.3.0-beta.6'
+
+  '@ecopages/logger@0.2.3':
+    resolution: {integrity: sha512-Hkt5H9Kzv6y07aiPZPaDkJ6/Bp7+Aen5ZFuI5zQ6ON7PyeuVu1lMiQy9pL+9Wm8yeO3wnMO44Jmph84Cc0X0lQ==}
+    peerDependencies:
+      typescript: ^5.0.0
+
+  '@ecopages/mdx@0.2.0-beta.43':
+    resolution: {integrity: sha512-0KAalriXkrnsTV7/YKAK9mXJ503iH4CFaG/ZTbbrTwfc52nsPp42R54wVZonP4XtuhjUbMOe0Dw8bAAyYllgQA==}
+    peerDependencies:
+      '@ecopages/core': 0.2.0-beta.43
+      '@mdx-js/mdx': ^3.1.0
+
+  '@ecopages/postcss-processor@0.2.0-beta.43':
+    resolution: {integrity: sha512-Ng1omlA+3LtEPVOzkrNw6R2ETGLwTCxdPxybGLzS5gc3Et0fYd35I7TC14Eey29309QdmGQ1qA581rbTeIfl6g==}
+    peerDependencies:
+      '@ecopages/core': 0.2.0-beta.43
+      '@tailwindcss/postcss': '>=4'
+      tailwindcss: '>=3'
+    peerDependenciesMeta:
+      '@tailwindcss/postcss':
+        optional: true
+      tailwindcss:
+        optional: true
+
+  '@ecopages/radiant@0.3.0-beta.6':
+    resolution: {integrity: sha512-pXBAjkZioF8pQhBcwTpLB4AbsPRmuH228n5m4yHHK/XEVp0u69f4eEsF5RgJ5t6nFiw3h5pWmF0t4llnLHVcpg==}
+    peerDependencies:
+      '@ecopages/jsx': '>=0.3.0-beta.6'
+
+  '@ecopages/radiant@0.3.0-beta.8':
+    resolution: {integrity: sha512-jaFs82UUMqSybIkGL3HT2sp+ZaXj4cbIMRdE1Xee72n91xziEOn8wEsXLIPNgdB9lji1lY4NuJG+IVP2NSd8uQ==}
+    peerDependencies:
+      '@ecopages/jsx': '>=0.3.0-beta.8'
+
+  '@ecopages/scripts-injector@0.1.5':
+    resolution: {integrity: sha512-4julGcmVkf4G8asK0/vAZ9o9bIWudEyGk4D/rRF/IE2J4ePT5FgmR8QdzRxD+DElzEnkJTnS7gyX2Dj7JeNtdg==}
+    peerDependencies:
+      typescript: ^5.0.0
+
+  '@ecopages/signals@0.3.0-beta.6':
+    resolution: {integrity: sha512-VjF9D5kiTSQGx3k3Dqe5pmvkjb8uI6Fo7+3Zw4ed9jTPEa4cnk/COhm5JGOTQnXvqg3i1zOQNVMOi+WeiMs1ng==}
+
+  '@ecopages/signals@0.3.0-beta.8':
+    resolution: {integrity: sha512-fZSFmzNeoCWQGKLB32VnovwtojPH9YwSId44eyK2ynXDnGRqtxoQIG12TWBScUM520VvoX3efFqp9riWyXv6tg==}
+
+  '@emnapi/core@1.11.2':
+    resolution: {integrity: sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==}
+
+  '@emnapi/core@1.9.2':
+    resolution: {integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==}
+
+  '@emnapi/runtime@1.11.2':
+    resolution: {integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==}
+
+  '@emnapi/runtime@1.9.2':
+    resolution: {integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@emnapi/wasi-threads@1.2.2':
+    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
+
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/aix-ppc64@0.28.2':
+    resolution: {integrity: sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.28.2':
+    resolution: {integrity: sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.2':
+    resolution: {integrity: sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.2':
+    resolution: {integrity: sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-arm64@0.28.2':
+    resolution: {integrity: sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.2':
+    resolution: {integrity: sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-arm64@0.28.2':
+    resolution: {integrity: sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.2':
+    resolution: {integrity: sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm64@0.28.2':
+    resolution: {integrity: sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.2':
+    resolution: {integrity: sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.2':
+    resolution: {integrity: sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.2':
+    resolution: {integrity: sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.2':
+    resolution: {integrity: sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.2':
+    resolution: {integrity: sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.2':
+    resolution: {integrity: sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.2':
+    resolution: {integrity: sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.2':
+    resolution: {integrity: sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.2':
+    resolution: {integrity: sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.2':
+    resolution: {integrity: sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.28.2':
+    resolution: {integrity: sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.28.2':
+    resolution: {integrity: sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.28.2':
+    resolution: {integrity: sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.2':
+    resolution: {integrity: sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.2':
+    resolution: {integrity: sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@inquirer/external-editor@1.0.3':
+    resolution: {integrity: sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@istanbuljs/schema@0.1.6':
+    resolution: {integrity: sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==}
+    engines: {node: '>=8'}
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@manypkg/find-root@1.1.0':
+    resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
+
+  '@manypkg/get-packages@1.1.3':
+    resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
+
+  '@mdx-js/esbuild@3.1.1':
+    resolution: {integrity: sha512-NS35VhTdvKNj5/B1JSD5W3kN1R0WDHgk+zCWq+tSChQw5L2Bgeiz7yyZPFrc5LWuPVOxE1xMbJr82bO9VVzmfQ==}
+    peerDependencies:
+      esbuild: '>=0.14.0'
+
+  '@mdx-js/mdx@3.1.1':
+    resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
+
+  '@mdx-js/react@3.1.1':
+    resolution: {integrity: sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==}
+    peerDependencies:
+      '@types/react': '>=16'
+      react: '>=16'
+
+  '@napi-rs/lzma-linux-x64-gnu@1.5.1':
+    resolution: {integrity: sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==}
+    engines: {node: ^22.20 || ^24.12 || >=25}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/wasm-runtime@1.2.3':
+    resolution: {integrity: sha512-UMduMbqO5s5zF2NkNacMT/yK5Y5QiKvWr2+50bzIIxFDwVJ2h49b+oyjaCGPhJxd2/gC2x39EHv/gHVuu36x2Q==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=23.5.0}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1 || ^2.0.0-alpha.4
+      '@emnapi/runtime': ^1.7.1 || ^2.0.0-alpha.4
+
+  '@neoconfetti/react@1.0.0':
+    resolution: {integrity: sha512-klcSooChXXOzIm+SE5IISIAn3bYzYfPjbX7D7HoqZL84oAfgREeSg5vSIaSFH+DaGzzvImTyWe1OyrJ67vik4A==}
+
+  '@nodelib/fs.scandir@2.1.5':
+    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.stat@2.0.5':
+    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.walk@1.2.8':
+    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
+    engines: {node: '>= 8'}
+
+  '@oxc-parser/binding-android-arm-eabi@0.127.0':
+    resolution: {integrity: sha512-0LC7ye4hvqbIKxAzThzvswgHLFu2AURKzYLeSVvLdu2TBOYWQDmHnTqPLeA597BcUCxiLqLsS4CJ5uoI5WYWCQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxc-parser/binding-android-arm-eabi@0.141.0':
+    resolution: {integrity: sha512-jk7086MFvR/T4DG9IY7MKBVt1PMxvSZoz/TvnifodvS0pjghVwJHRttnAExhlwdMOgHv1TmLdENnbNpYk2zjvA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxc-parser/binding-android-arm64@0.127.0':
+    resolution: {integrity: sha512-b5jtVTH6AU5CJXHNdj7Jj9IEiR9yVjjnwHzPJhGyHGPdcsZSzBCkS9GBbV33niRMvKthDwQRFRJfI4a+k4PvYg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxc-parser/binding-android-arm64@0.141.0':
+    resolution: {integrity: sha512-a4XDQ27ZT7e7zwAlxJDTiCA7IBGWDuy2+MhFq85Of7XlBSmpkfcBFml11q0Zx6f7RMuI0B4xCtt2ytBS4yOptg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxc-parser/binding-darwin-arm64@0.127.0':
+    resolution: {integrity: sha512-obCE8B7ISKkJidjlhv9xRGJPOSDG2Yu6PRga9Ruaz35uintHxbp1Ki/Yc71wx4rj3Edrm0a1kzG1TAwit0wFpg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-parser/binding-darwin-arm64@0.141.0':
+    resolution: {integrity: sha512-m/kVk6rzYmBeHYnz+1Y5fod00AVTTxMbC71azFfm/zjx1j9XxwKtA0+VfkKuVMC8rbghb9TtfevnuWZa9OuPEg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-parser/binding-darwin-x64@0.127.0':
+    resolution: {integrity: sha512-JL6Xb5IwPQT8rUzlpsX7E+AgfcdNklXNPFp8pjCQQ5MQOQo5rtEB2ui+3Hgg9Sn7Y9Egj6YOLLiHhLpdAe12Aw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-parser/binding-darwin-x64@0.141.0':
+    resolution: {integrity: sha512-o0X+6KZlfucWU/v5oKRQPwdFXsXAjW8jmpo/Gpw/qyKsbKtlfkHoeH9Bjp/m13TwjewvJnCkwF0DWzgpC4HjTQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-parser/binding-freebsd-x64@0.127.0':
+    resolution: {integrity: sha512-SDQ/3MQFw58fqQz3Z1PhSKFF3JoCF4gmlNjziDm8X02tTahCw0qJbd7FGPDKw1i4VTBZene9JPyC3mHtSvi+wA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxc-parser/binding-freebsd-x64@0.141.0':
+    resolution: {integrity: sha512-W5KbTnNkTMMMylqj6dYqnsXvkmESVPodPKYLJ5zdzIPdl9fUJtolkpUeSzYEbGGYB4a4A4avl3EePnZ/wLIdJg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.127.0':
+    resolution: {integrity: sha512-Av+D1MIqzV0YMGPT9we2SIZaMKD7Cxs4CvXSx/yxaWHewZjYEjScpOf5igc8IILASViw4WTnjlwUdI1KzVtDHQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.141.0':
+    resolution: {integrity: sha512-g3dtbJa8zeOGK36Sr9cQavsdi5H/ie2hVjrSjIxsNAR1qZA40ZYVXnfdfoMAlq8CmB9qFL1yhsSCUHeNmdmt8w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm-musleabihf@0.127.0':
+    resolution: {integrity: sha512-Cs2fdJ8cPpFdeebj6p4dag8A4+56hPvZ0AhQQzlaLswGz1tz7bXt1nETLeorrM9+AMcWFFkqxcXwDGfTVidY8g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm-musleabihf@0.141.0':
+    resolution: {integrity: sha512-e6hwQqd+3lvP13G2jxvFpoA7dzHcFLN+Mq47JCVMtdNHbbyBRo756JCtbbJH6ca8inTfyqZoqBmS3vhQlzAK2w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.127.0':
+    resolution: {integrity: sha512-qdOfTcT6SY8gsJrrV92uyEUyjqMGPpIB5JZUG6QN5dukYd+7/j0kX6MwK1DgQj39jtUYixxPiaRUiEN1+0CXgQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.141.0':
+    resolution: {integrity: sha512-vXz2BLAuypA+4MLyBg94pzEo6THVnzYnCtAjXoihIIQo0t2pnp/AmW+SH1EI+4VbuJnC//KplIJ5yyaCGua4jA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-arm64-musl@0.127.0':
+    resolution: {integrity: sha512-EoTCZneNFU/P2qrpEM+RHmQwt+CvDkyGESG6qhr7KaegXLZwePfbrkCDfAk8/rhxbDUVGsZILX+2tqPzFtoFWA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-linux-arm64-musl@0.141.0':
+    resolution: {integrity: sha512-jMkS/EztNW34HKsXIaT/SoHcmtocq/vWhwFOVduF9kduuuRIVwfwQ6uxzIO+qPKSXdd2TXt54of0BJ2zFMXnmw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-linux-ppc64-gnu@0.127.0':
+    resolution: {integrity: sha512-zALjmZYgxFLHjXeudcDF0xFGNydTAtkAeXAr2EuC17ywCyFxcmQra4w0BMde0Yi/re4Bi4iwEoEXtYN7l6eBLQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-ppc64-gnu@0.141.0':
+    resolution: {integrity: sha512-vo+MR+n3zQJ6Mq92hiP084NZcgDv5iJlVR02gMf28neMvVT1tKVm7VeiW/DxhdqOi3QLeaXIk9cUcLL1qrkngw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-riscv64-gnu@0.127.0':
+    resolution: {integrity: sha512-fPP8M6zQLS7Jz7o9d5ArUSuAuSK3e+WCYVrCpdzeCOejidtZExJ9tjhDrAd3HEPqARBCPmdpqxESPFqy44vkBQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-riscv64-gnu@0.141.0':
+    resolution: {integrity: sha512-oh80w+7RuiO5gBp9Jnoa/H8Qlt3JsHL2MkW+0dwEdlDMdslVZX/YsekSK6EeyEenY66/mhCfypsNATQ7Ph3qlQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.127.0':
+    resolution: {integrity: sha512-7IcC4Ao02oGpfnjt+X/oF4U2mllo2qoSkw5xxiXNKL9MCTsTiAC6616beOuehdxGcnz1bRoPC1RQ2f1GQDdN+g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.141.0':
+    resolution: {integrity: sha512-LOyEmFA8sCnYbEXP1+iQvCC/P1YXHMA/t6x1Ksp0Y9VwhLFsiBJFzV1zIxrOIE2LKaGGhDjQ29xq9cbq6omDXA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-linux-s390x-gnu@0.127.0':
+    resolution: {integrity: sha512-pbXIhiNFHoqWeqDNLiJ9JkpHz1IM9k4DXa66x+1GTWMG7iLxtkXgE53iiuKSXwmk3zIYmaPVfBvgcAhS583K4Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-s390x-gnu@0.141.0':
+    resolution: {integrity: sha512-3wnwk/l1CvszVE5TJR1wSl/zSEfydRqrNhn6s7Vr9IzSJpUQIroqVsIoPARHRFA+FQwkxAFDAHDAasa7v8OobQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-x64-gnu@0.127.0':
+    resolution: {integrity: sha512-MYCguB9RvBvlSd6gbuNI7QwiLoCCAlGnlRJFPrzLI6U1/9wkC/WK6LtBAUln55H1Ctqw45PWmqrobKoMhsYQzQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-x64-gnu@0.141.0':
+    resolution: {integrity: sha512-qtyQVAAebFq57B2tifTlel3TgGqUtsYNI/e+p6aya9rN9lOZVTDvr215fGYSA9XWooxzMxDiVxkBLk2jQHbsOQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-x64-musl@0.127.0':
+    resolution: {integrity: sha512-5eY0B/bxf1xIUxb4NOTvOI3KWtBQfPWYyKAzgcrCt0mDibSZygVpO1Pz8bkeiSZ5Jj9+M09dkggG3H8I5d0Uyg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-linux-x64-musl@0.141.0':
+    resolution: {integrity: sha512-SkGV1nKw40roEc94pv5EaaeH2ay14G6+roe8Q0wIUC1LcEKxzKW921h7+ZuZX0D3q2Mb/7aSFmxEVqnko3lPRw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-openharmony-arm64@0.127.0':
+    resolution: {integrity: sha512-Gld0ajrFTUXNtdw20fVBuTQx66FA75nIVg+//pPfR3sXkuABB4mTBhl3r9JNzrJpgW//qiwxf0nWXUWGJSL3UQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxc-parser/binding-openharmony-arm64@0.141.0':
+    resolution: {integrity: sha512-cVgDM7n8QziQqOaP5hNgUYfMG7S/ZeuPxFWXnnHRv7rh025COk0rfQ6eEdKG3j/GaUuyvNZN4ifF1J8KmuXLLA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxc-parser/binding-wasm32-wasi@0.127.0':
+    resolution: {integrity: sha512-T6KVD7rhLzFlwGRXMnxUFfkCZD8FHnb968wVXW1mXzgRFc5RNXOBY2mPPDZ77x5Ln76ltLMgtPg0cOkU1NSrEQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@oxc-parser/binding-wasm32-wasi@0.141.0':
+    resolution: {integrity: sha512-HggH++Fkn3OilBn+bs3jpgIFQa34oMAyUUHy0vpGum+gt1Eb5nyLc8dNU/RAPSw6lsLrx7ncKtHSZE+3Sp0l2g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.127.0':
+    resolution: {integrity: sha512-Ujvw4X+LD1CCGULcsQcvb4YNVoBGqt+JHgNNzGGaCImELiZLk477ifUH53gIbE7EKd933NdTi25JWEr9K2HwXw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.141.0':
+    resolution: {integrity: sha512-KLSEH9GwgbrqbJOjtGHt9STw96s+78yDzp7IDN8Lno+7Ut9sNBfZ4jYZIz4mD50qmWUjoOI7i9I6UENbhNbMZQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-ia32-msvc@0.127.0':
+    resolution: {integrity: sha512-0cwxKO7KHQQQfo4Uf4B2SQrhgm+cJaP9OvFFhx52Tkg4bezsacu83GB2/In5bC415Ueeym+kXdnge/57rbSfTw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-ia32-msvc@0.141.0':
+    resolution: {integrity: sha512-9UVWUOOCI/1YkiSSNjg2zyBJYM9E/t1A/8GNobd48JDn/fQ6mzxcVO3H08jb3rAaW/B1VBf8eCORTvSsO9T08g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-x64-msvc@0.127.0':
+    resolution: {integrity: sha512-rOrnSQSCbhI2kowr9XxE7m9a8oQXnBHjnS6j95LxxAnEZ0+Fz20WlRXG4ondQb+ejjt2KOsa65sE6++L6kUd+w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-x64-msvc@0.141.0':
+    resolution: {integrity: sha512-HI/wsvbWT5RHHw5c37D0fEgeTd8/1Q4OJs5jUmEBc17VZFG6SsCIe4barq7NsAPPks/JW+3ayi3Rp+PQI5h4Kg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxc-project/runtime@0.141.0':
+    resolution: {integrity: sha512-Z/6jQ0dyvE2fVjMUO7GoD4h+3q0G4lI4BWQNjaPhC4RPxaS4hF1b7/QYKB/Tl+KAQwqqKgMF54ukR/VvV5FILg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
+  '@oxc-project/types@0.127.0':
+    resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
+
+  '@oxc-project/types@0.141.0':
+    resolution: {integrity: sha512-S4as7z0j0xQkXcJlyY5ehntwK8/wRkQb9Cyqw+J/N2rkWGQGK0SxD6X6DhQTc7qsxVTBxXbxZtBJh3mr3PtIzQ==}
+
+  '@oxc-project/types@0.144.0':
+    resolution: {integrity: sha512-nuhZIOLuI6TFQ32I/WnUx+SCPY7SdSKwgnFHydAuoS1+Z4BRcaP+RRJmGzl9lw+0OFF7UmaESf7KQRXaNLHypg==}
+
+  '@oxc-resolver/binding-android-arm-eabi@11.24.2':
+    resolution: {integrity: sha512-y09e0L0SRI2OA2tUIrjBgoV3eH5hvUKXNkJqXmNo5V2WxIjyC7I7aJfRLMEVpA8yi95f90gFDvO0VMgrDw+vwA==}
+    cpu: [arm]
+    os: [android]
+
+  '@oxc-resolver/binding-android-arm64@11.24.2':
+    resolution: {integrity: sha512-cl4icWaZFnLdg8m6qtnh5rBMuGbxc/ptStFHLeCNwr+2cZjkjNwQu/jYRS0CHlnPecOJMpuS5M6/BH+0J/YkEg==}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxc-resolver/binding-darwin-arm64@11.24.2':
+    resolution: {integrity: sha512-At29QEMF6HajbQvgY8K6OXnHD1x9rad74xBEfmCB6ZqCGsdq75aK7tOYcTbOanMy8qdIBrfL3SMr3p/lfSlb9w==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-resolver/binding-darwin-x64@11.24.2':
+    resolution: {integrity: sha512-A5Kqr1EUj4oIL5CF4WRssq/o5P0Y11cwoFouMRmQ7YnC/A8V93nv1nb7aSU8HwcgmXropjLNkVTl4MN87cu28Q==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-resolver/binding-freebsd-x64@11.24.2':
+    resolution: {integrity: sha512-R5xkRBRRz7ceH/P5Jrc6G7FmdUdgpLYyESFAUDVTNQ9K0sGPxcp4ljiwEwEqsvNcQ4sYbMRrWcHHBCu7ksAJVw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxc-resolver/binding-linux-arm-gnueabihf@11.24.2':
+    resolution: {integrity: sha512-k/RuYL4L/R58IBn3wT5ma3Wh4k62bp1eYCFRWCmMsasUOqL+H6sW0VGFadEzKWXFFlz+2uIMoeMk9ySSZJHgbg==}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-resolver/binding-linux-arm-musleabihf@11.24.2':
+    resolution: {integrity: sha512-bnHAak3ujYfH5pKk4NieFNbvYvernfoQDgwLddbZ3OtMYrem87/qjlA+u+aKG0oZcqSLGCful/6/CEA+aeAgaA==}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-resolver/binding-linux-arm64-gnu@11.24.2':
+    resolution: {integrity: sha512-vDT3KHgzYp47gmtNOqL2VNhCyl5Zv643eyxm//A68J8DeUGXrvD1pZFiaT4jSfe+RInfnn1R2yVHye4enx6RnA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-arm64-musl@11.24.2':
+    resolution: {integrity: sha512-+kMlQvbzfyEYtu5FcjE4p+ttBLpKW4d/AsAsuE69BxV6V4twZJeIQZFfD8gh/wqglY0MkPSezWXQH0jBV13MUw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-resolver/binding-linux-ppc64-gnu@11.24.2':
+    resolution: {integrity: sha512-shjfMhmZ3gq9fv/w7bi3PnZlgOPG+2QAOFf0BJF0EgBSIGZ6PMLN2zbGEblTUYB/NKVDRyYhE2ff3dJ1QqNPkA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-riscv64-gnu@11.24.2':
+    resolution: {integrity: sha512-zGelwFR5oRo+b69k8Lrzun86DyUHzfKN6cnjbR9l7Z7NIRznOE/2ZvPa1IUKqAL2PzAXOdwkfVqNvO1H2RlpAw==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-riscv64-musl@11.24.2':
+    resolution: {integrity: sha512-qxZ1SWCXJY0eyhAlP6Lmo9F2Nrtx7EkYj9oCgL8apDPCwXwCEDA2U697bbT81JIc2IrVjxO4KX6WU2N+oN9Z4w==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-resolver/binding-linux-s390x-gnu@11.24.2':
+    resolution: {integrity: sha512-sGCecF3cx2DFlH4t/z7ApnOnXqN48p5p5mlHDEnHTAukQa2P+qMVE4CwyWE9W+q/m3QJ7kKfGrIjax31f44oFQ==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-x64-gnu@11.24.2':
+    resolution: {integrity: sha512-k/VlMMcSzMlahb3/fENM4rTlsJ0s3fFROA0KXPBmKggqmTSaE383sl8F3KCOXPLmVsYfW6hCitMhXCEtNeZxxg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-x64-musl@11.24.2':
+    resolution: {integrity: sha512-8hbnZyNi97b/8wapYaIF9+t9GmZKBW2vunaOc3h9HGJptH7b7XpvZqOTBSm/MpTjr7H497BlgOaSfLUdhmy2bw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-resolver/binding-openharmony-arm64@11.24.2':
+    resolution: {integrity: sha512-MvyGik3a6pVgZ0t/kWlbmFxFLmXQJwgLsY2eYFHLpy0wGwRbfzeIGgDwQ3kXqE30z+kSXennRkCrT7TUvkptNg==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxc-resolver/binding-wasm32-wasi@11.24.2':
+    resolution: {integrity: sha512-vHcssMPwO08RTvj/c0iOBz90attxyG3wQJ0dTcyEQK43LRpcdLWZlV5feBhv6Isn6ahbQIzHbCgfa81+RiML0Q==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@oxc-resolver/binding-win32-arm64-msvc@11.24.2':
+    resolution: {integrity: sha512-uokJqro2iBqkFvJdKQLP7d8/BUmFwESQFVmIJUQKj1Xn1a/LysJoe1vmeECLF5b3jsV8CAL5sEMJXX6SdK9Nhg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-resolver/binding-win32-x64-msvc@11.24.2':
+    resolution: {integrity: sha512-UqGPmo56KDfLlfXFAFIrNflHT8tFxWGEivWg3Zeyp4Uy2NlKN1FGPr6/BxcLGG3+kZ6Wp14g5Uj+n71boqZfiw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxlint/binding-android-arm-eabi@1.78.0':
+    resolution: {integrity: sha512-Bu819lmAfZMUHErrpe0cEWj3iaefuUODHSU8+UbXy67V/r7/7f4K3FL0NmbD85E+wiFLDYuhP8Zlv0XnVeXshw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxlint/binding-android-arm64@1.78.0':
+    resolution: {integrity: sha512-CDfxZgB61B7buRdY2FJoAYYPPXCZ1EoC1LKscnC5dg3kjobdxiconvAvvN1BmHyW4PyFT3jRLDag/BY/roSNBQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxlint/binding-darwin-arm64@1.78.0':
+    resolution: {integrity: sha512-2Y2U9Ahrz+OO0Ej88f9SJYq51/jUBp1Mc7iZu0ukrbeeZ3gpRGfzIFnoqfHDY96xr0GEfNrPUBFEy0nN5aD7HA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxlint/binding-darwin-x64@1.78.0':
+    resolution: {integrity: sha512-rpych6eJq6m9jDRypTEaPD1xysaEW5h9+xuxhGK/QhOg+/xaqPZrCrTNoIl/f3nEjuJeCEmstNDlrE9rJi/3/g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxlint/binding-freebsd-x64@1.78.0':
+    resolution: {integrity: sha512-IcMGrQT3QizkOESUJd5et+rOhVqSkNDfNik1cvrKDqIbzqx9KMtRswpFgkCuNTSwylCFLKhGUu8KmqY1ZnC0Dg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxlint/binding-linux-arm-gnueabihf@1.78.0':
+    resolution: {integrity: sha512-/uLdoJ0IXE6vo/0f0LKjinQAp+re+VMaCWaNT8ENIv2EOCkSsc8SGaflXAuW0Jua2dq5+GLVWm1NQK7P3UFSNQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxlint/binding-linux-arm-musleabihf@1.78.0':
+    resolution: {integrity: sha512-7xi4Wb/O8NRJhLoUXmDJMUVpNYvB5kefdhFU1Jb8rtae4QoXlTiLwI14X4YvAXVZLNZChP8m5qO9SQAlWQTbkQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxlint/binding-linux-arm64-gnu@1.78.0':
+    resolution: {integrity: sha512-4hFW0+fVXa3OIh1Y4A5SPkmvI4wuuBSrCVKzOyE7PTjhc7yEqZ1pmvEEeS5Lj/MaqvegFxXyF33N+6jkehxdyg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-arm64-musl@1.78.0':
+    resolution: {integrity: sha512-oC0mvsgBJjlMijSDEhx9KuvR9zYeHXceA9MjbuXB1F8NSR78Yj2unOBrstEvTVaq+pko+kuue6DajC00eqvTdg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxlint/binding-linux-ppc64-gnu@1.78.0':
+    resolution: {integrity: sha512-XAllT5SUZS+ohjuZ3/5S0cwe0r7eboiuigeStCZ5DXRYx/2KVM2UvQXvAfyzXEimtQjAB7cDQ2YxDe2Zl2WNQQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-riscv64-gnu@1.78.0':
+    resolution: {integrity: sha512-trucMER/0QtecoXvc1y/UVqE3kwJipDwrx4oHfj+nNm3dq2zjP44WT0CfHNDPM3G1DXIkx/gY6lAD21NSCZVhA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-riscv64-musl@1.78.0':
+    resolution: {integrity: sha512-cm3O4F/HQbdzOUX5mKHqG5KDL6E5w0pnlZ+fbBy2rmLryPOowkuLagFHTopQsEIpjcaZoPOrL+BmmAytAG9HFg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxlint/binding-linux-s390x-gnu@1.78.0':
+    resolution: {integrity: sha512-33wRf6HqGNsybJ3qX4cGaQN2ODPxNmc1rMa0mrTmx3eFq1VzOnvQooi9bIGVYakW8a/wmqVx1mgsUm8R2xfTiw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-x64-gnu@1.78.0':
+    resolution: {integrity: sha512-rRdISSYegj6VganMZ9tjRjijowfHJ09IZU01i0toBAqr6n5LEtwHq2IeS4FjW2RoskOHlb6efB26H5izYb3GEQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-x64-musl@1.78.0':
+    resolution: {integrity: sha512-GmsP4rW0xTL6u5CVdcDsaN5Fbc7hBc382Wmar1kttbnwSEviM+rSINKOMQ+UQ6iH+AGwC+8gaAiwu134Tgh6Lg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxlint/binding-openharmony-arm64@1.78.0':
+    resolution: {integrity: sha512-sy9yeYuADc8a+n4TLBayzMCZiHPW78DcIFVpOXTmdKHWQeM9xe5uzkqIIZmi326D5hY9XVwacipEB1p7tQjPAg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxlint/binding-win32-arm64-msvc@1.78.0':
+    resolution: {integrity: sha512-rjc2hF1KfMi8fZj1X/m3AmnHbdsF3rL0v6KQg0Uc880Yb2khjz+3U14sfdZ7jWTpRnN1m1NQa/TT7uU9lJWPrA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxlint/binding-win32-ia32-msvc@1.78.0':
+    resolution: {integrity: sha512-zcuXFVrEFHIafRfkCQT8w/Xe41o07ozl/vwHq7p94vB29xVzsB0sZGYORU1jhcYKv3Lr0J3HbJ2T4fHH5rWmvA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxlint/binding-win32-x64-msvc@1.78.0':
+    resolution: {integrity: sha512-Sb5ocmLSuYeOuXd+CFOToGKp/gjXUEWDnvIGwhnh8aq8wY4TMmEnKnvbogSW7RdMZv77JSARduS7/gv+khYEjA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@polka/url@1.0.0-next.29':
+    resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
+
+  '@rolldown/binding-android-arm64@1.2.4':
+    resolution: {integrity: sha512-jHC2cnyKz5xU2fhECtFl8OZ83cYNt13GZQD+0uMJ/X3o+ijmd56okHhTUwxVSHPx1IRVIJEZ1/1pPzeLCU6XKA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-Dc5mPD8F5F/FS8i01syd7FTF6yB2fVthH/TRkjwJkzUK6EpoxHtqvZQP5Zwq80/5z19TWYHIg1KOHboCgVx/aQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-fpDm4oBo6SqLvWUYCmFhdde3U9KH2fRNNMeAnAPAIwxRL345xutL0EtEUcuoxsoazdJGv/MuDBQHlCDrtbvqOg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.2.4':
+    resolution: {integrity: sha512-rSJoreDE/HoIzoaib6MTp5jQtCTdMHKIvItAKT/ImS6Y6Ww76oUaeMyp4Vc/fAgd/ehji068IxetHXAnqUwN9A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.4':
+    resolution: {integrity: sha512-/jm8OGHgn7oGaJu3i/qZI9spUGcJ+y/lk43ttQ/iO1tOd9NissG6o97bighBCiL+BKRngmcDuR6ikfwYdJmVuQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.2.4':
+    resolution: {integrity: sha512-tIP06BeD9EqvECBrPZ+sqdPlYrT+aYaAiu1wYziVx5elRK/ftm33JxVDy2bXGbr6J0CrtirCkR87/X5a2euEng==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-musl@1.2.4':
+    resolution: {integrity: sha512-Ql1Q0EQqVThvn9VAVlwNzsUvbSFtCMGjLpRRi4pk5i7NZZ4n5ISiLMjHYtus4VQ2PvkSw24zyaCVsiS+sXPj1w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.2.4':
+    resolution: {integrity: sha512-GjbjXD4XXfN19D0LZNbmiCBUoDiRACsYHr0yaIbbn8aFsXjHZifcYqu/W5Er5X2X990WjHXFrxarn5chzItorQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.2.4':
+    resolution: {integrity: sha512-p5WR0NOwaRmJ/B1b6IjEFLLivwEsf3PrdBIhRbhTCQisbo2SvHHpG4ELB/+FgQNnB88LTOF86upmJmbvZdQ2lw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.2.4':
+    resolution: {integrity: sha512-4/GyVjmhR+Tc6HLJvwc1sOhPqAZtySiSMesOZyX6JQ5XBxoTDEMKQzvo07NIK6nTon/SivlZqvhzvuVBNQhObQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.2.4':
+    resolution: {integrity: sha512-l9eeLsCNvPpmSXUej0etw/J1eqV0Jj1D5G/xG6YTijmE6dkv6E2QezgWbTfQk63v952DPqrjOCoiqxq7Bw0YUQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-openharmony-arm64@1.2.4':
+    resolution: {integrity: sha512-e0F355MSTMm3+UOqtV3L24gFUp2N5m1f8L/7d56deik6va+AXdrt9F8LbzGpeWGWRbZEDq4m8NVnJDeBtf9DZg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-win32-arm64-msvc@1.2.4':
+    resolution: {integrity: sha512-AWLi0uBRYh6QlE7OKhiz+phZC0qwtij2QZmhmOdsLdFn64m7oMpooE9ICE3lhm9xMb4SpDo2WbHcxX1iFLFtqw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.2.4':
+    resolution: {integrity: sha512-UwSDJOg3dqCAejWdxclJjCsh3Qq4vLYMDxmyHqo1btz3stK2VqgwNd3mm5tuIwzSlGIQ/1H9Hr+Zn09mrezNqQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/plugin-babel@0.2.3':
+    resolution: {integrity: sha512-+zEk16yGlz1F9STiRr6uG9hmIXb6nprjLczV/htGptYuLoCuxb+itZ03RKCEeOhBpDDd1NU7qF6x1VLMUp62bw==}
+    engines: {node: '>=22.12.0 || ^24.0.0'}
+    peerDependencies:
+      '@babel/core': ^7.29.0 || ^8.0.0-rc.1
+      '@babel/plugin-transform-runtime': ^7.29.0 || ^8.0.0-rc.1
+      '@babel/runtime': ^7.27.0 || ^8.0.0-rc.1
+      rolldown: ^1.0.0-rc.5
+      vite: ^8.0.0
+    peerDependenciesMeta:
+      '@babel/plugin-transform-runtime':
+        optional: true
+      '@babel/runtime':
+        optional: true
+      vite:
+        optional: true
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
+
+  '@rollup/rollup-android-arm-eabi@4.62.4':
+    resolution: {integrity: sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.62.4':
+    resolution: {integrity: sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.62.4':
+    resolution: {integrity: sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.62.4':
+    resolution: {integrity: sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.62.4':
+    resolution: {integrity: sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.62.4':
+    resolution: {integrity: sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.4':
+    resolution: {integrity: sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.4':
+    resolution: {integrity: sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.4':
+    resolution: {integrity: sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.62.4':
+    resolution: {integrity: sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.4':
+    resolution: {integrity: sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.62.4':
+    resolution: {integrity: sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.4':
+    resolution: {integrity: sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.4':
+    resolution: {integrity: sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.4':
+    resolution: {integrity: sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.4':
+    resolution: {integrity: sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.4':
+    resolution: {integrity: sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.62.4':
+    resolution: {integrity: sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.62.4':
+    resolution: {integrity: sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.62.4':
+    resolution: {integrity: sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.62.4':
+    resolution: {integrity: sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.4':
+    resolution: {integrity: sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.4':
+    resolution: {integrity: sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.62.4':
+    resolution: {integrity: sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.62.4':
+    resolution: {integrity: sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==}
+    cpu: [x64]
+    os: [win32]
+
+  '@shikijs/core@3.23.0':
+    resolution: {integrity: sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==}
+
+  '@shikijs/engine-javascript@3.23.0':
+    resolution: {integrity: sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA==}
+
+  '@shikijs/engine-oniguruma@3.23.0':
+    resolution: {integrity: sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==}
+
+  '@shikijs/langs@3.23.0':
+    resolution: {integrity: sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==}
+
+  '@shikijs/themes@3.23.0':
+    resolution: {integrity: sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==}
+
+  '@shikijs/types@3.23.0':
+    resolution: {integrity: sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==}
+
+  '@shikijs/vscode-textmate@10.0.2':
+    resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
+
+  '@stardazed/streams-compression@1.0.0':
+    resolution: {integrity: sha512-SQCiwxdIVJ5xxUBYptN+fc+tJpSDbxQuJ0+3u2SmHjIzr6JIRZ28AVFtFnGy6x6j3UBlaLx73w9rC6UAFxnd1g==}
+
+  '@stardazed/zlib@1.0.1':
+    resolution: {integrity: sha512-MS6PCYiRNJ32c69+3NPyL+bu7LpiFDvMcBXnlhQnF8CKMG0R/xRVCCo422NPkQ0+Cox3xKpk5Lc1LfWFS4b3cw==}
+
+  '@storybook/addon-a11y@10.5.7':
+    resolution: {integrity: sha512-I30rsNz6aA3xg3811MEry40uJDHP3l5SOkfqtmNkp7y4NdqTDdKhmbhhDAZQX1WWEk6GeMBGr3AJ3TCz7r7JmQ==}
+    peerDependencies:
+      storybook: ^10.5.7
+
+  '@storybook/addon-docs@10.5.7':
+    resolution: {integrity: sha512-KNARJfjICaizinsR3INMEiipZm1ObYo+xw+E26gteu50Bcy2dIZUtk5uHY5XdtardU3AXX6yRXoBZ2HCY3lbHA==}
+    peerDependencies:
+      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      storybook: ^10.5.7
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@storybook/addon-vitest@10.5.7':
+    resolution: {integrity: sha512-7NK7Kzazc2vb2h8nGlH15QlUn5J6/LV0xF70VziAK0bxu3r1JupLCoBvckX39vHzFXiAZljXZtt1Wq/OidBxow==}
+    peerDependencies:
+      '@vitest/browser': ^3.0.0 || ^4.0.0
+      '@vitest/browser-playwright': ^4.0.0
+      '@vitest/runner': ^3.0.0 || ^4.0.0
+      storybook: ^10.5.7
+      vitest: ^3.0.0 || ^4.0.0
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/runner':
+        optional: true
+      vitest:
+        optional: true
+
+  '@storybook/builder-vite@10.5.7':
+    resolution: {integrity: sha512-fShF/aQaITqcJuMCLr42BGNUAbhDi4IboqvlbZqXAwgrrTslnZEUnY8GcEcvpZmjl11VwlmazhMJdH50fIgBPg==}
+    peerDependencies:
+      storybook: ^10.5.7
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  '@storybook/csf-plugin@10.5.7':
+    resolution: {integrity: sha512-IaX8FlM0H36HNFhJ2+4L9bCldqfvHGqcLg841SJNyK/DhfMlM7JsvY/GDH2ZFuWrUf8FSOx96GRRnHq6XfRKag==}
+    peerDependencies:
+      esbuild: '*'
+      rollup: '*'
+      storybook: ^10.5.7
+      vite: '*'
+      webpack: '*'
+    peerDependenciesMeta:
+      esbuild:
+        optional: true
+      rollup:
+        optional: true
+      vite:
+        optional: true
+      webpack:
+        optional: true
+
+  '@storybook/global@5.0.0':
+    resolution: {integrity: sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ==}
+
+  '@storybook/icons@2.1.0':
+    resolution: {integrity: sha512-Fxh9vYpX9bQqFeHRiY8h2ApeRGDzRSMLwJwNZ/AIRqnyOKHxRKL+yFe+ctEkVJmuptRE9u1Hrn8ZZNHyfDKKNg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@storybook/react-dom-shim@10.5.7':
+    resolution: {integrity: sha512-lxOkyh+wu/MiBXvYQHjZfD+DRKOa4bHBzbuGuiHXnHXmdOcTRdcrQTsoeN2FPtfugmmOG66cZUEgDwNX+k5eRA==}
+    peerDependencies:
+      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      storybook: ^10.5.7
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@tailwindcss/node@4.3.3':
+    resolution: {integrity: sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==}
+
+  '@tailwindcss/oxide-android-arm64@4.3.3':
+    resolution: {integrity: sha512-Y85A2gmPSkl5Ve5qR86GL4HT509cFqQh1aes9p3sSkyTPwt0Pppf3GkwGe4JPACcRYjgJIEhQgM6dBClnr0NYw==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [android]
+
+  '@tailwindcss/oxide-darwin-arm64@4.3.3':
+    resolution: {integrity: sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-darwin-x64@4.3.3':
+    resolution: {integrity: sha512-fAeUqfV5ndhxRwai8cXGzdLvul9utWOmeTkv69unv4ZXixjn61Z+p9lCWdwOwA3TYboG3BwdVuN/RDjhBRl0mw==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-freebsd-x64@4.3.3':
+    resolution: {integrity: sha512-iyf5bV6+wnAlflVeEy7R25dupxTNECZN5QMI0qNT6eT+EgaGdZcKhGkr5SdoaWiLJ3spLqIY9VCeSGrwmtg4kw==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.3':
+    resolution: {integrity: sha512-aAYUprJAJQWWbRrPvtjdroZ56Md+JM8pMiopS6xGEwDfLhqj+2ver2p4nU4Mb3CRqcMmNBjo8KkUgcxhkzVQGQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.3':
+    resolution: {integrity: sha512-nDxldcEENOxZRzC2uu9jrutZdAAQtb+8WWDCSnWL1zvBk1+FN+x6MtDViPB5AJMfttVCUhehGWus3XBPgatM/w==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.3':
+    resolution: {integrity: sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.3':
+    resolution: {integrity: sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tailwindcss/oxide-linux-x64-musl@4.3.3':
+    resolution: {integrity: sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@tailwindcss/oxide-wasm32-wasi@4.3.3':
+    resolution: {integrity: sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+    bundledDependencies:
+      - '@napi-rs/wasm-runtime'
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@tybys/wasm-util'
+      - '@emnapi/wasi-threads'
+      - tslib
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.3':
+    resolution: {integrity: sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.3':
+    resolution: {integrity: sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [win32]
+
+  '@tailwindcss/oxide@4.3.3':
+    resolution: {integrity: sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA==}
+    engines: {node: '>= 20'}
+
+  '@tailwindcss/postcss@4.3.3':
+    resolution: {integrity: sha512-JTSZZGQi1AyKirbLN3azmjVzef92tcX7h+iSqPdaeStyFpGpDlKvvpxeOE8njhbUanbRwr3z8DyzhICWnMtQeg==}
+
+  '@tailwindcss/vite@4.3.3':
+    resolution: {integrity: sha512-yYU8cogLeSh/ms2jh8Fj7jaba/EWa7Ja6GoUqYZaraEuCI5YS6ms6ObZgjjedm+jm6XZjdNRWBpPP6Z86oOxcw==}
+    peerDependencies:
+      vite: ^5.2.0 || ^6 || ^7 || ^8
+
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.9.1':
+    resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/user-event@14.6.4':
+    resolution: {integrity: sha512-QCGwP6QrjypBLwyj5cuyfVamkaIEy/XGY+1VDehbtbQqOggYmTFpFOdWR5mPz14vX8vXLMVjDHlRNBcClyO9ew==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
+  '@tybys/wasm-util@0.10.3':
+    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/debug@4.1.13':
+    resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree-jsx@1.0.5':
+    resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/hast@3.0.5':
+    resolution: {integrity: sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==}
+
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/mdx@2.0.14':
+    resolution: {integrity: sha512-T48PeuJtvLosNTPVhfnIp3i/n3a4g4Bad7YCq5k64D4u7NwDrAotikQ+5+sjtUvBmxCMlbo3dVL+C2dP0rWHzg==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
+
+  '@types/node@12.20.55':
+    resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
+
+  '@types/node@24.13.3':
+    resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
+
+  '@types/picomatch@4.0.3':
+    resolution: {integrity: sha512-iG0T6+nYJ9FAPmx9SsUlnwcq1ZVRuCXcVEvWnntoPlrOpwtSTKNDC9uVAxTsC3PUvJ+99n4RpAcNgBbHX3JSnQ==}
+
+  '@types/react@19.2.18':
+    resolution: {integrity: sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==}
+
+  '@types/unist@2.0.11':
+    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@types/whatwg-mimetype@3.0.2':
+    resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    resolution: {integrity: sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    resolution: {integrity: sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    resolution: {integrity: sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    resolution: {integrity: sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    resolution: {integrity: sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    resolution: {integrity: sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    resolution: {integrity: sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    resolution: {integrity: sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    resolution: {integrity: sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    resolution: {integrity: sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    resolution: {integrity: sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    resolution: {integrity: sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    resolution: {integrity: sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    resolution: {integrity: sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    resolution: {integrity: sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    resolution: {integrity: sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    resolution: {integrity: sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@ungap/structured-clone@1.3.3':
+    resolution: {integrity: sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==}
+
+  '@vitest/browser-playwright@4.1.10':
+    resolution: {integrity: sha512-nMoXGEiRpT7m3W7NsbvrM2aKNwiNHZf+zEpUCvMteGjZFvfT96Q9fh7QyB98dvDWXiKvrLxA7bJ1mCOOv+JQPw==}
+    peerDependencies:
+      playwright: '*'
+      vitest: 4.1.10
+
+  '@vitest/browser@4.1.10':
+    resolution: {integrity: sha512-UDwuWGwXj646CBx/bQHOaJSX7np0I8JL/UKQYa1e4QrVHH8VdWtx8eaOuf8sy0ShwDgR6NjJAsp5eF6vjF6qng==}
+    peerDependencies:
+      vitest: 4.1.10
+
+  '@vitest/coverage-istanbul@4.1.10':
+    resolution: {integrity: sha512-AyNJ5pQRFqCX7pwB9PSTmoVKPaZ4H5IEVJfJsT+q1DYkXvZMEFYgJlyk5sfStmt9rVYRyYYRRsuBeImCOc39ww==}
+    peerDependencies:
+      vitest: 4.1.10
+
+  '@vitest/coverage-v8@4.1.10':
+    resolution: {integrity: sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==}
+    peerDependencies:
+      '@vitest/browser': 4.1.10
+      vitest: 4.1.10
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
+  '@vitest/expect@3.2.4':
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.4':
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
+
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
+
+  '@vitest/spy@3.2.4':
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+
+  '@vitest/utils@3.2.4':
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
+
+  '@webcontainer/env@1.1.1':
+    resolution: {integrity: sha512-6aN99yL695Hi9SuIk1oC88l9o0gmxL1nGWWQ/kNy81HigJ0FoaoTXpytCj6ItzgyCEwA9kF1wixsTuv5cjsgng==}
+
+  '@worker-tools/html-rewriter@0.1.0-pre.19':
+    resolution: {integrity: sha512-IUbEZwvSdp8vtaB1LAZ/sBRJGNycd9a8cbkqO05rMEPm5MC59Sb+wiGCWaaRXrwQLDAyWeod4QC/q0TuSUI5EA==}
+
+  '@worker-tools/resolvable-promise@0.2.0-pre.6':
+    resolution: {integrity: sha512-+5RcuruCLB/P3FYYb376RgyImXaq9BBQoOskUbgPyNK3O0AXPakrXUj1EELv+lcnUSdFws/ufdrrWODLJyoTmg==}
+
+  acorn-jsx@5.3.2:
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  acorn@8.18.0:
+    resolution: {integrity: sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  ansi-colors@4.1.3:
+    resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
+    engines: {node: '>=6'}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-regex@6.3.0:
+    resolution: {integrity: sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==}
+    engines: {node: '>=12'}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
+  anymatch@3.1.3:
+    resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
+    engines: {node: '>= 8'}
+
+  argparse@1.0.10:
+    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
+  aria-query@5.3.2:
+    resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
+    engines: {node: '>= 0.4'}
+
+  array-union@2.1.0:
+    resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
+    engines: {node: '>=8'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  ast-types@0.16.1:
+    resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
+    engines: {node: '>=4'}
+
+  ast-v8-to-istanbul@1.0.5:
+    resolution: {integrity: sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==}
+
+  astring@1.9.0:
+    resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
+    hasBin: true
+
+  atomically@2.1.1:
+    resolution: {integrity: sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ==}
+
+  autoprefixer@10.5.4:
+    resolution: {integrity: sha512-MaU0U/za7N3r6brxD4YB/l4NSrFzLPlANv6wEuQVaIPlD3L4W9rFcQPbL/EilY9BHhHvhfcz3gInDLrEtWT4EA==}
+    engines: {node: ^10 || ^12 || >=14}
+    hasBin: true
+    peerDependencies:
+      postcss: ^8.1.0
+
+  axe-core@4.13.0:
+    resolution: {integrity: sha512-UzGt8zg7Ny8djbYMhxl2zuEevVa7r2gJjYY5Lwr1xM7+XU2nd6CkIWFTVcCIbAP63vSz71NaVyyuSk9lHKcy0A==}
+    engines: {node: '>=4'}
+
+  bail@2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+
+  baseline-browser-mapping@2.11.13:
+    resolution: {integrity: sha512-k9HNuUVMlqVjQ9UHzfPjIqiDbWw7WqT1AoT7GL8VwvF3r0ZfArtgiSPAlmupyNquNgOJHTuH4CKYf8ttMTWBTQ==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  better-commits@1.24.0:
+    resolution: {integrity: sha512-Vkr/gLvNSLyfRmS4N/9EVc65vImcqNZe42DudlPBXsfNqW8RhYMAzuUjAgupunDpFloYkkoChkKQnQSuotcqkA==}
+    engines: {node: '>=20.19.0'}
+    hasBin: true
+
+  better-path-resolve@1.0.0:
+    resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
+    engines: {node: '>=4'}
+
+  binary-extensions@2.3.0:
+    resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
+    engines: {node: '>=8'}
+
+  boolbase@1.0.0:
+    resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
+
+  browserslist@4.28.8:
+    resolution: {integrity: sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
+  buffer-image-size@0.6.4:
+    resolution: {integrity: sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==}
+    engines: {node: '>=4.0'}
+
+  bun-types@1.3.14:
+    resolution: {integrity: sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ==}
+
+  bundle-name@4.1.0:
+    resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
+    engines: {node: '>=18'}
+
+  bundle-require@5.1.0:
+    resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    peerDependencies:
+      esbuild: '>=0.18'
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  caniuse-api@4.0.0:
+    resolution: {integrity: sha512-B0hQ1OLyJuHTQSOWXvwibWqM6DCoqJdvBA6X1S/53bd4XU7LJ1yurIPlrsouol3mw1jh9pGI4ivubSpmJeIqCA==}
+
+  caniuse-lite@1.0.30001809:
+    resolution: {integrity: sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==}
+
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+
+  character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
+  character-reference-invalid@2.0.1:
+    resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
+
+  chardet@2.2.0:
+    resolution: {integrity: sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
+
+  chokidar@3.6.0:
+    resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
+    engines: {node: '>= 8.10.0'}
+
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+
+  chokidar@5.0.0:
+    resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
+    engines: {node: '>= 20.19.0'}
+
+  chromatic@18.2.0:
+    resolution: {integrity: sha512-xyTKDhBQPDd4qrsXhJK7GAJyIStpRoSTs4b7EtPyliSL0luej3DcqkeCZ9osHxbiLXiViNyWfMxo5Xgzejex8A==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+    peerDependencies:
+      '@chromatic-com/cypress': ^0.*.* || ^1.0.0
+      '@chromatic-com/playwright': ^0.*.* || ^1.0.0
+      '@chromatic-com/vitest': ^0.*.* || ^1.0.0
+    peerDependenciesMeta:
+      '@chromatic-com/cypress':
+        optional: true
+      '@chromatic-com/playwright':
+        optional: true
+      '@chromatic-com/vitest':
+        optional: true
+
+  citty@0.1.6:
+    resolution: {integrity: sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==}
+
+  citty@0.2.2:
+    resolution: {integrity: sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==}
+
+  collapse-white-space@2.1.0:
+    resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
+
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
+
+  commander@11.1.0:
+    resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
+    engines: {node: '>=16'}
+
+  commander@4.1.1:
+    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
+    engines: {node: '>= 6'}
+
+  commander@9.5.0:
+    resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==}
+    engines: {node: ^12.20.0 || >=14}
+
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
+  configstore@8.0.0:
+    resolution: {integrity: sha512-U51WPZg+o6FDFhBCV6yYFEspGMCoHvCgJSGFw9AwsW2u75gYBPoDlYca5XfDs4TdMUu3/y0R6FFdvvgyH31mKQ==}
+    engines: {node: '>=20'}
+
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
+  crossws@0.4.10:
+    resolution: {integrity: sha512-pz3oubH/dt12KjqsUB0IuXW4nwRDQ583iDsP4555Cpdqx0NoU7pGlWBcayyFI8f/l/idRpgjMEfwuOxSWJYlIA==}
+    peerDependencies:
+      srvx: '>=0.11.5'
+    peerDependenciesMeta:
+      srvx:
+        optional: true
+
+  css-select@5.2.2:
+    resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
+
+  css-tree@2.2.1:
+    resolution: {integrity: sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0, npm: '>=7.0.0'}
+
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  css-what@6.2.2:
+    resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
+    engines: {node: '>= 6'}
+
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
+  cssesc@3.0.0:
+    resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
+    engines: {node: '>=4'}
+    hasBin: true
+
+  cssnano-preset-default@8.0.5:
+    resolution: {integrity: sha512-R9O+oRNnKcVBf7GZZ7nfBcOiBZZwi3kR1HtKirBHel/gTtHLMHOCsL2H3QGy1161CPystJV4EiKniC7XyUKfcw==}
+    engines: {node: ^22.11.0 || ^24.11.0 || >=26.0}
+    peerDependencies:
+      postcss: ^8.5.26
+
+  cssnano-utils@6.0.3:
+    resolution: {integrity: sha512-HskzChO3gRkXBQSWg68DfwoVfptRUV2GvuiQBvt+C7mUw4VB0CvPjkC4iF4JSf7yW1/66Hsc6WJtqNqD5Ydt2Q==}
+    engines: {node: ^22.11.0 || ^24.11.0 || >=26.0}
+    peerDependencies:
+      postcss: ^8.5.26
+
+  cssnano@8.0.5:
+    resolution: {integrity: sha512-Yigb8Apuqi/jWwii1XFmZwgAPZ2RHDUx/ANodBZsEQusYIFryChhwOQNKco0A7V6zgFqDDy3LqefGK6OnniGMA==}
+    engines: {node: ^22.11.0 || ^24.11.0 || >=26.0}
+    peerDependencies:
+      postcss: ^8.5.26
+
+  csso@5.0.5:
+    resolution: {integrity: sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0, npm: '>=7.0.0'}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  dataloader@1.4.0:
+    resolution: {integrity: sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==}
+
+  db0@0.3.4:
+    resolution: {integrity: sha512-RiXXi4WaNzPTHEOu8UPQKMooIbqOEyqA1t7Z6MsdxSCeb8iUC9ko3LcmsLmeUt2SM5bctfArZKkRQggKZz7JNw==}
+    peerDependencies:
+      '@electric-sql/pglite': '*'
+      '@libsql/client': '*'
+      better-sqlite3: '*'
+      drizzle-orm: '*'
+      mysql2: '*'
+      sqlite3: '*'
+    peerDependenciesMeta:
+      '@electric-sql/pglite':
+        optional: true
+      '@libsql/client':
+        optional: true
+      better-sqlite3:
+        optional: true
+      drizzle-orm:
+        optional: true
+      mysql2:
+        optional: true
+      sqlite3:
+        optional: true
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  decode-named-character-reference@1.3.0:
+    resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
+  default-browser-id@5.0.1:
+    resolution: {integrity: sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==}
+    engines: {node: '>=18'}
+
+  default-browser@5.5.0:
+    resolution: {integrity: sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==}
+    engines: {node: '>=18'}
+
+  define-lazy-prop@3.0.0:
+    resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
+    engines: {node: '>=12'}
+
+  defu@6.1.7:
+    resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
+  detect-indent@6.1.0:
+    resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
+    engines: {node: '>=8'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+
+  dir-glob@3.0.1:
+    resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
+    engines: {node: '>=8'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
+  dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+
+  domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+
+  domutils@3.2.2:
+    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
+
+  dot-prop@10.2.0:
+    resolution: {integrity: sha512-BTJ9aZYL3vCfZlZOBLy9v8TUqWGQ0pzFnygKwFZt5udj6viBoFIBviKPUoZLDCPn1FoXffv6McQFDenrm5Krfw==}
+    engines: {node: '>=20'}
+
+  dotenv@8.6.0:
+    resolution: {integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==}
+    engines: {node: '>=10'}
+
+  ecopages@0.2.0-beta.43:
+    resolution: {integrity: sha512-pnjefjdb6Vs1QMniwfJpoy75bRuktUXmOKLIW38LTLowr0TxBDGSg27tezi7Wrgy62FIENf8/q17OIa7SPs4HA==}
+    engines: {node: '>=24.0.0'}
+    hasBin: true
+    peerDependencies:
+      bun-types: '*'
+      typescript: ^5
+
+  electron-to-chromium@1.5.405:
+    resolution: {integrity: sha512-bNglH7lPH5l+yHOes7Zr4VqxhOy4BQ9ZBUX4VdoFgxMpzJk7W1ZoO3Vgd9Pxa9PyjQ76sfm2aKH/nzEcCNRlew==}
+
+  enhanced-resolve@5.24.5:
+    resolution: {integrity: sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==}
+    engines: {node: '>=10.13.0'}
+
+  enquirer@2.4.1:
+    resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
+    engines: {node: '>=8.6'}
+
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
+
+  env-runner@0.1.16:
+    resolution: {integrity: sha512-2LRJM4P2KLX6J83QZZrMqvgCDt/D5ea7wPcI3yYiy5cG/9rX5QwdwZFx0D7ktWnjdRyZxYjttGGorb5nFqb1CA==}
+    hasBin: true
+    peerDependencies:
+      '@netlify/runtime': ^4.1.23
+      '@vercel/queue': '>=0.2.0'
+      miniflare: ^4.20260515.0
+      wrangler: ^4.0.0
+    peerDependenciesMeta:
+      '@netlify/runtime':
+        optional: true
+      '@vercel/queue':
+        optional: true
+      miniflare:
+        optional: true
+      wrangler:
+        optional: true
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-module-lexer@2.3.1:
+    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
+
+  esast-util-from-estree@2.0.0:
+    resolution: {integrity: sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==}
+
+  esast-util-from-js@2.0.1:
+    resolution: {integrity: sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==}
+
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.28.2:
+    resolution: {integrity: sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
+
+  esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
+
+  estree-util-attach-comments@3.0.0:
+    resolution: {integrity: sha512-cKUwm/HUcTDsYh/9FgnuFqpfquUbwIqwKM26BVCGDPVgvaCl/nDCCjUfiLlx6lsEZ3Z4RFxNbOQ60pkaEwFxGw==}
+
+  estree-util-build-jsx@3.0.1:
+    resolution: {integrity: sha512-8U5eiL6BTrPxp/CHbs2yMgP8ftMhR5ww1eIKoWRMlqvltHF8fZn5LRDvTKuxD3DUn+shRbLGqXemcP51oFCsGQ==}
+
+  estree-util-is-identifier-name@3.0.0:
+    resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
+
+  estree-util-scope@1.0.0:
+    resolution: {integrity: sha512-2CAASclonf+JFWBNJPndcOpA8EMJwa0Q8LUFJEKqXLW6+qBvbFZuF5gItbQOs/umBUkjviCSDCbBwU2cXbmrhQ==}
+
+  estree-util-to-js@2.0.0:
+    resolution: {integrity: sha512-WDF+xj5rRWmD5tj6bIqRi6CkLIXbbNQUcxQHzGysQzvHmdYG2G7p/Tf0J0gpxGgkeMZNTIjT/AoSvC9Xehcgdg==}
+
+  estree-util-visit@2.0.0:
+    resolution: {integrity: sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
+
+  exsolve@1.1.1:
+    resolution: {integrity: sha512-9U/jZUgjnSGyntRr6y5Muu1MJcwFl6kPu7k8qLF0IMNfLqvw0NZ4nnVDq0RVoZ0RvCyumib4Ez3KYrVfilrw+g==}
+
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
+  extendable-error@0.1.7:
+    resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
+
+  fast-glob@3.3.3:
+    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
+    engines: {node: '>=8.6.0'}
+
+  fast-string-truncated-width@3.0.3:
+    resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
+
+  fast-string-width@3.0.2:
+    resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
+
+  fast-wrap-ansi@0.2.2:
+    resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
+
+  fastq@1.20.1:
+    resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
+
+  fault@2.0.1:
+    resolution: {integrity: sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
+
+  find-up@4.1.0:
+    resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
+    engines: {node: '>=8'}
+
+  fix-dts-default-cjs-exports@1.0.1:
+    resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
+
+  format@0.2.2:
+    resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==}
+    engines: {node: '>=0.4.x'}
+
+  fraction.js@5.3.4:
+    resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
+
+  fs-extra@7.0.1:
+    resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
+    engines: {node: '>=6 <7 || >=8'}
+
+  fs-extra@8.1.0:
+    resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
+    engines: {node: '>=6 <7 || >=8'}
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
+
+  ghtml@4.0.2:
+    resolution: {integrity: sha512-ymJljsiXUc6hrq2407EnkyCQ8dk5NVEvpAbB4fhnZ+oqP0u9Aq/YWsNkDh+Ew5lBz2uGqyLfzCBdE8J8g4NNgg==}
+    engines: {node: '>=18'}
+
+  giget@2.0.0:
+    resolution: {integrity: sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==}
+    hasBin: true
+
+  glob-parent@5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
+
+  globby@11.1.0:
+    resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
+    engines: {node: '>=10'}
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  h3@2.0.1-rc.26:
+    resolution: {integrity: sha512-GDxlvDsKxgjRvG5UBRJYyGJTMWLV30CJ4cV+e7QCTgftDHihrvio1fVPbNembhEr6J4WNm8IWy3fookgyTweLw==}
+    engines: {node: '>=20.11.1'}
+    hasBin: true
+    peerDependencies:
+      crossws: ^0.4.9
+    peerDependenciesMeta:
+      crossws:
+        optional: true
+
+  happy-dom@20.11.2:
+    resolution: {integrity: sha512-7MB+bJLkxu3SowAfBJbjW+c55kNz5tkR45gu2qzrxznezhLeN5YIlJbwUgSzlGc+qWoZ8Ykg71H5ezz69xixrw==}
+    engines: {node: '>=20.0.0'}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
+    engines: {node: '>= 0.4'}
+
+  hast-util-from-html@2.0.3:
+    resolution: {integrity: sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==}
+
+  hast-util-from-parse5@8.0.3:
+    resolution: {integrity: sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==}
+
+  hast-util-parse-selector@4.0.0:
+    resolution: {integrity: sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==}
+
+  hast-util-to-estree@3.1.3:
+    resolution: {integrity: sha512-48+B/rJWAp0jamNbAAf9M7Uf//UVqAoMmgXhBdxTDJLGKY+LRnZ99qcG+Qjl5HfMpYNzS5v4EAwVEF34LeAj7w==}
+
+  hast-util-to-html@9.0.5:
+    resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
+
+  hast-util-to-jsx-runtime@2.3.6:
+    resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
+
+  hast-util-to-string@3.0.1:
+    resolution: {integrity: sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==}
+
+  hast-util-whitespace@3.0.0:
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
+  hastscript@9.0.1:
+    resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
+
+  hookable@6.1.1:
+    resolution: {integrity: sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  html-void-elements@3.0.0:
+    resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
+
+  httpxy@0.5.5:
+    resolution: {integrity: sha512-uDjmnPyp1q4Sgzf3w+J/Fc6UqcCEj0x4Wjp7OqK5dGhNeDgpyrAmnS6ey8QWrX3SWDon2DMKf9sBa5X9+CVyMA==}
+
+  human-id@4.2.0:
+    resolution: {integrity: sha512-K3GbkIWqyvvlpfhBPlbEvD97TtqBpAYA4kt+cn2lD2x2HuohzZCibcA2nOlnJT6exqvJLggoB5nv2dNf192nEA==}
+    hasBin: true
+
+  iconv-lite@0.7.3:
+    resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
+    engines: {node: '>=0.10.0'}
+
+  ignore@5.3.2:
+    resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
+
+  inline-style-parser@0.2.7:
+    resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
+  is-alphabetical@2.0.1:
+    resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
+
+  is-alphanumerical@2.0.1:
+    resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
+
+  is-binary-path@2.1.0:
+    resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
+    engines: {node: '>=8'}
+
+  is-core-module@2.16.2:
+    resolution: {integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==}
+    engines: {node: '>= 0.4'}
+
+  is-decimal@2.0.1:
+    resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
+
+  is-docker@3.0.0:
+    resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    hasBin: true
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
+  is-hexadecimal@2.0.1:
+    resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
+
+  is-inside-container@1.0.0:
+    resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
+    engines: {node: '>=14.16'}
+    hasBin: true
+
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
+
+  is-safe-filename@0.1.1:
+    resolution: {integrity: sha512-4SrR7AdnY11LHfDKTZY1u6Ga3RuxZdl3YKWWShO5iyuG5h8QS4GD2tOb04peBJ5I7pXbR+CGBNEhTcwK+FzN3g==}
+    engines: {node: '>=20'}
+
+  is-subdir@1.2.0:
+    resolution: {integrity: sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==}
+    engines: {node: '>=4'}
+
+  is-windows@1.0.2:
+    resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
+    engines: {node: '>=0.10.0'}
+
+  is-wsl@3.1.1:
+    resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
+    engines: {node: '>=16'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
+  jiti@2.7.0:
+    resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
+    hasBin: true
+
+  joycon@3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-yaml@3.15.1:
+    resolution: {integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==}
+    hasBin: true
+
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
+    hasBin: true
+
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  jsonc-parser@3.3.1:
+    resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
+
+  jsonfile@4.0.0:
+    resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
+
+  jsonfile@6.2.1:
+    resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
+
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-android-arm64@1.33.0:
+    resolution: {integrity: sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-arm64@1.33.0:
+    resolution: {integrity: sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.33.0:
+    resolution: {integrity: sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-freebsd-x64@1.33.0:
+    resolution: {integrity: sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    resolution: {integrity: sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-gnu@1.33.0:
+    resolution: {integrity: sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-arm64-musl@1.33.0:
+    resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-gnu@1.33.0:
+    resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-musl@1.33.0:
+    resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-arm64-msvc@1.33.0:
+    resolution: {integrity: sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.33.0:
+    resolution: {integrity: sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
+  lightningcss@1.33.0:
+    resolution: {integrity: sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==}
+    engines: {node: '>= 12.0.0'}
+
+  lilconfig@3.1.3:
+    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
+    engines: {node: '>=14'}
+
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  load-tsconfig@0.2.5:
+    resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  locate-path@5.0.0:
+    resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
+    engines: {node: '>=8'}
+
+  lodash.startcase@4.4.0:
+    resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
+
+  longest-streak@3.1.0:
+    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.5.4:
+    resolution: {integrity: sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
+
+  markdown-extensions@2.0.0:
+    resolution: {integrity: sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==}
+    engines: {node: '>=16'}
+
+  markdown-table@3.0.4:
+    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
+  mdast-util-find-and-replace@3.0.2:
+    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
+
+  mdast-util-from-markdown@2.0.3:
+    resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+
+  mdast-util-frontmatter@2.0.1:
+    resolution: {integrity: sha512-LRqI9+wdgC25P0URIJY9vwocIzCcksduHQ9OF2joxQoyTNVduwLAFUzjoopuRJbJAReaKrNQKAZKL3uCMugWJA==}
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
+
+  mdast-util-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
+
+  mdast-util-gfm-table@2.0.0:
+    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
+
+  mdast-util-gfm@3.1.0:
+    resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
+
+  mdast-util-mdx-expression@2.0.1:
+    resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
+
+  mdast-util-mdx-jsx@3.2.0:
+    resolution: {integrity: sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==}
+
+  mdast-util-mdx@3.0.0:
+    resolution: {integrity: sha512-JfbYLAW7XnYTTbUsmpu0kdBUVe+yKVJZBItEjwyYJiDJuZ9w4eeaqks4HQO+R7objWgS2ymV60GYpI14Ug554w==}
+
+  mdast-util-mdxjs-esm@2.0.1:
+    resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
+
+  mdast-util-phrasing@4.1.0:
+    resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
+
+  mdast-util-to-hast@13.2.1:
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
+  mdast-util-to-markdown@2.1.2:
+    resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
+
+  mdast-util-to-string@4.0.0:
+    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
+  mdn-data@2.0.28:
+    resolution: {integrity: sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
+  merge2@1.4.1:
+    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
+    engines: {node: '>= 8'}
+
+  micromark-core-commonmark@2.0.3:
+    resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-frontmatter@2.0.0:
+    resolution: {integrity: sha512-C4AkuM3dA58cgZha7zVnuVxBhDsbttIMiytjgsM2XbHAB2faRVaHRle40558FBN+DJcrLNCoqG5mlrpdU4cRtg==}
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
+
+  micromark-extension-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
+
+  micromark-extension-gfm-table@2.1.1:
+    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    resolution: {integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==}
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
+
+  micromark-extension-gfm@3.0.0:
+    resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
+
+  micromark-extension-mdx-expression@3.0.1:
+    resolution: {integrity: sha512-dD/ADLJ1AeMvSAKBwO22zG22N4ybhe7kFIZ3LsDI0GlsNr2A3KYxb0LdC1u5rj4Nw+CHKY0RVdnHX8vj8ejm4Q==}
+
+  micromark-extension-mdx-jsx@3.0.2:
+    resolution: {integrity: sha512-e5+q1DjMh62LZAJOnDraSSbDMvGJ8x3cbjygy2qFEi7HCeUT4BDKCvMozPozcD6WmOt6sVvYDNBKhFSz3kjOVQ==}
+
+  micromark-extension-mdx-md@2.0.0:
+    resolution: {integrity: sha512-EpAiszsB3blw4Rpba7xTOUptcFeBFi+6PY8VnJ2hhimH+vCQDirWgsMpz7w1XcZE7LVrSAUGb9VJpG9ghlYvYQ==}
+
+  micromark-extension-mdxjs-esm@3.0.0:
+    resolution: {integrity: sha512-DJFl4ZqkErRpq/dAPyeWp15tGrcrrJho1hKK5uBS70BCtfrIFg81sqcTVu3Ta+KD1Tk5vAtBNElWxtAa+m8K9A==}
+
+  micromark-extension-mdxjs@3.0.0:
+    resolution: {integrity: sha512-A873fJfhnJ2siZyUrJ31l34Uqwy4xIFmvPY1oj+Ean5PHcPBYzEsvqvWGaWcfEIr11O5Dlw3p2y0tZWpKHDejQ==}
+
+  micromark-factory-destination@2.0.1:
+    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
+
+  micromark-factory-label@2.0.1:
+    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+
+  micromark-factory-mdx-expression@2.0.3:
+    resolution: {integrity: sha512-kQnEtA3vzucU2BkrIa8/VaSAsP+EJ3CKOvhMuJgOEGg9KDC6OAY6nSnNDVRiVNRqj7Y4SlSzcStaH/5jge8JdQ==}
+
+  micromark-factory-space@2.0.1:
+    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
+
+  micromark-factory-title@2.0.1:
+    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
+
+  micromark-factory-whitespace@2.0.1:
+    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-chunked@2.0.1:
+    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
+
+  micromark-util-classify-character@2.0.1:
+    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
+
+  micromark-util-combine-extensions@2.0.1:
+    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
+
+  micromark-util-decode-string@2.0.1:
+    resolution: {integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-events-to-acorn@2.0.3:
+    resolution: {integrity: sha512-jmsiEIiZ1n7X1Rr5k8wVExBQCg5jy4UXVADItHmNk1zkwEVhBuIUKRu3fqv+hs4nxLISi2DQGlqIOGiFxgbfHg==}
+
+  micromark-util-html-tag-name@2.0.1:
+    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
+
+  micromark-util-normalize-identifier@2.0.1:
+    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
+
+  micromark-util-resolve-all@2.0.1:
+    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-subtokenize@2.1.0:
+    resolution: {integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
+  micromark@4.0.2:
+    resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
+
+  micromatch@4.0.8:
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
+    engines: {node: '>=8.6'}
+
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
+
+  mitata@1.0.34:
+    resolution: {integrity: sha512-Mc3zrtNBKIMeHSCQ0XqRLo1vbdIx1wvFV9c8NJAiyho6AjNfMY8bVhbS12bwciUdd1t4rj8099CH3N3NFahaUA==}
+
+  mlly@1.8.2:
+    resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
+
+  morphdom@2.7.8:
+    resolution: {integrity: sha512-D/fR4xgGUyVRbdMGU6Nejea1RFzYxYtyurG4Fbv2Fi/daKlWKuXGLOdXtl+3eIwL110cI2hz1ZojGICjjFLgTg==}
+
+  mri@1.2.0:
+    resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
+    engines: {node: '>=4'}
+
+  mrmime@2.0.1:
+    resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
+    engines: {node: '>=10'}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mylas@2.1.14:
+    resolution: {integrity: sha512-BzQguy9W9NJgoVn2mRWzbFrFWWztGCcng2QI9+41frfk+Athwgx3qhqhvStz7ExeUUu7Kzw427sNzHpEZNINog==}
+    engines: {node: '>=16.0.0'}
+
+  mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  nf3@0.3.23:
+    resolution: {integrity: sha512-RWVLAWozmVD3AaDmaU3qMGB3v+yNlH5d9qqStI4e/WLlNQVnJ4YErGDbYCIrGFyrHdbF6I6Baf0Ae6c7tFYmSg==}
+
+  nitro@3.0.260311-beta:
+    resolution: {integrity: sha512-0o0fJ9LUh4WKUqJNX012jyieUOtMCnadkNDWr0mHzdraoHpJP/1CGNefjRyZyMXSpoJfwoWdNEZu2iGf35TUvQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      dotenv: '*'
+      giget: '*'
+      jiti: ^2.6.1
+      rollup: ^4.59.0
+      vite: ^7 || ^8 || >=8.0.0-0
+      xml2js: ^0.6.2
+      zephyr-agent: ^0.1.15
+    peerDependenciesMeta:
+      dotenv:
+        optional: true
+      giget:
+        optional: true
+      jiti:
+        optional: true
+      rollup:
+        optional: true
+      vite:
+        optional: true
+      xml2js:
+        optional: true
+      zephyr-agent:
+        optional: true
+
+  node-fetch-native@1.6.7:
+    resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
+  node-releases@2.0.53:
+    resolution: {integrity: sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==}
+    engines: {node: '>=18'}
+
+  normalize-path@3.0.0:
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    engines: {node: '>=0.10.0'}
+
+  nth-check@2.1.1:
+    resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
+
+  nypm@0.6.9:
+    resolution: {integrity: sha512-zxlE2yvSWZWmHcNdT3+5zV2lrCogeE9YOklHrR3dFjqutq5wO7GFDYLFDRXLsYnJzwvy/im9fYoxePvS0VTW0w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  obug@2.1.4:
+    resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
+    engines: {node: '>=12.20.0'}
+
+  ocache@0.1.5:
+    resolution: {integrity: sha512-kNNnkkVQup/QDvmTz8Q84wc2ntiyoVHDxa6eHWKt5qdGAmFRBIxy83rxgCYEjW0x06UJ9E3P6VgM2yY4rOBH4w==}
+
+  ofetch@2.0.0-alpha.3:
+    resolution: {integrity: sha512-zpYTCs2byOuft65vI3z43Dd6iSdFbOZZLb9/d21aCpx2rGastVU9dOCv0lu4ykc1Ur1anAYjDi3SUvR0vq50JA==}
+
+  ohash@2.0.11:
+    resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
+
+  oniguruma-parser@0.12.2:
+    resolution: {integrity: sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==}
+
+  oniguruma-to-es@4.3.6:
+    resolution: {integrity: sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==}
+
+  open@10.2.0:
+    resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
+    engines: {node: '>=18'}
+
+  outdent@0.5.0:
+    resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
+
+  oxc-parser@0.127.0:
+    resolution: {integrity: sha512-bkgD4qHlN7WxLdX8bLXdaU54TtQtAIg/ZBAfm0aje/mo3MRDo3P0hZSgr4U7O3xfX+fQmR5AP04JS/TGcZLcFA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
+  oxc-parser@0.141.0:
+    resolution: {integrity: sha512-uFkGGr1KMWd6aWv9UAqooYrN78trw8MWWmoPvgWokfBEUq1+eiIQ+qfj3wokhy0fxtZWZk+0dHoS7/yRTJtd6w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
+  oxc-resolver@11.24.2:
+    resolution: {integrity: sha512-FY91FiDBj7ls5MsFS9jN3tjz2o0/zsdSsymlakySaBwVJZorHhkWyICLZMKxlu1R9vYo+sd3z1jwb4J8x7bNDw==}
+
+  oxlint@1.78.0:
+    resolution: {integrity: sha512-QgQePuxIqKOzo1KSjG2EnITEeWvWnKAm77eq8nrMtf6AGoA+zyGc4PFYtDNJSD25g/ibOwfQ851hZ4/SPkMVoA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      oxlint-tsgolint: '>=7.0.2001'
+      vite-plus: '*'
+    peerDependenciesMeta:
+      oxlint-tsgolint:
+        optional: true
+      vite-plus:
+        optional: true
+
+  p-filter@2.1.0:
+    resolution: {integrity: sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==}
+    engines: {node: '>=8'}
+
+  p-limit@2.3.0:
+    resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
+    engines: {node: '>=6'}
+
+  p-locate@4.1.0:
+    resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
+    engines: {node: '>=8'}
+
+  p-map@2.1.0:
+    resolution: {integrity: sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==}
+    engines: {node: '>=6'}
+
+  p-try@2.2.0:
+    resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
+    engines: {node: '>=6'}
+
+  package-manager-detector@0.2.11:
+    resolution: {integrity: sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==}
+
+  parse-entities@4.0.2:
+    resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
+
+  parse-numeric-range@1.3.0:
+    resolution: {integrity: sha512-twN+njEipszzlMJd4ONUYgSfZPDxgHhT9Ahed5uTigpQn90FggW4SA/AIPq/6a149fTbE9qBEcSwE3FAEp6wQQ==}
+
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-parse@1.0.7:
+    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  path-type@4.0.0:
+    resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
+    engines: {node: '>=8'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
+    engines: {node: '>=8.6'}
+
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
+    engines: {node: '>=12'}
+
+  pify@2.3.0:
+    resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
+    engines: {node: '>=0.10.0'}
+
+  pify@4.0.1:
+    resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
+    engines: {node: '>=6'}
+
+  pirates@4.0.7:
+    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
+    engines: {node: '>= 6'}
+
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  playwright-core@1.62.1:
+    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.62.1:
+    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  plimit-lit@1.6.1:
+    resolution: {integrity: sha512-B7+VDyb8Tl6oMJT9oSO2CW8XC/T4UcJGrwOVoNGwOQsQYhlpfajmrMj5xeejqaASq3V/EqThyOeATEOMuSEXiA==}
+    engines: {node: '>=12'}
+
+  pngjs@7.0.0:
+    resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
+    engines: {node: '>=14.19.0'}
+
+  postcss-calc@10.1.1:
+    resolution: {integrity: sha512-NYEsLHh8DgG/PRH2+G9BTuUdtf9ViS+vdoQ0YA5OQdGsfN4ztiwtDWNtBl9EKeqNMFnIu8IKZ0cLxEQ5r5KVMw==}
+    engines: {node: ^18.12 || ^20.9 || >=22.0}
+    peerDependencies:
+      postcss: ^8.4.38
+
+  postcss-colormin@8.0.3:
+    resolution: {integrity: sha512-kypgzYcOcrKsrAZyId3TMumHtIiwZxgK1h5B33S4RjQNV02RHKrXCWP8ndyx5S0R5mk4pkcIfJ95o3BwIN8r2Q==}
+    engines: {node: ^22.11.0 || ^24.11.0 || >=26.0}
+    peerDependencies:
+      postcss: ^8.5.26
+
+  postcss-convert-values@8.0.3:
+    resolution: {integrity: sha512-14lU1u5MeX8oGQ4zMhiMYhFcav9ebgmjjxTYwk77pmZ5A9Rq8hr5X/XZaTfffvbIGMOoLK82YDsLxA+1hFGbbA==}
+    engines: {node: ^22.11.0 || ^24.11.0 || >=26.0}
+    peerDependencies:
+      postcss: ^8.5.26
+
+  postcss-discard-comments@8.0.3:
+    resolution: {integrity: sha512-oDe4ITEfp1/113ebPi/ujyfWX2E9+vbHhY0dPnypgHwIgw8LBQ7MczmtAbccw8gUs+Zlmgt80qtTKS0t8eCi+Q==}
+    engines: {node: ^22.11.0 || ^24.11.0 || >=26.0}
+    peerDependencies:
+      postcss: ^8.5.26
+
+  postcss-discard-duplicates@8.0.3:
+    resolution: {integrity: sha512-6f6ZVBozciZ0nG7nurrHk+K2yNeBgEoOjZvj5JwFThK982tSPyOjtClbkTYgqwDuSFjBvtu5C9Iz/2QEPvUg+Q==}
+    engines: {node: ^22.11.0 || ^24.11.0 || >=26.0}
+    peerDependencies:
+      postcss: ^8.5.26
+
+  postcss-discard-empty@8.0.3:
+    resolution: {integrity: sha512-IpqNmuH9djHODVELb5c4tC6274pxjEWqrpGtTu7BR8TtOz3beqTv7JjE9xSuGOacphh9XZbbyEebvfMxYC5PTA==}
+    engines: {node: ^22.11.0 || ^24.11.0 || >=26.0}
+    peerDependencies:
+      postcss: ^8.5.26
+
+  postcss-discard-overridden@8.0.3:
+    resolution: {integrity: sha512-G2Ksn7kkNsNlsYsgfVn0YFfcGewJTuc1KOENvoVtwu2bSEyR28+GaomozkV4DPUBbKF8Nvco/9rLyKkgf/TY6w==}
+    engines: {node: ^22.11.0 || ^24.11.0 || >=26.0}
+    peerDependencies:
+      postcss: ^8.5.26
+
+  postcss-import@16.2.0:
+    resolution: {integrity: sha512-0mQUGlSp87Zl70K58RNwQAN1WS9plFE6KWGui9nyK6ninduMyjW/Khaoy/BpBoFTBh7ndAvAKrSKVbwy6vd/BA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      postcss: ^8.0.0
+
+  postcss-load-config@6.0.1:
+    resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      jiti: '>=1.21.0'
+      postcss: '>=8.0.9'
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+      postcss:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  postcss-merge-longhand@8.0.3:
+    resolution: {integrity: sha512-/Byag1rLsEffmnidL+8HGwr0AsQWiaY2gpChEKwKP4+YcBtzz44rKVxAJLdhQtRLFrpGiBoLzCdCfH/ZTkozuA==}
+    engines: {node: ^22.11.0 || ^24.11.0 || >=26.0}
+    peerDependencies:
+      postcss: ^8.5.26
+
+  postcss-merge-rules@8.0.3:
+    resolution: {integrity: sha512-gBnrjp2ebQyrBNDqxORirC6ZM6g4cHKglAwGf1JiuKmDPjUJbNM6WhxYMYkHf+hxysnZfq27+TtxGrYESv3GMQ==}
+    engines: {node: ^22.11.0 || ^24.11.0 || >=26.0}
+    peerDependencies:
+      postcss: ^8.5.26
+
+  postcss-minify-font-values@8.0.3:
+    resolution: {integrity: sha512-kAXxTCIVub5LZvyKTr9AObrRxri0WtWpNVsG6R9NdBKHDHYu5WNAnZRntgOforsKeFeZRZvOOXnTqOANQeyzKg==}
+    engines: {node: ^22.11.0 || ^24.11.0 || >=26.0}
+    peerDependencies:
+      postcss: ^8.5.26
+
+  postcss-minify-gradients@8.0.3:
+    resolution: {integrity: sha512-0O9UDPjIB4OikREx/aOwPY3pco23txEpXpdTlzfoSrVQllNh5j9GaCkThA5ylsKcDWz5sunV3tFW9+zlHFWUww==}
+    engines: {node: ^22.11.0 || ^24.11.0 || >=26.0}
+    peerDependencies:
+      postcss: ^8.5.26
+
+  postcss-minify-params@8.0.3:
+    resolution: {integrity: sha512-DuSZEJbWxUX7wvIkz6K4qN8zs5unI/MSg7gcH4AXXA3524OcI4BOBUhR8B8OIBIi9FfcBbfgHYlATVhMeDBXNg==}
+    engines: {node: ^22.11.0 || ^24.11.0 || >=26.0}
+    peerDependencies:
+      postcss: ^8.5.26
+
+  postcss-minify-selectors@8.0.4:
+    resolution: {integrity: sha512-+rqBW9gYNLq2RNBwfVx2QdElj2cTiqbNwah+bw1XvyhCnRe4uFLNW2kny0VspFyYR7OGuVyWZaz2K4DbX5J9sw==}
+    engines: {node: ^22.11.0 || ^24.11.0 || >=26.0}
+    peerDependencies:
+      postcss: ^8.5.26
+
+  postcss-nested@8.0.1:
+    resolution: {integrity: sha512-PvSIwDVh1NTw939iu4FBK+oeZfSm0cbErFAjXCTPiStammzobBNE2SiQNezy8Xp+Oud2uLXaLpTauv3UdxWjbQ==}
+    engines: {node: ^22.0.0 || ^24.0.0 || >= 26.0.0}
+    peerDependencies:
+      postcss: ^8.2.14
+
+  postcss-normalize-charset@8.0.3:
+    resolution: {integrity: sha512-losd0Uu4XVpiKN5tcGh32QxpB9t3S09PMQaW6I2GszKl9wOR0I34DY0a8ApO50jzfBC52lv8jPpkvh5ltbgajg==}
+    engines: {node: ^22.11.0 || ^24.11.0 || >=26.0}
+    peerDependencies:
+      postcss: ^8.5.26
+
+  postcss-normalize-display-values@8.0.3:
+    resolution: {integrity: sha512-IaCp/Rp7bg0e8Hv0Wc4G+niuuA61iGOSzhGBUeo6P6qyoumyFbOzYbYWZSkzMNsC4o2gfHAj3q2VbQfds8Huzw==}
+    engines: {node: ^22.11.0 || ^24.11.0 || >=26.0}
+    peerDependencies:
+      postcss: ^8.5.26
+
+  postcss-normalize-positions@8.0.3:
+    resolution: {integrity: sha512-OA/n9pI6W66Sv1vki0MLv/0QpDECV8i3UHwlXPVnv3XewsBjx310NQDV+ybMx2ZZQc/RHS7Uf8ES+oxLVhd0iA==}
+    engines: {node: ^22.11.0 || ^24.11.0 || >=26.0}
+    peerDependencies:
+      postcss: ^8.5.26
+
+  postcss-normalize-repeat-style@8.0.3:
+    resolution: {integrity: sha512-lMCbxiLBd7awGEoRM1WD02R08XpEGDHg3x7z9VSWnZibgSGHNJ+k7aheucuLBcxPAHWPudwc8O65sYD2FDx0Hg==}
+    engines: {node: ^22.11.0 || ^24.11.0 || >=26.0}
+    peerDependencies:
+      postcss: ^8.5.26
+
+  postcss-normalize-string@8.0.3:
+    resolution: {integrity: sha512-F8jkemEEIGDjerUzTa5w18CQc4GfhpJdEk78LdtwOjLjG1DlaDZyCdec+PyxCHjSY7vsbULXhlk24vSA+eUtIg==}
+    engines: {node: ^22.11.0 || ^24.11.0 || >=26.0}
+    peerDependencies:
+      postcss: ^8.5.26
+
+  postcss-normalize-timing-functions@8.0.3:
+    resolution: {integrity: sha512-6MO4j7ySljCmhPKx6GLkIpDdV6nOhb5UaB8j/0i0EbfooH1NeVQG60Zt7qAQ9h21HUwV6kQDIbWGqU78DhPHtw==}
+    engines: {node: ^22.11.0 || ^24.11.0 || >=26.0}
+    peerDependencies:
+      postcss: ^8.5.26
+
+  postcss-normalize-unicode@8.0.3:
+    resolution: {integrity: sha512-gfMC9A0z8d1HrS792ZFIUMZeTysN/GrtQEiyV/aSJPBwqOOak9BTGTSUp1VHozNuEeQs4MUoO+fBQzDXpRX28A==}
+    engines: {node: ^22.11.0 || ^24.11.0 || >=26.0}
+    peerDependencies:
+      postcss: ^8.5.26
+
+  postcss-normalize-url@8.0.3:
+    resolution: {integrity: sha512-ksA0HgWATlnIzDaB9gFPslXxJkTa7aHZK3jWSbbyJdFJuRIY0BOL0eNMRrZNpe6//g4Af/iB00ETbT0cNmCzKQ==}
+    engines: {node: ^22.11.0 || ^24.11.0 || >=26.0}
+    peerDependencies:
+      postcss: ^8.5.26
+
+  postcss-normalize-whitespace@8.0.3:
+    resolution: {integrity: sha512-Hz/IeeZXk1686EZtnCKKIkU8Mu+PGTxPhkuXnKxJZCD8lkVgD9blIhymu3I/itL4FoOyFTWzh7hQvIri8SbrXg==}
+    engines: {node: ^22.11.0 || ^24.11.0 || >=26.0}
+    peerDependencies:
+      postcss: ^8.5.26
+
+  postcss-ordered-values@8.0.3:
+    resolution: {integrity: sha512-Sp62UbMrsCNcPvtnme1Kz+nNJK3tqCqRvGiKdL7ugYgu3/m8buMlFy3QO/BJ0dJQHHJP2u6CESrw4xhKFJTvvA==}
+    engines: {node: ^22.11.0 || ^24.11.0 || >=26.0}
+    peerDependencies:
+      postcss: ^8.5.26
+
+  postcss-reduce-initial@8.0.3:
+    resolution: {integrity: sha512-z2cMLQtjr+gXd4QIg2O6c21xGsk1QV2HNKaiYVvxZYRrvyuAqPAHFfRSo+7zbGc/n7rilzEFkljJN5WihG99AQ==}
+    engines: {node: ^22.11.0 || ^24.11.0 || >=26.0}
+    peerDependencies:
+      postcss: ^8.5.26
+
+  postcss-reduce-transforms@8.0.3:
+    resolution: {integrity: sha512-MKebqhCviCaOlz9ZnlQxviw0R94q3POvxv3m2Xk1IEyBrk2lsNiKBJsuwXLWHWkQB3y+pQDE0FA26J4+NYhzLg==}
+    engines: {node: ^22.11.0 || ^24.11.0 || >=26.0}
+    peerDependencies:
+      postcss: ^8.5.26
+
+  postcss-selector-parser@7.1.5:
+    resolution: {integrity: sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==}
+    engines: {node: '>=4'}
+
+  postcss-svgo@8.0.4:
+    resolution: {integrity: sha512-cmxRK3zz5BLFO/r/crOHy4QosyNCHpyAG9fOjtOSAEKkajcAK5xyURRWcotPOXcz88VbzIrYJCWVAGjrX4GeJw==}
+    engines: {node: ^22.11.0 || ^24.11.0 || >=26.0}
+    peerDependencies:
+      postcss: ^8.5.26
+
+  postcss-unique-selectors@8.0.3:
+    resolution: {integrity: sha512-uKwlnCNyKmny7yFPOnQJAN82Er0WzGQbSlpZHTKTqlTQsvZF+skA4ANMHqKh+68jQYet6IotH3dtxs1VdyBdxw==}
+    engines: {node: ^22.11.0 || ^24.11.0 || >=26.0}
+    peerDependencies:
+      postcss: ^8.5.26
+
+  postcss-value-parser@4.2.0:
+    resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
+
+  postcss@8.5.26:
+    resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  prettier@2.8.8:
+    resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+
+  prettier@3.9.6:
+    resolution: {integrity: sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==}
+    engines: {node: '>=14'}
+    hasBin: true
+
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
+  property-information@7.2.0:
+    resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
+
+  quansync@0.2.11:
+    resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
+
+  queue-lit@1.5.2:
+    resolution: {integrity: sha512-tLc36IOPeMAubu8BkW8YDBV+WyIgKlYU7zUNs0J5Vk9skSZ4JfGlPOqplP0aHdfv7HL0B2Pg6nwiq60Qc6M2Hw==}
+    engines: {node: '>=12'}
+
+  queue-microtask@1.2.3:
+    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  react-dom@19.2.8:
+    resolution: {integrity: sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==}
+    peerDependencies:
+      react: ^19.2.8
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
+  react@19.2.8:
+    resolution: {integrity: sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==}
+    engines: {node: '>=0.10.0'}
+
+  read-cache@1.0.0:
+    resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
+
+  read-yaml-file@1.1.0:
+    resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
+    engines: {node: '>=6'}
+
+  readdirp@3.6.0:
+    resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
+    engines: {node: '>=8.10.0'}
+
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
+
+  readdirp@5.1.1:
+    resolution: {integrity: sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==}
+    engines: {node: '>= 20.19.0'}
+
+  recast@0.23.21:
+    resolution: {integrity: sha512-mFAyJq9vUbSTARLZUvAEf1z3YxlvAwswbmxMx2mPA/MSm4KmpwvwvhsH/NIrZhyOuwD60Lzyw2qh83uCbgTPYw==}
+    engines: {node: '>= 4'}
+
+  recma-build-jsx@1.0.0:
+    resolution: {integrity: sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew==}
+
+  recma-jsx@1.0.1:
+    resolution: {integrity: sha512-huSIy7VU2Z5OLv6oFLosQGGDqPqdO1iq6bWNAdhzMxSJP7RAso4fCZ1cKu8j9YHCZf3TPrq4dw3okhrylgcd7w==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  recma-parse@1.0.0:
+    resolution: {integrity: sha512-OYLsIGBB5Y5wjnSnQW6t3Xg7q3fQ7FWbw/vcXtORTnyaSFscOtABg+7Pnz6YZ6c27fG1/aN8CjfwoUEUIdwqWQ==}
+
+  recma-stringify@1.0.0:
+    resolution: {integrity: sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g==}
+
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
+
+  regex-recursion@6.0.2:
+    resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
+
+  regex-utilities@2.3.0:
+    resolution: {integrity: sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==}
+
+  regex@6.1.0:
+    resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
+
+  rehype-parse@9.0.1:
+    resolution: {integrity: sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==}
+
+  rehype-pretty-code@0.14.5:
+    resolution: {integrity: sha512-+DhMMNMgOwmE0xu2RmagN63nR0GRObPIQ9TuoNdUYYIDcCr8nWXU1CJUG6yca7vg99Gp5d+62A/+ZvksmsQXjA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      shiki: ^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0
+
+  rehype-recma@1.0.0:
+    resolution: {integrity: sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw==}
+
+  remark-frontmatter@5.0.0:
+    resolution: {integrity: sha512-XTFYvNASMe5iPN0719nPrdItC9aU0ssC4v14mH1BCi1u0n1gAocqcujWUrByftZTbLhRtiKRyjYTSIOcr69UVQ==}
+
+  remark-gfm@4.0.1:
+    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
+  remark-mdx@3.1.1:
+    resolution: {integrity: sha512-Pjj2IYlUY3+D8x00UJsIOg5BEvfMyeI+2uLPn9VO9Wg4MEtN/VTIq2NEJQfde9PnX15KgtHyl9S0BcTnWrIuWg==}
+
+  remark-parse@11.0.0:
+    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+
+  remark-rehype@11.1.2:
+    resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
+
+  resolve-from@5.0.0:
+    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
+    engines: {node: '>=8'}
+
+  resolve@1.22.12:
+    resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
+    engines: {node: '>= 0.4'}
+    hasBin: true
+
+  reusify@1.1.0:
+    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  rolldown@1.2.4:
+    resolution: {integrity: sha512-rSr7irW0K7QRWzjdJXqZowkcRdDtjRduh43rBltnVKd0VFq839l1lJoDvGJb6gl7+4rTTCrPWu+YfujUL8Ug7w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  rollup@4.62.4:
+    resolution: {integrity: sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  rou3@0.9.2:
+    resolution: {integrity: sha512-3SOzvaAg8rkHrXtRjpCvCvbyO5to9oOO27Z/XqHEYXfMRVSw/qMIVdmaOk9W2lcRLtR6dlqTjo9hDeJk70QBYQ==}
+
+  run-applescript@7.1.0:
+    resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
+    engines: {node: '>=18'}
+
+  run-parallel@1.2.0:
+    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  sax@1.6.1:
+    resolution: {integrity: sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==}
+    engines: {node: '>=11.0.0'}
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  shiki@3.23.0:
+    resolution: {integrity: sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==}
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
+  sirv@3.0.2:
+    resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
+    engines: {node: '>=18'}
+
+  sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+
+  slash@3.0.0:
+    resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
+    engines: {node: '>=8'}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  source-map@0.6.1:
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
+    engines: {node: '>=0.10.0'}
+
+  source-map@0.7.6:
+    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
+    engines: {node: '>= 12'}
+
+  source-map@0.8.0:
+    resolution: {integrity: sha512-d8EqvL+k/SOXCreS/SUzg2ciyHqBBLcN/yuRjFsbvVhHTE2pgei7oAhmPM7kWFbkX6OSMQfUq4KbkF3au9lhYQ==}
+    engines: {node: '>= 12'}
+
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
+  spawndamnit@3.0.1:
+    resolution: {integrity: sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==}
+
+  sprintf-js@1.0.3:
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
+  srvx@0.11.22:
+    resolution: {integrity: sha512-LqZxxBDMKuMAZzFzJnDCkFOrs9MZQZr0LvHiO/SuSZVdQaXD7xQ5UWTUxheJrQPve1qk9MG2B/yttUvJxw8egQ==}
+    engines: {node: '>=20.16.0'}
+    hasBin: true
+
+  srvx@0.12.5:
+    resolution: {integrity: sha512-IuvtDNQg5EIwv3c6dleyau7u8hCyGQ7D6+V/QM799Aud07z0wCUcurKLTRfyG33C8oUY+UWcVBFkfHMcbtmRLA==}
+    engines: {node: '>=20.16.0'}
+    hasBin: true
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
+
+  storybook@10.5.7:
+    resolution: {integrity: sha512-oiKvWIwIoOhFP1i6dASYyMXwPHKEtVZMshqSB7EvIVYjWRh0l9H7gHEt1z4Gh2rLGFMekWdsm4s94rvwpR7gkg==}
+    hasBin: true
+    peerDependencies:
+      '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      prettier: ^2 || ^3
+      vite-plus: ^0.1.15 || ^0.2.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      prettier:
+        optional: true
+      vite-plus:
+        optional: true
+
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
+
+  strip-bom@3.0.0:
+    resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
+    engines: {node: '>=4'}
+
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
+
+  stubborn-fs@2.0.0:
+    resolution: {integrity: sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==}
+
+  stubborn-utils@1.0.2:
+    resolution: {integrity: sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==}
+
+  style-to-js@1.1.21:
+    resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
+
+  style-to-object@1.0.14:
+    resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
+
+  stylehacks@8.0.3:
+    resolution: {integrity: sha512-cHciVnyMEuLOYt6AGCTyzRjEvBTvA+0H/QThOFgKTI9uuFK4RA34gLVEt/Uuz11rtSPvZHjMWLjTazF9pLMPog==}
+    engines: {node: ^22.11.0 || ^24.11.0 || >=26.0}
+    peerDependencies:
+      postcss: ^8.5.26
+
+  sucrase@3.35.1:
+    resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
+  supports-preserve-symlinks-flag@1.0.0:
+    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
+    engines: {node: '>= 0.4'}
+
+  svgo@4.0.2:
+    resolution: {integrity: sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng==}
+    engines: {node: '>=16'}
+    hasBin: true
+
+  tagged-tag@1.0.0:
+    resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
+    engines: {node: '>=20'}
+
+  tailwindcss@4.3.3:
+    resolution: {integrity: sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==}
+
+  tapable@2.3.3:
+    resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
+    engines: {node: '>=6'}
+
+  term-size@2.2.1:
+    resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
+    engines: {node: '>=8'}
+
+  thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+
+  thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyexec@1.3.0:
+    resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyrainbow@3.1.1:
+    resolution: {integrity: sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
+
+  to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
+
+  totalist@3.0.1:
+    resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
+    engines: {node: '>=6'}
+
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
+
+  trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
+  trough@2.2.0:
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
+  ts-dedent@2.3.0:
+    resolution: {integrity: sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==}
+    engines: {node: '>=6.10'}
+
+  ts-interface-checker@0.1.13:
+    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
+  tsc-alias@1.8.10:
+    resolution: {integrity: sha512-Ibv4KAWfFkFdKJxnWfVtdOmB0Zi1RJVxcbPGiCDsFpCQSsmpWyuzHG3rQyI5YkobWwxFPEyQfu1hdo4qLG2zPw==}
+    hasBin: true
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsup@8.5.1:
+    resolution: {integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      '@microsoft/api-extractor': ^7.36.0
+      '@swc/core': ^1
+      postcss: ^8.4.12
+      typescript: '>=4.5.0'
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      '@swc/core':
+        optional: true
+      postcss:
+        optional: true
+      typescript:
+        optional: true
+
+  tsx@4.23.12:
+    resolution: {integrity: sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  type-fest@5.8.0:
+    resolution: {integrity: sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==}
+    engines: {node: '>=20'}
+
+  typescript@7.0.2:
+    resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
+    engines: {node: '>=16.20.0'}
+    hasBin: true
+
+  ufo@1.6.4:
+    resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
+
+  undici-types@7.18.2:
+    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
+  unenv@2.0.0-rc.24:
+    resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
+
+  unified@11.0.5:
+    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-position-from-estree@2.0.0:
+    resolution: {integrity: sha512-KaFVRjoqLyF6YXCbVLNad/eS4+OfPQQn2yOd7zF/h5T/CSL2v8NpN6a5TPvtbXthAGw5nG+PuTtq+DdIZr+cRQ==}
+
+  unist-util-position@5.0.0:
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
+  universalify@0.1.2:
+    resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
+    engines: {node: '>= 4.0.0'}
+
+  universalify@2.0.1:
+    resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
+    engines: {node: '>= 10.0.0'}
+
+  unplugin@2.3.11:
+    resolution: {integrity: sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==}
+    engines: {node: '>=18.12.0'}
+
+  unstorage@2.0.0-alpha.7:
+    resolution: {integrity: sha512-ELPztchk2zgFJnakyodVY3vJWGW9jy//keJ32IOJVGUMyaPydwcA1FtVvWqT0TNRch9H+cMNEGllfVFfScImog==}
+    peerDependencies:
+      '@azure/app-configuration': ^1.11.0
+      '@azure/cosmos': ^4.9.1
+      '@azure/data-tables': ^13.3.2
+      '@azure/identity': ^4.13.0
+      '@azure/keyvault-secrets': ^4.10.0
+      '@azure/storage-blob': ^12.31.0
+      '@capacitor/preferences': ^6 || ^7 || ^8
+      '@deno/kv': '>=0.13.0'
+      '@netlify/blobs': ^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0
+      '@planetscale/database': ^1.19.0
+      '@upstash/redis': ^1.36.2
+      '@vercel/blob': '>=0.27.3'
+      '@vercel/functions': ^2.2.12 || ^3.0.0
+      '@vercel/kv': ^1.0.1
+      aws4fetch: ^1.0.20
+      chokidar: ^4 || ^5
+      db0: '>=0.3.4'
+      idb-keyval: ^6.2.2
+      ioredis: ^5.9.3
+      lru-cache: ^11.2.6
+      mongodb: ^6 || ^7
+      ofetch: '*'
+      uploadthing: ^7.7.4
+    peerDependenciesMeta:
+      '@azure/app-configuration':
+        optional: true
+      '@azure/cosmos':
+        optional: true
+      '@azure/data-tables':
+        optional: true
+      '@azure/identity':
+        optional: true
+      '@azure/keyvault-secrets':
+        optional: true
+      '@azure/storage-blob':
+        optional: true
+      '@capacitor/preferences':
+        optional: true
+      '@deno/kv':
+        optional: true
+      '@netlify/blobs':
+        optional: true
+      '@planetscale/database':
+        optional: true
+      '@upstash/redis':
+        optional: true
+      '@vercel/blob':
+        optional: true
+      '@vercel/functions':
+        optional: true
+      '@vercel/kv':
+        optional: true
+      aws4fetch:
+        optional: true
+      chokidar:
+        optional: true
+      db0:
+        optional: true
+      idb-keyval:
+        optional: true
+      ioredis:
+        optional: true
+      lru-cache:
+        optional: true
+      mongodb:
+        optional: true
+      ofetch:
+        optional: true
+      uploadthing:
+        optional: true
+
+  update-browserslist-db@1.3.1:
+    resolution: {integrity: sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  valibot@1.4.2:
+    resolution: {integrity: sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  vfile-location@5.0.3:
+    resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
+
+  vfile-matter@5.0.1:
+    resolution: {integrity: sha512-o6roP82AiX0XfkyTHyRCMXgHfltUNlXSEqCIS80f+mbAyiQBE2fxtDVMtseyytGx75sihiJFo/zR6r/4LTs2Cw==}
+
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
+
+  vite@8.2.1:
+    resolution: {integrity: sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.4.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  web-namespaces@2.0.1:
+    resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
+
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  webpack-virtual-modules@0.6.2:
+    resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
+
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
+  when-exit@2.1.5:
+    resolution: {integrity: sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==}
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  ws@8.21.3:
+    resolution: {integrity: sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  wsl-utils@0.1.0:
+    resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
+    engines: {node: '>=18'}
+
+  xdg-basedir@5.1.0:
+    resolution: {integrity: sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ==}
+    engines: {node: '>=12'}
+
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
-    '@adobe/css-tools@4.5.0': {}
-
-    '@alloc/quick-lru@5.2.0': {}
-
-    '@babel/code-frame@7.29.7':
-        dependencies:
-            '@babel/helper-validator-identifier': 7.29.7
-            js-tokens: 4.0.0
-            picocolors: 1.1.1
-
-    '@babel/compat-data@7.29.7': {}
-
-    '@babel/core@7.29.7(supports-color@7.2.0)':
-        dependencies:
-            '@babel/code-frame': 7.29.7
-            '@babel/generator': 7.29.8
-            '@babel/helper-compilation-targets': 7.29.7
-            '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@7.2.0))(supports-color@7.2.0)
-            '@babel/helpers': 7.29.7
-            '@babel/parser': 7.29.8
-            '@babel/template': 7.29.7
-            '@babel/traverse': 7.29.8(supports-color@7.2.0)
-            '@babel/types': 7.29.8
-            '@jridgewell/remapping': 2.3.5
-            convert-source-map: 2.0.0
-            debug: 4.4.3(supports-color@7.2.0)
-            gensync: 1.0.0-beta.2
-            json5: 2.2.3
-            semver: 6.3.1
-        transitivePeerDependencies:
-            - supports-color
-
-    '@babel/generator@7.29.8':
-        dependencies:
-            '@babel/parser': 7.29.8
-            '@babel/types': 7.29.8
-            '@jridgewell/gen-mapping': 0.3.13
-            '@jridgewell/trace-mapping': 0.3.31
-            jsesc: 3.1.0
-
-    '@babel/helper-annotate-as-pure@7.29.7':
-        dependencies:
-            '@babel/types': 7.29.8
-
-    '@babel/helper-compilation-targets@7.29.7':
-        dependencies:
-            '@babel/compat-data': 7.29.7
-            '@babel/helper-validator-option': 7.29.7
-            browserslist: 4.28.7
-            lru-cache: 5.1.1
-            semver: 6.3.1
-
-    '@babel/helper-create-class-features-plugin@7.29.7(@babel/core@7.29.7(supports-color@7.2.0))(supports-color@7.2.0)':
-        dependencies:
-            '@babel/core': 7.29.7(supports-color@7.2.0)
-            '@babel/helper-annotate-as-pure': 7.29.7
-            '@babel/helper-member-expression-to-functions': 7.29.7(supports-color@7.2.0)
-            '@babel/helper-optimise-call-expression': 7.29.7
-            '@babel/helper-replace-supers': 7.29.7(@babel/core@7.29.7(supports-color@7.2.0))(supports-color@7.2.0)
-            '@babel/helper-skip-transparent-expression-wrappers': 7.29.7(supports-color@7.2.0)
-            '@babel/traverse': 7.29.8(supports-color@7.2.0)
-            semver: 6.3.1
-        transitivePeerDependencies:
-            - supports-color
-
-    '@babel/helper-globals@7.29.7': {}
-
-    '@babel/helper-member-expression-to-functions@7.29.7(supports-color@7.2.0)':
-        dependencies:
-            '@babel/traverse': 7.29.8(supports-color@7.2.0)
-            '@babel/types': 7.29.8
-        transitivePeerDependencies:
-            - supports-color
-
-    '@babel/helper-module-imports@7.29.7(supports-color@7.2.0)':
-        dependencies:
-            '@babel/traverse': 7.29.8(supports-color@7.2.0)
-            '@babel/types': 7.29.8
-        transitivePeerDependencies:
-            - supports-color
-
-    '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7(supports-color@7.2.0))(supports-color@7.2.0)':
-        dependencies:
-            '@babel/core': 7.29.7(supports-color@7.2.0)
-            '@babel/helper-module-imports': 7.29.7(supports-color@7.2.0)
-            '@babel/helper-validator-identifier': 7.29.7
-            '@babel/traverse': 7.29.8(supports-color@7.2.0)
-        transitivePeerDependencies:
-            - supports-color
-
-    '@babel/helper-optimise-call-expression@7.29.7':
-        dependencies:
-            '@babel/types': 7.29.8
-
-    '@babel/helper-plugin-utils@7.29.7': {}
-
-    '@babel/helper-replace-supers@7.29.7(@babel/core@7.29.7(supports-color@7.2.0))(supports-color@7.2.0)':
-        dependencies:
-            '@babel/core': 7.29.7(supports-color@7.2.0)
-            '@babel/helper-member-expression-to-functions': 7.29.7(supports-color@7.2.0)
-            '@babel/helper-optimise-call-expression': 7.29.7
-            '@babel/traverse': 7.29.8(supports-color@7.2.0)
-        transitivePeerDependencies:
-            - supports-color
-
-    '@babel/helper-skip-transparent-expression-wrappers@7.29.7(supports-color@7.2.0)':
-        dependencies:
-            '@babel/traverse': 7.29.8(supports-color@7.2.0)
-            '@babel/types': 7.29.8
-        transitivePeerDependencies:
-            - supports-color
-
-    '@babel/helper-string-parser@7.29.7': {}
-
-    '@babel/helper-string-parser@8.0.0': {}
-
-    '@babel/helper-validator-identifier@7.29.7': {}
-
-    '@babel/helper-validator-identifier@8.0.4': {}
-
-    '@babel/helper-validator-option@7.29.7': {}
-
-    '@babel/helpers@7.29.7':
-        dependencies:
-            '@babel/template': 7.29.7
-            '@babel/types': 7.29.8
-
-    '@babel/parser@7.29.8':
-        dependencies:
-            '@babel/types': 7.29.8
-
-    '@babel/plugin-proposal-decorators@7.29.7(@babel/core@7.29.7(supports-color@7.2.0))(supports-color@7.2.0)':
-        dependencies:
-            '@babel/core': 7.29.7(supports-color@7.2.0)
-            '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7(supports-color@7.2.0))(supports-color@7.2.0)
-            '@babel/helper-plugin-utils': 7.29.7
-            '@babel/plugin-syntax-decorators': 7.29.7(@babel/core@7.29.7(supports-color@7.2.0))
-        transitivePeerDependencies:
-            - supports-color
-
-    '@babel/plugin-syntax-decorators@7.29.7(@babel/core@7.29.7(supports-color@7.2.0))':
-        dependencies:
-            '@babel/core': 7.29.7(supports-color@7.2.0)
-            '@babel/helper-plugin-utils': 7.29.7
-
-    '@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7(supports-color@7.2.0))':
-        dependencies:
-            '@babel/core': 7.29.7(supports-color@7.2.0)
-            '@babel/helper-plugin-utils': 7.29.7
-
-    '@babel/plugin-transform-class-properties@7.29.7(@babel/core@7.29.7(supports-color@7.2.0))(supports-color@7.2.0)':
-        dependencies:
-            '@babel/core': 7.29.7(supports-color@7.2.0)
-            '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7(supports-color@7.2.0))(supports-color@7.2.0)
-            '@babel/helper-plugin-utils': 7.29.7
-        transitivePeerDependencies:
-            - supports-color
-
-    '@babel/runtime@7.29.7': {}
-
-    '@babel/template@7.29.7':
-        dependencies:
-            '@babel/code-frame': 7.29.7
-            '@babel/parser': 7.29.8
-            '@babel/types': 7.29.8
-
-    '@babel/traverse@7.29.8(supports-color@7.2.0)':
-        dependencies:
-            '@babel/code-frame': 7.29.7
-            '@babel/generator': 7.29.8
-            '@babel/helper-globals': 7.29.7
-            '@babel/parser': 7.29.8
-            '@babel/template': 7.29.7
-            '@babel/types': 7.29.8
-            debug: 4.4.3(supports-color@7.2.0)
-        transitivePeerDependencies:
-            - supports-color
-
-    '@babel/types@7.29.8':
-        dependencies:
-            '@babel/helper-string-parser': 7.29.7
-            '@babel/helper-validator-identifier': 7.29.7
-
-    '@babel/types@8.0.4':
-        dependencies:
-            '@babel/helper-string-parser': 8.0.0
-            '@babel/helper-validator-identifier': 8.0.4
-
-    '@bcoe/v8-coverage@1.0.2': {}
-
-    '@blazediff/core@1.9.1': {}
-
-    '@bomb.sh/args@0.3.1': {}
-
-    '@changesets/apply-release-plan@7.1.1':
-        dependencies:
-            '@changesets/config': 3.1.4
-            '@changesets/get-version-range-type': 0.4.0
-            '@changesets/git': 3.0.4
-            '@changesets/should-skip-package': 0.1.2
-            '@changesets/types': 6.1.0
-            '@manypkg/get-packages': 1.1.3
-            detect-indent: 6.1.0
-            fs-extra: 7.0.1
-            lodash.startcase: 4.4.0
-            outdent: 0.5.0
-            prettier: 2.8.8
-            resolve-from: 5.0.0
-            semver: 7.8.5
-
-    '@changesets/assemble-release-plan@6.0.10':
-        dependencies:
-            '@changesets/errors': 0.2.0
-            '@changesets/get-dependents-graph': 2.1.4
-            '@changesets/should-skip-package': 0.1.2
-            '@changesets/types': 6.1.0
-            '@manypkg/get-packages': 1.1.3
-            semver: 7.8.5
-
-    '@changesets/changelog-git@0.2.1':
-        dependencies:
-            '@changesets/types': 6.1.0
-
-    '@changesets/changelog-github@0.5.2':
-        dependencies:
-            '@changesets/get-github-info': 0.7.0
-            '@changesets/types': 6.1.0
-            dotenv: 8.6.0
-        transitivePeerDependencies:
-            - encoding
-
-    '@changesets/cli@2.31.1(@types/node@24.13.3)':
-        dependencies:
-            '@changesets/apply-release-plan': 7.1.1
-            '@changesets/assemble-release-plan': 6.0.10
-            '@changesets/changelog-git': 0.2.1
-            '@changesets/config': 3.1.4
-            '@changesets/errors': 0.2.0
-            '@changesets/get-dependents-graph': 2.1.4
-            '@changesets/get-release-plan': 4.0.16
-            '@changesets/git': 3.0.4
-            '@changesets/logger': 0.1.1
-            '@changesets/pre': 2.0.2
-            '@changesets/read': 0.6.7
-            '@changesets/should-skip-package': 0.1.2
-            '@changesets/types': 6.1.0
-            '@changesets/write': 0.4.0
-            '@inquirer/external-editor': 1.0.3(@types/node@24.13.3)
-            '@manypkg/get-packages': 1.1.3
-            ansi-colors: 4.1.3
-            enquirer: 2.4.1
-            fs-extra: 7.0.1
-            mri: 1.2.0
-            package-manager-detector: 0.2.11
-            picocolors: 1.1.1
-            resolve-from: 5.0.0
-            semver: 7.8.5
-            spawndamnit: 3.0.1
-            term-size: 2.2.1
-        transitivePeerDependencies:
-            - '@types/node'
-
-    '@changesets/config@3.1.4':
-        dependencies:
-            '@changesets/errors': 0.2.0
-            '@changesets/get-dependents-graph': 2.1.4
-            '@changesets/logger': 0.1.1
-            '@changesets/should-skip-package': 0.1.2
-            '@changesets/types': 6.1.0
-            '@manypkg/get-packages': 1.1.3
-            fs-extra: 7.0.1
-            micromatch: 4.0.8
-
-    '@changesets/errors@0.2.0':
-        dependencies:
-            extendable-error: 0.1.7
-
-    '@changesets/get-dependents-graph@2.1.4':
-        dependencies:
-            '@changesets/types': 6.1.0
-            '@manypkg/get-packages': 1.1.3
-            picocolors: 1.1.1
-            semver: 7.8.5
-
-    '@changesets/get-github-info@0.7.0':
-        dependencies:
-            dataloader: 1.4.0
-            node-fetch: 2.7.0
-        transitivePeerDependencies:
-            - encoding
-
-    '@changesets/get-release-plan@4.0.16':
-        dependencies:
-            '@changesets/assemble-release-plan': 6.0.10
-            '@changesets/config': 3.1.4
-            '@changesets/pre': 2.0.2
-            '@changesets/read': 0.6.7
-            '@changesets/types': 6.1.0
-            '@manypkg/get-packages': 1.1.3
-
-    '@changesets/get-version-range-type@0.4.0': {}
-
-    '@changesets/git@3.0.4':
-        dependencies:
-            '@changesets/errors': 0.2.0
-            '@manypkg/get-packages': 1.1.3
-            is-subdir: 1.2.0
-            micromatch: 4.0.8
-            spawndamnit: 3.0.1
-
-    '@changesets/logger@0.1.1':
-        dependencies:
-            picocolors: 1.1.1
-
-    '@changesets/parse@0.4.3':
-        dependencies:
-            '@changesets/types': 6.1.0
-            js-yaml: 4.3.1
-
-    '@changesets/pre@2.0.2':
-        dependencies:
-            '@changesets/errors': 0.2.0
-            '@changesets/types': 6.1.0
-            '@manypkg/get-packages': 1.1.3
-            fs-extra: 7.0.1
-
-    '@changesets/read@0.6.7':
-        dependencies:
-            '@changesets/git': 3.0.4
-            '@changesets/logger': 0.1.1
-            '@changesets/parse': 0.4.3
-            '@changesets/types': 6.1.0
-            fs-extra: 7.0.1
-            p-filter: 2.1.0
-            picocolors: 1.1.1
-
-    '@changesets/should-skip-package@0.1.2':
-        dependencies:
-            '@changesets/types': 6.1.0
-            '@manypkg/get-packages': 1.1.3
-
-    '@changesets/types@4.1.0': {}
-
-    '@changesets/types@6.1.0': {}
-
-    '@changesets/write@0.4.0':
-        dependencies:
-            '@changesets/types': 6.1.0
-            fs-extra: 7.0.1
-            human-id: 4.2.0
-            prettier: 2.8.8
-
-    '@chromatic-com/storybook@5.2.1(storybook@10.5.5(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))':
-        dependencies:
-            '@neoconfetti/react': 1.0.0
-            chromatic: 16.10.0
-            jsonfile: 6.2.1
-            storybook: 10.5.5(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8)
-            strip-ansi: 7.2.0
-        transitivePeerDependencies:
-            - '@chromatic-com/cypress'
-            - '@chromatic-com/playwright'
-            - '@chromatic-com/vitest'
-
-    '@clack/core@1.4.3':
-        dependencies:
-            fast-wrap-ansi: 0.2.2
-            sisteransi: 1.0.5
-
-    '@clack/prompts@1.7.0':
-        dependencies:
-            '@clack/core': 1.4.3
-            fast-string-width: 3.0.2
-            fast-wrap-ansi: 0.2.2
-            sisteransi: 1.0.5
-
-    '@colordx/core@5.5.0': {}
-
-    '@ecopages/browser-router@0.2.0-beta.43(@ecopages/core@0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(typescript@7.0.2))':
-        dependencies:
-            '@ecopages/core': 0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(typescript@7.0.2)
-            morphdom: 2.7.8
-
-    '@ecopages/content-processor@0.2.0-beta.43(@ecopages/core@0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(typescript@7.0.2))(supports-color@7.2.0)(typescript@7.0.2)':
-        dependencies:
-            '@ecopages/core': 0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(typescript@7.0.2)
-            '@ecopages/file-system': 0.2.0-beta.43
-            '@ecopages/logger': 0.2.3(typescript@7.0.2)
-            remark-frontmatter: 5.0.0(supports-color@7.2.0)
-            unified: 11.0.5
-            vfile: 6.0.3
-            vfile-matter: 5.0.1
-        transitivePeerDependencies:
-            - supports-color
-            - typescript
-
-    '@ecopages/core@0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(typescript@7.0.2)':
-        dependencies:
-            '@ecopages/file-system': 0.2.0-beta.43
-            '@ecopages/logger': 0.2.3(typescript@7.0.2)
-            '@ecopages/scripts-injector': 0.1.5(typescript@7.0.2)
-            '@oxc-project/runtime': 0.141.0
-            '@standard-schema/spec': 1.1.0
-            '@standard-schema/utils': 0.3.0
-            '@worker-tools/html-rewriter': 0.1.0-pre.19
-            chokidar: 5.0.0
-            ghtml: 4.0.2
-            oxc-parser: 0.141.0
-            oxc-resolver: 11.24.2
-            rolldown: 1.2.1
-            ws: 8.21.1
-        optionalDependencies:
-            '@ecopages/dev-toolbar': 0.2.0-beta.43
-        transitivePeerDependencies:
-            - bufferutil
-            - typescript
-            - utf-8-validate
-
-    '@ecopages/dev-toolbar@0.2.0-beta.43':
-        dependencies:
-            '@ecopages/jsx': 0.3.0-beta.6(@ecopages/signals@0.3.0-beta.6)
-            '@ecopages/radiant': 0.3.0-beta.6(@ecopages/jsx@0.3.0-beta.6(@ecopages/signals@0.3.0-beta.6))
-            '@ecopages/signals': 0.3.0-beta.6
-            axe-core: 4.12.1
-
-    '@ecopages/ecopages-jsx@0.2.0-beta.43(@ecopages/core@0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(typescript@7.0.2))(@ecopages/jsx@packages+jsx+dist)(@ecopages/radiant@packages+radiant+dist)(supports-color@7.2.0)(typescript@7.0.2)':
-        dependencies:
-            '@ecopages/core': 0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(typescript@7.0.2)
-            '@ecopages/jsx': link:packages/jsx/dist
-            '@ecopages/mdx': 0.2.0-beta.43(@ecopages/core@0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(typescript@7.0.2))(@mdx-js/mdx@3.1.1(supports-color@7.2.0))(typescript@7.0.2)
-            '@ecopages/radiant': link:packages/radiant/dist
-            '@mdx-js/mdx': 3.1.1(supports-color@7.2.0)
-            vfile: 6.0.3
-        transitivePeerDependencies:
-            - supports-color
-            - typescript
-
-    '@ecopages/file-system@0.2.0-beta.43': {}
-
-    '@ecopages/jsx@0.3.0-beta.6(@ecopages/signals@0.3.0-beta.6)':
-        dependencies:
-            '@ecopages/signals': 0.3.0-beta.6
-
-    '@ecopages/logger@0.2.3(typescript@7.0.2)':
-        dependencies:
-            typescript: 7.0.2
-
-    '@ecopages/mdx@0.2.0-beta.43(@ecopages/core@0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(typescript@7.0.2))(@mdx-js/mdx@3.1.1(supports-color@7.2.0))(typescript@7.0.2)':
-        dependencies:
-            '@ecopages/core': 0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(typescript@7.0.2)
-            '@ecopages/logger': 0.2.3(typescript@7.0.2)
-            '@mdx-js/mdx': 3.1.1(supports-color@7.2.0)
-            source-map: 0.8.0
-            vfile: 6.0.3
-        transitivePeerDependencies:
-            - typescript
-
-    '@ecopages/postcss-processor@0.2.0-beta.43(@ecopages/core@0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(typescript@7.0.2))(@tailwindcss/postcss@4.3.3)(tailwindcss@4.3.3)(typescript@7.0.2)':
-        dependencies:
-            '@ecopages/core': 0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(typescript@7.0.2)
-            '@ecopages/file-system': 0.2.0-beta.43
-            '@ecopages/logger': 0.2.3(typescript@7.0.2)
-            autoprefixer: 10.5.4(postcss@8.5.25)
-            browserslist: 4.28.7
-            cssnano: 8.0.2(postcss@8.5.25)
-            postcss: 8.5.25
-            postcss-import: 16.1.1(postcss@8.5.25)
-            postcss-nested: 8.0.1(postcss@8.5.25)
-        optionalDependencies:
-            '@tailwindcss/postcss': 4.3.3
-            tailwindcss: 4.3.3
-        transitivePeerDependencies:
-            - typescript
-
-    '@ecopages/radiant@0.3.0-beta.6(@ecopages/jsx@0.3.0-beta.6(@ecopages/signals@0.3.0-beta.6))':
-        dependencies:
-            '@ecopages/jsx': 0.3.0-beta.6(@ecopages/signals@0.3.0-beta.6)
-
-    '@ecopages/radiant@0.3.0-beta.6(@ecopages/jsx@packages+jsx+dist)':
-        dependencies:
-            '@ecopages/jsx': link:packages/jsx/dist
-
-    '@ecopages/scripts-injector@0.1.5(typescript@7.0.2)':
-        dependencies:
-            typescript: 7.0.2
-
-    '@ecopages/signals@0.3.0-beta.6': {}
-
-    '@emnapi/core@1.11.2':
-        dependencies:
-            '@emnapi/wasi-threads': 1.2.2
-            tslib: 2.8.1
-        optional: true
-
-    '@emnapi/core@1.9.2':
-        dependencies:
-            '@emnapi/wasi-threads': 1.2.1
-            tslib: 2.8.1
-        optional: true
-
-    '@emnapi/core@2.0.0-alpha.3':
-        dependencies:
-            '@emnapi/wasi-threads': 2.0.1
-            tslib: 2.8.1
-        optional: true
-
-    '@emnapi/runtime@1.11.2':
-        dependencies:
-            tslib: 2.8.1
-        optional: true
-
-    '@emnapi/runtime@1.9.2':
-        dependencies:
-            tslib: 2.8.1
-        optional: true
-
-    '@emnapi/runtime@2.0.0-alpha.3':
-        dependencies:
-            tslib: 2.8.1
-        optional: true
-
-    '@emnapi/wasi-threads@1.2.1':
-        dependencies:
-            tslib: 2.8.1
-        optional: true
-
-    '@emnapi/wasi-threads@1.2.2':
-        dependencies:
-            tslib: 2.8.1
-        optional: true
-
-    '@emnapi/wasi-threads@2.0.1':
-        dependencies:
-            tslib: 2.8.1
-        optional: true
-
-    '@esbuild/aix-ppc64@0.27.7':
-        optional: true
-
-    '@esbuild/aix-ppc64@0.28.1':
-        optional: true
-
-    '@esbuild/android-arm64@0.27.7':
-        optional: true
-
-    '@esbuild/android-arm64@0.28.1':
-        optional: true
-
-    '@esbuild/android-arm@0.27.7':
-        optional: true
-
-    '@esbuild/android-arm@0.28.1':
-        optional: true
-
-    '@esbuild/android-x64@0.27.7':
-        optional: true
-
-    '@esbuild/android-x64@0.28.1':
-        optional: true
-
-    '@esbuild/darwin-arm64@0.27.7':
-        optional: true
-
-    '@esbuild/darwin-arm64@0.28.1':
-        optional: true
-
-    '@esbuild/darwin-x64@0.27.7':
-        optional: true
-
-    '@esbuild/darwin-x64@0.28.1':
-        optional: true
-
-    '@esbuild/freebsd-arm64@0.27.7':
-        optional: true
-
-    '@esbuild/freebsd-arm64@0.28.1':
-        optional: true
-
-    '@esbuild/freebsd-x64@0.27.7':
-        optional: true
-
-    '@esbuild/freebsd-x64@0.28.1':
-        optional: true
-
-    '@esbuild/linux-arm64@0.27.7':
-        optional: true
-
-    '@esbuild/linux-arm64@0.28.1':
-        optional: true
-
-    '@esbuild/linux-arm@0.27.7':
-        optional: true
-
-    '@esbuild/linux-arm@0.28.1':
-        optional: true
-
-    '@esbuild/linux-ia32@0.27.7':
-        optional: true
-
-    '@esbuild/linux-ia32@0.28.1':
-        optional: true
-
-    '@esbuild/linux-loong64@0.27.7':
-        optional: true
-
-    '@esbuild/linux-loong64@0.28.1':
-        optional: true
-
-    '@esbuild/linux-mips64el@0.27.7':
-        optional: true
-
-    '@esbuild/linux-mips64el@0.28.1':
-        optional: true
-
-    '@esbuild/linux-ppc64@0.27.7':
-        optional: true
-
-    '@esbuild/linux-ppc64@0.28.1':
-        optional: true
-
-    '@esbuild/linux-riscv64@0.27.7':
-        optional: true
-
-    '@esbuild/linux-riscv64@0.28.1':
-        optional: true
-
-    '@esbuild/linux-s390x@0.27.7':
-        optional: true
-
-    '@esbuild/linux-s390x@0.28.1':
-        optional: true
-
-    '@esbuild/linux-x64@0.27.7':
-        optional: true
-
-    '@esbuild/linux-x64@0.28.1':
-        optional: true
-
-    '@esbuild/netbsd-arm64@0.27.7':
-        optional: true
-
-    '@esbuild/netbsd-arm64@0.28.1':
-        optional: true
-
-    '@esbuild/netbsd-x64@0.27.7':
-        optional: true
-
-    '@esbuild/netbsd-x64@0.28.1':
-        optional: true
-
-    '@esbuild/openbsd-arm64@0.27.7':
-        optional: true
-
-    '@esbuild/openbsd-arm64@0.28.1':
-        optional: true
-
-    '@esbuild/openbsd-x64@0.27.7':
-        optional: true
-
-    '@esbuild/openbsd-x64@0.28.1':
-        optional: true
-
-    '@esbuild/openharmony-arm64@0.27.7':
-        optional: true
-
-    '@esbuild/openharmony-arm64@0.28.1':
-        optional: true
-
-    '@esbuild/sunos-x64@0.27.7':
-        optional: true
-
-    '@esbuild/sunos-x64@0.28.1':
-        optional: true
-
-    '@esbuild/win32-arm64@0.27.7':
-        optional: true
-
-    '@esbuild/win32-arm64@0.28.1':
-        optional: true
-
-    '@esbuild/win32-ia32@0.27.7':
-        optional: true
-
-    '@esbuild/win32-ia32@0.28.1':
-        optional: true
-
-    '@esbuild/win32-x64@0.27.7':
-        optional: true
-
-    '@esbuild/win32-x64@0.28.1':
-        optional: true
-
-    '@inquirer/external-editor@1.0.3(@types/node@24.13.3)':
-        dependencies:
-            chardet: 2.2.0
-            iconv-lite: 0.7.3
-        optionalDependencies:
-            '@types/node': 24.13.3
-
-    '@istanbuljs/schema@0.1.6': {}
-
-    '@jridgewell/gen-mapping@0.3.13':
-        dependencies:
-            '@jridgewell/sourcemap-codec': 1.5.5
-            '@jridgewell/trace-mapping': 0.3.31
-
-    '@jridgewell/remapping@2.3.5':
-        dependencies:
-            '@jridgewell/gen-mapping': 0.3.13
-            '@jridgewell/trace-mapping': 0.3.31
-
-    '@jridgewell/resolve-uri@3.1.2': {}
-
-    '@jridgewell/sourcemap-codec@1.5.5': {}
-
-    '@jridgewell/trace-mapping@0.3.31':
-        dependencies:
-            '@jridgewell/resolve-uri': 3.1.2
-            '@jridgewell/sourcemap-codec': 1.5.5
-
-    '@manypkg/find-root@1.1.0':
-        dependencies:
-            '@babel/runtime': 7.29.7
-            '@types/node': 12.20.55
-            find-up: 4.1.0
-            fs-extra: 8.1.0
-
-    '@manypkg/get-packages@1.1.3':
-        dependencies:
-            '@babel/runtime': 7.29.7
-            '@changesets/types': 4.1.0
-            '@manypkg/find-root': 1.1.0
-            fs-extra: 8.1.0
-            globby: 11.1.0
-            read-yaml-file: 1.1.0
-
-    '@mdx-js/esbuild@3.1.1(esbuild@0.28.1)(supports-color@7.2.0)':
-        dependencies:
-            '@mdx-js/mdx': 3.1.1(supports-color@7.2.0)
-            '@types/unist': 3.0.3
-            esbuild: 0.28.1
-            source-map: 0.7.6
-            vfile: 6.0.3
-            vfile-message: 4.0.3
-        transitivePeerDependencies:
-            - supports-color
-
-    '@mdx-js/mdx@3.1.1(supports-color@7.2.0)':
-        dependencies:
-            '@types/estree': 1.0.9
-            '@types/estree-jsx': 1.0.5
-            '@types/hast': 3.0.5
-            '@types/mdx': 2.0.14
-            acorn: 8.18.0
-            collapse-white-space: 2.1.0
-            devlop: 1.1.0
-            estree-util-is-identifier-name: 3.0.0
-            estree-util-scope: 1.0.0
-            estree-walker: 3.0.3
-            hast-util-to-jsx-runtime: 2.3.6(supports-color@7.2.0)
-            markdown-extensions: 2.0.0
-            recma-build-jsx: 1.0.0
-            recma-jsx: 1.0.1(acorn@8.18.0)
-            recma-stringify: 1.0.0
-            rehype-recma: 1.0.0(supports-color@7.2.0)
-            remark-mdx: 3.1.1(supports-color@7.2.0)
-            remark-parse: 11.0.0(supports-color@7.2.0)
-            remark-rehype: 11.1.2
-            source-map: 0.7.6
-            unified: 11.0.5
-            unist-util-position-from-estree: 2.0.0
-            unist-util-stringify-position: 4.0.0
-            unist-util-visit: 5.1.0
-            vfile: 6.0.3
-        transitivePeerDependencies:
-            - supports-color
-
-    '@mdx-js/react@3.1.1(@types/react@19.2.18)(react@19.2.8)':
-        dependencies:
-            '@types/mdx': 2.0.14
-            '@types/react': 19.2.18
-            react: 19.2.8
-
-    '@napi-rs/lzma-linux-x64-gnu@1.5.1':
-        optional: true
-
-    '@napi-rs/wasm-runtime@1.2.2(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
-        dependencies:
-            '@emnapi/core': 1.11.2
-            '@emnapi/runtime': 1.11.2
-            '@tybys/wasm-util': 0.10.3
-        optional: true
-
-    '@napi-rs/wasm-runtime@1.2.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
-        dependencies:
-            '@emnapi/core': 1.9.2
-            '@emnapi/runtime': 1.9.2
-            '@tybys/wasm-util': 0.10.3
-        optional: true
-
-    '@napi-rs/wasm-runtime@1.2.2(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)':
-        dependencies:
-            '@emnapi/core': 2.0.0-alpha.3
-            '@emnapi/runtime': 2.0.0-alpha.3
-            '@tybys/wasm-util': 0.10.3
-        optional: true
-
-    '@neoconfetti/react@1.0.0': {}
-
-    '@nodelib/fs.scandir@2.1.5':
-        dependencies:
-            '@nodelib/fs.stat': 2.0.5
-            run-parallel: 1.2.0
-
-    '@nodelib/fs.stat@2.0.5': {}
-
-    '@nodelib/fs.walk@1.2.8':
-        dependencies:
-            '@nodelib/fs.scandir': 2.1.5
-            fastq: 1.20.1
-
-    '@oxc-parser/binding-android-arm-eabi@0.127.0':
-        optional: true
-
-    '@oxc-parser/binding-android-arm-eabi@0.141.0':
-        optional: true
-
-    '@oxc-parser/binding-android-arm64@0.127.0':
-        optional: true
-
-    '@oxc-parser/binding-android-arm64@0.141.0':
-        optional: true
-
-    '@oxc-parser/binding-darwin-arm64@0.127.0':
-        optional: true
-
-    '@oxc-parser/binding-darwin-arm64@0.141.0':
-        optional: true
-
-    '@oxc-parser/binding-darwin-x64@0.127.0':
-        optional: true
-
-    '@oxc-parser/binding-darwin-x64@0.141.0':
-        optional: true
-
-    '@oxc-parser/binding-freebsd-x64@0.127.0':
-        optional: true
-
-    '@oxc-parser/binding-freebsd-x64@0.141.0':
-        optional: true
-
-    '@oxc-parser/binding-linux-arm-gnueabihf@0.127.0':
-        optional: true
-
-    '@oxc-parser/binding-linux-arm-gnueabihf@0.141.0':
-        optional: true
-
-    '@oxc-parser/binding-linux-arm-musleabihf@0.127.0':
-        optional: true
-
-    '@oxc-parser/binding-linux-arm-musleabihf@0.141.0':
-        optional: true
-
-    '@oxc-parser/binding-linux-arm64-gnu@0.127.0':
-        optional: true
-
-    '@oxc-parser/binding-linux-arm64-gnu@0.141.0':
-        optional: true
-
-    '@oxc-parser/binding-linux-arm64-musl@0.127.0':
-        optional: true
-
-    '@oxc-parser/binding-linux-arm64-musl@0.141.0':
-        optional: true
-
-    '@oxc-parser/binding-linux-ppc64-gnu@0.127.0':
-        optional: true
-
-    '@oxc-parser/binding-linux-ppc64-gnu@0.141.0':
-        optional: true
-
-    '@oxc-parser/binding-linux-riscv64-gnu@0.127.0':
-        optional: true
-
-    '@oxc-parser/binding-linux-riscv64-gnu@0.141.0':
-        optional: true
-
-    '@oxc-parser/binding-linux-riscv64-musl@0.127.0':
-        optional: true
-
-    '@oxc-parser/binding-linux-riscv64-musl@0.141.0':
-        optional: true
-
-    '@oxc-parser/binding-linux-s390x-gnu@0.127.0':
-        optional: true
-
-    '@oxc-parser/binding-linux-s390x-gnu@0.141.0':
-        optional: true
-
-    '@oxc-parser/binding-linux-x64-gnu@0.127.0':
-        optional: true
-
-    '@oxc-parser/binding-linux-x64-gnu@0.141.0':
-        optional: true
-
-    '@oxc-parser/binding-linux-x64-musl@0.127.0':
-        optional: true
-
-    '@oxc-parser/binding-linux-x64-musl@0.141.0':
-        optional: true
-
-    '@oxc-parser/binding-openharmony-arm64@0.127.0':
-        optional: true
-
-    '@oxc-parser/binding-openharmony-arm64@0.141.0':
-        optional: true
-
-    '@oxc-parser/binding-wasm32-wasi@0.127.0':
-        dependencies:
-            '@emnapi/core': 1.9.2
-            '@emnapi/runtime': 1.9.2
-            '@napi-rs/wasm-runtime': 1.2.2(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
-        optional: true
-
-    '@oxc-parser/binding-wasm32-wasi@0.141.0':
-        dependencies:
-            '@emnapi/core': 1.11.2
-            '@emnapi/runtime': 1.11.2
-            '@napi-rs/wasm-runtime': 1.2.2(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
-        optional: true
-
-    '@oxc-parser/binding-win32-arm64-msvc@0.127.0':
-        optional: true
-
-    '@oxc-parser/binding-win32-arm64-msvc@0.141.0':
-        optional: true
-
-    '@oxc-parser/binding-win32-ia32-msvc@0.127.0':
-        optional: true
-
-    '@oxc-parser/binding-win32-ia32-msvc@0.141.0':
-        optional: true
-
-    '@oxc-parser/binding-win32-x64-msvc@0.127.0':
-        optional: true
-
-    '@oxc-parser/binding-win32-x64-msvc@0.141.0':
-        optional: true
-
-    '@oxc-project/runtime@0.141.0': {}
-
-    '@oxc-project/types@0.127.0': {}
-
-    '@oxc-project/types@0.141.0': {}
-
-    '@oxc-project/types@0.142.0': {}
-
-    '@oxc-resolver/binding-android-arm-eabi@11.24.2':
-        optional: true
-
-    '@oxc-resolver/binding-android-arm64@11.24.2':
-        optional: true
-
-    '@oxc-resolver/binding-darwin-arm64@11.24.2':
-        optional: true
-
-    '@oxc-resolver/binding-darwin-x64@11.24.2':
-        optional: true
-
-    '@oxc-resolver/binding-freebsd-x64@11.24.2':
-        optional: true
-
-    '@oxc-resolver/binding-linux-arm-gnueabihf@11.24.2':
-        optional: true
-
-    '@oxc-resolver/binding-linux-arm-musleabihf@11.24.2':
-        optional: true
-
-    '@oxc-resolver/binding-linux-arm64-gnu@11.24.2':
-        optional: true
-
-    '@oxc-resolver/binding-linux-arm64-musl@11.24.2':
-        optional: true
-
-    '@oxc-resolver/binding-linux-ppc64-gnu@11.24.2':
-        optional: true
-
-    '@oxc-resolver/binding-linux-riscv64-gnu@11.24.2':
-        optional: true
-
-    '@oxc-resolver/binding-linux-riscv64-musl@11.24.2':
-        optional: true
-
-    '@oxc-resolver/binding-linux-s390x-gnu@11.24.2':
-        optional: true
-
-    '@oxc-resolver/binding-linux-x64-gnu@11.24.2':
-        optional: true
-
-    '@oxc-resolver/binding-linux-x64-musl@11.24.2':
-        optional: true
-
-    '@oxc-resolver/binding-openharmony-arm64@11.24.2':
-        optional: true
-
-    '@oxc-resolver/binding-wasm32-wasi@11.24.2':
-        dependencies:
-            '@emnapi/core': 1.11.2
-            '@emnapi/runtime': 1.11.2
-            '@napi-rs/wasm-runtime': 1.2.2(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
-        optional: true
-
-    '@oxc-resolver/binding-win32-arm64-msvc@11.24.2':
-        optional: true
-
-    '@oxc-resolver/binding-win32-x64-msvc@11.24.2':
-        optional: true
-
-    '@oxlint/binding-android-arm-eabi@1.76.0':
-        optional: true
-
-    '@oxlint/binding-android-arm64@1.76.0':
-        optional: true
-
-    '@oxlint/binding-darwin-arm64@1.76.0':
-        optional: true
-
-    '@oxlint/binding-darwin-x64@1.76.0':
-        optional: true
-
-    '@oxlint/binding-freebsd-x64@1.76.0':
-        optional: true
-
-    '@oxlint/binding-linux-arm-gnueabihf@1.76.0':
-        optional: true
-
-    '@oxlint/binding-linux-arm-musleabihf@1.76.0':
-        optional: true
-
-    '@oxlint/binding-linux-arm64-gnu@1.76.0':
-        optional: true
-
-    '@oxlint/binding-linux-arm64-musl@1.76.0':
-        optional: true
-
-    '@oxlint/binding-linux-ppc64-gnu@1.76.0':
-        optional: true
-
-    '@oxlint/binding-linux-riscv64-gnu@1.76.0':
-        optional: true
-
-    '@oxlint/binding-linux-riscv64-musl@1.76.0':
-        optional: true
-
-    '@oxlint/binding-linux-s390x-gnu@1.76.0':
-        optional: true
-
-    '@oxlint/binding-linux-x64-gnu@1.76.0':
-        optional: true
-
-    '@oxlint/binding-linux-x64-musl@1.76.0':
-        optional: true
-
-    '@oxlint/binding-openharmony-arm64@1.76.0':
-        optional: true
-
-    '@oxlint/binding-win32-arm64-msvc@1.76.0':
-        optional: true
-
-    '@oxlint/binding-win32-ia32-msvc@1.76.0':
-        optional: true
-
-    '@oxlint/binding-win32-x64-msvc@1.76.0':
-        optional: true
-
-    '@polka/url@1.0.0-next.29': {}
-
-    '@rolldown/binding-android-arm64@1.2.1':
-        optional: true
-
-    '@rolldown/binding-darwin-arm64@1.2.1':
-        optional: true
-
-    '@rolldown/binding-darwin-x64@1.2.1':
-        optional: true
-
-    '@rolldown/binding-freebsd-x64@1.2.1':
-        optional: true
-
-    '@rolldown/binding-linux-arm-gnueabihf@1.2.1':
-        optional: true
-
-    '@rolldown/binding-linux-arm64-gnu@1.2.1':
-        optional: true
-
-    '@rolldown/binding-linux-arm64-musl@1.2.1':
-        optional: true
-
-    '@rolldown/binding-linux-ppc64-gnu@1.2.1':
-        optional: true
-
-    '@rolldown/binding-linux-s390x-gnu@1.2.1':
-        optional: true
-
-    '@rolldown/binding-linux-x64-gnu@1.2.1':
-        optional: true
-
-    '@rolldown/binding-linux-x64-musl@1.2.1':
-        optional: true
-
-    '@rolldown/binding-openharmony-arm64@1.2.1':
-        optional: true
-
-    '@rolldown/binding-wasm32-wasi@1.2.1':
-        dependencies:
-            '@emnapi/core': 2.0.0-alpha.3
-            '@emnapi/runtime': 2.0.0-alpha.3
-            '@napi-rs/wasm-runtime': 1.2.2(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)
-        optional: true
-
-    '@rolldown/binding-win32-arm64-msvc@1.2.1':
-        optional: true
-
-    '@rolldown/binding-win32-x64-msvc@1.2.1':
-        optional: true
-
-    '@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7(supports-color@7.2.0))(@babel/runtime@7.29.7)(rolldown@1.2.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))':
-        dependencies:
-            '@babel/core': 7.29.7(supports-color@7.2.0)
-            picomatch: 4.0.5
-            rolldown: 1.2.1
-        optionalDependencies:
-            '@babel/runtime': 7.29.7
-            vite: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
-
-    '@rolldown/pluginutils@1.0.1': {}
-
-    '@rollup/rollup-android-arm-eabi@4.62.4':
-        optional: true
-
-    '@rollup/rollup-android-arm64@4.62.4':
-        optional: true
-
-    '@rollup/rollup-darwin-arm64@4.62.4':
-        optional: true
-
-    '@rollup/rollup-darwin-x64@4.62.4':
-        optional: true
-
-    '@rollup/rollup-freebsd-arm64@4.62.4':
-        optional: true
-
-    '@rollup/rollup-freebsd-x64@4.62.4':
-        optional: true
-
-    '@rollup/rollup-linux-arm-gnueabihf@4.62.4':
-        optional: true
-
-    '@rollup/rollup-linux-arm-musleabihf@4.62.4':
-        optional: true
-
-    '@rollup/rollup-linux-arm64-gnu@4.62.4':
-        optional: true
-
-    '@rollup/rollup-linux-arm64-musl@4.62.4':
-        optional: true
-
-    '@rollup/rollup-linux-loong64-gnu@4.62.4':
-        optional: true
-
-    '@rollup/rollup-linux-loong64-musl@4.62.4':
-        optional: true
-
-    '@rollup/rollup-linux-ppc64-gnu@4.62.4':
-        optional: true
-
-    '@rollup/rollup-linux-ppc64-musl@4.62.4':
-        optional: true
-
-    '@rollup/rollup-linux-riscv64-gnu@4.62.4':
-        optional: true
-
-    '@rollup/rollup-linux-riscv64-musl@4.62.4':
-        optional: true
-
-    '@rollup/rollup-linux-s390x-gnu@4.62.4':
-        optional: true
-
-    '@rollup/rollup-linux-x64-gnu@4.62.4':
-        optional: true
-
-    '@rollup/rollup-linux-x64-musl@4.62.4':
-        optional: true
-
-    '@rollup/rollup-openbsd-x64@4.62.4':
-        optional: true
-
-    '@rollup/rollup-openharmony-arm64@4.62.4':
-        optional: true
-
-    '@rollup/rollup-win32-arm64-msvc@4.62.4':
-        optional: true
-
-    '@rollup/rollup-win32-ia32-msvc@4.62.4':
-        optional: true
-
-    '@rollup/rollup-win32-x64-gnu@4.62.4':
-        optional: true
-
-    '@rollup/rollup-win32-x64-msvc@4.62.4':
-        optional: true
-
-    '@shikijs/core@3.23.0':
-        dependencies:
-            '@shikijs/types': 3.23.0
-            '@shikijs/vscode-textmate': 10.0.2
-            '@types/hast': 3.0.5
-            hast-util-to-html: 9.0.5
-
-    '@shikijs/engine-javascript@3.23.0':
-        dependencies:
-            '@shikijs/types': 3.23.0
-            '@shikijs/vscode-textmate': 10.0.2
-            oniguruma-to-es: 4.3.6
-
-    '@shikijs/engine-oniguruma@3.23.0':
-        dependencies:
-            '@shikijs/types': 3.23.0
-            '@shikijs/vscode-textmate': 10.0.2
-
-    '@shikijs/langs@3.23.0':
-        dependencies:
-            '@shikijs/types': 3.23.0
-
-    '@shikijs/themes@3.23.0':
-        dependencies:
-            '@shikijs/types': 3.23.0
-
-    '@shikijs/types@3.23.0':
-        dependencies:
-            '@shikijs/vscode-textmate': 10.0.2
-            '@types/hast': 3.0.5
-
-    '@shikijs/vscode-textmate@10.0.2': {}
-
-    '@standard-schema/spec@1.1.0': {}
-
-    '@standard-schema/utils@0.3.0': {}
-
-    '@stardazed/streams-compression@1.0.0':
-        dependencies:
-            '@stardazed/zlib': 1.0.1
-
-    '@stardazed/zlib@1.0.1': {}
-
-    '@storybook/addon-a11y@10.5.5(storybook@10.5.5(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))':
-        dependencies:
-            '@storybook/global': 5.0.0
-            axe-core: 4.12.1
-            storybook: 10.5.5(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8)
-
-    '@storybook/addon-docs@10.5.5(@types/react@19.2.18)(esbuild@0.28.1)(rollup@4.62.4)(storybook@10.5.5(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))':
-        dependencies:
-            '@mdx-js/react': 3.1.1(@types/react@19.2.18)(react@19.2.8)
-            '@storybook/csf-plugin': 10.5.5(esbuild@0.28.1)(rollup@4.62.4)(storybook@10.5.5(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
-            '@storybook/icons': 2.1.0(react@19.2.8)
-            '@storybook/react-dom-shim': 10.5.5(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(storybook@10.5.5(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))
-            react: 19.2.8
-            react-dom: 19.2.8(react@19.2.8)
-            storybook: 10.5.5(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8)
-            ts-dedent: 2.3.0
-        optionalDependencies:
-            '@types/react': 19.2.18
-        transitivePeerDependencies:
-            - '@types/react-dom'
-            - esbuild
-            - rollup
-            - vite
-            - webpack
-
-    '@storybook/addon-vitest@10.5.5(@vitest/browser-playwright@4.1.10)(@vitest/browser@4.1.10)(@vitest/runner@4.1.10)(react@19.2.8)(storybook@10.5.5(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))(vitest@4.1.10)':
-        dependencies:
-            '@storybook/global': 5.0.0
-            '@storybook/icons': 2.1.0(react@19.2.8)
-            storybook: 10.5.5(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8)
-        optionalDependencies:
-            '@vitest/browser': 4.1.10(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)
-            '@vitest/browser-playwright': 4.1.10(playwright@1.62.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)
-            '@vitest/runner': 4.1.10
-            vitest: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
-        transitivePeerDependencies:
-            - react
-
-    '@storybook/builder-vite@10.5.5(esbuild@0.28.1)(rollup@4.62.4)(storybook@10.5.5(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))':
-        dependencies:
-            '@storybook/csf-plugin': 10.5.5(esbuild@0.28.1)(rollup@4.62.4)(storybook@10.5.5(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
-            storybook: 10.5.5(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8)
-            ts-dedent: 2.3.0
-            vite: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
-        transitivePeerDependencies:
-            - esbuild
-            - rollup
-            - webpack
-
-    '@storybook/csf-plugin@10.5.5(esbuild@0.28.1)(rollup@4.62.4)(storybook@10.5.5(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))':
-        dependencies:
-            storybook: 10.5.5(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8)
-            unplugin: 2.3.11
-        optionalDependencies:
-            esbuild: 0.28.1
-            rollup: 4.62.4
-            vite: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
-
-    '@storybook/global@5.0.0': {}
-
-    '@storybook/icons@2.1.0(react@19.2.8)':
-        dependencies:
-            react: 19.2.8
-
-    '@storybook/react-dom-shim@10.5.5(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(storybook@10.5.5(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))':
-        dependencies:
-            react: 19.2.8
-            react-dom: 19.2.8(react@19.2.8)
-            storybook: 10.5.5(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8)
-        optionalDependencies:
-            '@types/react': 19.2.18
-
-    '@tailwindcss/node@4.3.3':
-        dependencies:
-            '@jridgewell/remapping': 2.3.5
-            enhanced-resolve: 5.24.5
-            jiti: 2.7.0
-            lightningcss: 1.32.0
-            magic-string: 0.30.21
-            source-map-js: 1.2.1
-            tailwindcss: 4.3.3
-
-    '@tailwindcss/oxide-android-arm64@4.3.3':
-        optional: true
-
-    '@tailwindcss/oxide-darwin-arm64@4.3.3':
-        optional: true
-
-    '@tailwindcss/oxide-darwin-x64@4.3.3':
-        optional: true
-
-    '@tailwindcss/oxide-freebsd-x64@4.3.3':
-        optional: true
-
-    '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.3':
-        optional: true
-
-    '@tailwindcss/oxide-linux-arm64-gnu@4.3.3':
-        optional: true
-
-    '@tailwindcss/oxide-linux-arm64-musl@4.3.3':
-        optional: true
-
-    '@tailwindcss/oxide-linux-x64-gnu@4.3.3':
-        optional: true
-
-    '@tailwindcss/oxide-linux-x64-musl@4.3.3':
-        optional: true
-
-    '@tailwindcss/oxide-wasm32-wasi@4.3.3':
-        optional: true
-
-    '@tailwindcss/oxide-win32-arm64-msvc@4.3.3':
-        optional: true
-
-    '@tailwindcss/oxide-win32-x64-msvc@4.3.3':
-        optional: true
-
-    '@tailwindcss/oxide@4.3.3':
-        optionalDependencies:
-            '@tailwindcss/oxide-android-arm64': 4.3.3
-            '@tailwindcss/oxide-darwin-arm64': 4.3.3
-            '@tailwindcss/oxide-darwin-x64': 4.3.3
-            '@tailwindcss/oxide-freebsd-x64': 4.3.3
-            '@tailwindcss/oxide-linux-arm-gnueabihf': 4.3.3
-            '@tailwindcss/oxide-linux-arm64-gnu': 4.3.3
-            '@tailwindcss/oxide-linux-arm64-musl': 4.3.3
-            '@tailwindcss/oxide-linux-x64-gnu': 4.3.3
-            '@tailwindcss/oxide-linux-x64-musl': 4.3.3
-            '@tailwindcss/oxide-wasm32-wasi': 4.3.3
-            '@tailwindcss/oxide-win32-arm64-msvc': 4.3.3
-            '@tailwindcss/oxide-win32-x64-msvc': 4.3.3
-
-    '@tailwindcss/postcss@4.3.3':
-        dependencies:
-            '@alloc/quick-lru': 5.2.0
-            '@tailwindcss/node': 4.3.3
-            '@tailwindcss/oxide': 4.3.3
-            postcss: 8.5.25
-            tailwindcss: 4.3.3
-
-    '@tailwindcss/vite@4.3.3(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))':
-        dependencies:
-            '@tailwindcss/node': 4.3.3
-            '@tailwindcss/oxide': 4.3.3
-            tailwindcss: 4.3.3
-            vite: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
-
-    '@testing-library/dom@10.4.1':
-        dependencies:
-            '@babel/code-frame': 7.29.7
-            '@babel/runtime': 7.29.7
-            '@types/aria-query': 5.0.4
-            aria-query: 5.3.0
-            dom-accessibility-api: 0.5.16
-            lz-string: 1.5.0
-            picocolors: 1.1.1
-            pretty-format: 27.5.1
-
-    '@testing-library/jest-dom@6.9.1':
-        dependencies:
-            '@adobe/css-tools': 4.5.0
-            aria-query: 5.3.2
-            css.escape: 1.5.1
-            dom-accessibility-api: 0.6.3
-            picocolors: 1.1.1
-            redent: 3.0.0
-
-    '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
-        dependencies:
-            '@testing-library/dom': 10.4.1
-
-    '@tybys/wasm-util@0.10.3':
-        dependencies:
-            tslib: 2.8.1
-        optional: true
-
-    '@types/aria-query@5.0.4': {}
-
-    '@types/babel__traverse@7.28.0':
-        dependencies:
-            '@babel/types': 7.29.8
-
-    '@types/chai@5.2.3':
-        dependencies:
-            '@types/deep-eql': 4.0.2
-            assertion-error: 2.0.1
-
-    '@types/debug@4.1.13':
-        dependencies:
-            '@types/ms': 2.1.0
-
-    '@types/deep-eql@4.0.2': {}
-
-    '@types/estree-jsx@1.0.5':
-        dependencies:
-            '@types/estree': 1.0.9
-
-    '@types/estree@1.0.9': {}
-
-    '@types/hast@3.0.5':
-        dependencies:
-            '@types/unist': 3.0.3
-
-    '@types/mdast@4.0.4':
-        dependencies:
-            '@types/unist': 3.0.3
-
-    '@types/mdx@2.0.14': {}
-
-    '@types/ms@2.1.0': {}
-
-    '@types/node@12.20.55': {}
-
-    '@types/node@24.13.3':
-        dependencies:
-            undici-types: 7.18.2
-
-    '@types/picomatch@4.0.3': {}
-
-    '@types/react@19.2.18':
-        dependencies:
-            csstype: 3.2.3
-
-    '@types/unist@2.0.11': {}
-
-    '@types/unist@3.0.3': {}
-
-    '@types/whatwg-mimetype@3.0.2': {}
-
-    '@types/ws@8.18.1':
-        dependencies:
-            '@types/node': 24.13.3
-
-    '@typescript/typescript-aix-ppc64@7.0.2':
-        optional: true
-
-    '@typescript/typescript-darwin-arm64@7.0.2':
-        optional: true
-
-    '@typescript/typescript-darwin-x64@7.0.2':
-        optional: true
-
-    '@typescript/typescript-freebsd-arm64@7.0.2':
-        optional: true
-
-    '@typescript/typescript-freebsd-x64@7.0.2':
-        optional: true
-
-    '@typescript/typescript-linux-arm64@7.0.2':
-        optional: true
-
-    '@typescript/typescript-linux-arm@7.0.2':
-        optional: true
-
-    '@typescript/typescript-linux-loong64@7.0.2':
-        optional: true
-
-    '@typescript/typescript-linux-mips64el@7.0.2':
-        optional: true
-
-    '@typescript/typescript-linux-ppc64@7.0.2':
-        optional: true
-
-    '@typescript/typescript-linux-riscv64@7.0.2':
-        optional: true
-
-    '@typescript/typescript-linux-s390x@7.0.2':
-        optional: true
-
-    '@typescript/typescript-linux-x64@7.0.2':
-        optional: true
-
-    '@typescript/typescript-netbsd-arm64@7.0.2':
-        optional: true
-
-    '@typescript/typescript-netbsd-x64@7.0.2':
-        optional: true
-
-    '@typescript/typescript-openbsd-arm64@7.0.2':
-        optional: true
-
-    '@typescript/typescript-openbsd-x64@7.0.2':
-        optional: true
-
-    '@typescript/typescript-sunos-x64@7.0.2':
-        optional: true
-
-    '@typescript/typescript-win32-arm64@7.0.2':
-        optional: true
-
-    '@typescript/typescript-win32-x64@7.0.2':
-        optional: true
-
-    '@ungap/structured-clone@1.3.3': {}
-
-    '@vitest/browser-playwright@4.1.10(playwright@1.62.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)':
-        dependencies:
-            '@vitest/browser': 4.1.10(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)
-            '@vitest/mocker': 4.1.10(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
-            playwright: 1.62.1
-            tinyrainbow: 3.1.1
-            vitest: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
-        transitivePeerDependencies:
-            - bufferutil
-            - msw
-            - utf-8-validate
-            - vite
-
-    '@vitest/browser@4.1.10(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)':
-        dependencies:
-            '@blazediff/core': 1.9.1
-            '@vitest/mocker': 4.1.10(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
-            '@vitest/utils': 4.1.10
-            magic-string: 0.30.21
-            pngjs: 7.0.0
-            sirv: 3.0.2
-            tinyrainbow: 3.1.1
-            vitest: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
-            ws: 8.21.1
-        transitivePeerDependencies:
-            - bufferutil
-            - msw
-            - utf-8-validate
-            - vite
-
-    '@vitest/coverage-istanbul@4.1.10(supports-color@7.2.0)(vitest@4.1.10)':
-        dependencies:
-            '@babel/core': 7.29.7(supports-color@7.2.0)
-            '@istanbuljs/schema': 0.1.6
-            '@jridgewell/gen-mapping': 0.3.13
-            '@jridgewell/trace-mapping': 0.3.31
-            istanbul-lib-coverage: 3.2.2
-            istanbul-lib-report: 3.0.1
-            istanbul-reports: 3.2.0
-            magicast: 0.5.4
-            obug: 2.1.4
-            tinyrainbow: 3.1.1
-            vitest: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
-        transitivePeerDependencies:
-            - supports-color
-
-    '@vitest/coverage-v8@4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)':
-        dependencies:
-            '@bcoe/v8-coverage': 1.0.2
-            '@vitest/utils': 4.1.10
-            ast-v8-to-istanbul: 1.0.5
-            istanbul-lib-coverage: 3.2.2
-            istanbul-lib-report: 3.0.1
-            istanbul-reports: 3.2.0
-            magicast: 0.5.4
-            obug: 2.1.4
-            std-env: 4.2.0
-            tinyrainbow: 3.1.1
-            vitest: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
-        optionalDependencies:
-            '@vitest/browser': 4.1.10(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)
-
-    '@vitest/expect@3.2.4':
-        dependencies:
-            '@types/chai': 5.2.3
-            '@vitest/spy': 3.2.4
-            '@vitest/utils': 3.2.4
-            chai: 5.3.3
-            tinyrainbow: 2.0.0
-
-    '@vitest/expect@4.1.10':
-        dependencies:
-            '@standard-schema/spec': 1.1.0
-            '@types/chai': 5.2.3
-            '@vitest/spy': 4.1.10
-            '@vitest/utils': 4.1.10
-            chai: 6.2.2
-            tinyrainbow: 3.1.1
-
-    '@vitest/mocker@4.1.10(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))':
-        dependencies:
-            '@vitest/spy': 4.1.10
-            estree-walker: 3.0.3
-            magic-string: 0.30.21
-        optionalDependencies:
-            vite: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
-
-    '@vitest/pretty-format@3.2.4':
-        dependencies:
-            tinyrainbow: 2.0.0
-
-    '@vitest/pretty-format@4.1.10':
-        dependencies:
-            tinyrainbow: 3.1.1
-
-    '@vitest/runner@4.1.10':
-        dependencies:
-            '@vitest/utils': 4.1.10
-            pathe: 2.0.3
-
-    '@vitest/snapshot@4.1.10':
-        dependencies:
-            '@vitest/pretty-format': 4.1.10
-            '@vitest/utils': 4.1.10
-            magic-string: 0.30.21
-            pathe: 2.0.3
-
-    '@vitest/spy@3.2.4':
-        dependencies:
-            tinyspy: 4.0.4
-
-    '@vitest/spy@4.1.10': {}
-
-    '@vitest/utils@3.2.4':
-        dependencies:
-            '@vitest/pretty-format': 3.2.4
-            loupe: 3.2.1
-            tinyrainbow: 2.0.0
-
-    '@vitest/utils@4.1.10':
-        dependencies:
-            '@vitest/pretty-format': 4.1.10
-            convert-source-map: 2.0.0
-            tinyrainbow: 3.1.1
-
-    '@webcontainer/env@1.1.1': {}
-
-    '@worker-tools/html-rewriter@0.1.0-pre.19':
-        dependencies:
-            '@stardazed/streams-compression': 1.0.0
-            '@worker-tools/resolvable-promise': 0.2.0-pre.6
-
-    '@worker-tools/resolvable-promise@0.2.0-pre.6': {}
-
-    acorn-jsx@5.3.2(acorn@8.18.0):
-        dependencies:
-            acorn: 8.18.0
-
-    acorn@8.18.0: {}
-
-    ansi-colors@4.1.3: {}
-
-    ansi-regex@5.0.1: {}
-
-    ansi-regex@6.2.2: {}
-
-    ansi-styles@5.2.0: {}
-
-    any-promise@1.3.0: {}
-
-    anymatch@3.1.3:
-        dependencies:
-            normalize-path: 3.0.0
-            picomatch: 2.3.2
-
-    argparse@1.0.10:
-        dependencies:
-            sprintf-js: 1.0.3
-
-    argparse@2.0.1: {}
-
-    aria-query@5.3.0:
-        dependencies:
-            dequal: 2.0.3
-
-    aria-query@5.3.2: {}
-
-    array-union@2.1.0: {}
-
-    assertion-error@2.0.1: {}
-
-    ast-types@0.16.1:
-        dependencies:
-            tslib: 2.8.1
-
-    ast-v8-to-istanbul@1.0.5:
-        dependencies:
-            '@jridgewell/trace-mapping': 0.3.31
-            estree-walker: 3.0.3
-            js-tokens: 10.0.0
-
-    astring@1.9.0: {}
-
-    atomically@2.1.1:
-        dependencies:
-            stubborn-fs: 2.0.0
-            when-exit: 2.1.5
-
-    autoprefixer@10.5.4(postcss@8.5.25):
-        dependencies:
-            browserslist: 4.28.7
-            caniuse-lite: 1.0.30001806
-            fraction.js: 5.3.4
-            picocolors: 1.1.1
-            postcss: 8.5.25
-            postcss-value-parser: 4.2.0
-
-    axe-core@4.12.1: {}
-
-    bail@2.0.2: {}
-
-    baseline-browser-mapping@2.11.10: {}
-
-    better-commits@1.24.0(typescript@7.0.2):
-        dependencies:
-            '@bomb.sh/args': 0.3.1
-            '@clack/core': 1.4.3
-            '@clack/prompts': 1.7.0
-            configstore: 8.0.0
-            jsonc-parser: 3.3.1
-            picocolors: 1.1.1
-            valibot: 1.4.2(typescript@7.0.2)
-        transitivePeerDependencies:
-            - typescript
-
-    better-path-resolve@1.0.0:
-        dependencies:
-            is-windows: 1.0.2
-
-    binary-extensions@2.3.0: {}
-
-    boolbase@1.0.0: {}
-
-    braces@3.0.3:
-        dependencies:
-            fill-range: 7.1.1
-
-    browserslist@4.28.7:
-        dependencies:
-            baseline-browser-mapping: 2.11.10
-            caniuse-lite: 1.0.30001806
-            electron-to-chromium: 1.5.399
-            node-releases: 2.0.51
-            update-browserslist-db: 1.2.3(browserslist@4.28.7)
-
-    buffer-image-size@0.6.4:
-        dependencies:
-            '@types/node': 24.13.3
-
-    bun-types@1.3.14:
-        dependencies:
-            '@types/node': 24.13.3
-
-    bundle-name@4.1.0:
-        dependencies:
-            run-applescript: 7.1.0
-
-    bundle-require@5.1.0(esbuild@0.27.7):
-        dependencies:
-            esbuild: 0.27.7
-            load-tsconfig: 0.2.5
-
-    cac@6.7.14: {}
-
-    caniuse-api@4.0.0:
-        dependencies:
-            browserslist: 4.28.7
-            caniuse-lite: 1.0.30001806
-
-    caniuse-lite@1.0.30001806: {}
-
-    ccount@2.0.1: {}
-
-    chai@5.3.3:
-        dependencies:
-            assertion-error: 2.0.1
-            check-error: 2.1.3
-            deep-eql: 5.0.2
-            loupe: 3.2.1
-            pathval: 2.0.1
-
-    chai@6.2.2: {}
-
-    character-entities-html4@2.1.0: {}
-
-    character-entities-legacy@3.0.0: {}
-
-    character-entities@2.0.2: {}
-
-    character-reference-invalid@2.0.1: {}
-
-    chardet@2.2.0: {}
-
-    check-error@2.1.3: {}
-
-    chokidar@3.6.0:
-        dependencies:
-            anymatch: 3.1.3
-            braces: 3.0.3
-            glob-parent: 5.1.2
-            is-binary-path: 2.1.0
-            is-glob: 4.0.3
-            normalize-path: 3.0.0
-            readdirp: 3.6.0
-        optionalDependencies:
-            fsevents: 2.3.3
-
-    chokidar@4.0.3:
-        dependencies:
-            readdirp: 4.1.2
-
-    chokidar@5.0.0:
-        dependencies:
-            readdirp: 5.0.0
-
-    chromatic@16.10.0:
-        dependencies:
-            semver: 7.8.5
-
-    citty@0.1.6:
-        dependencies:
-            consola: 3.4.2
-
-    citty@0.2.2: {}
-
-    collapse-white-space@2.1.0: {}
-
-    comma-separated-tokens@2.0.3: {}
-
-    commander@11.1.0: {}
-
-    commander@4.1.1: {}
-
-    commander@9.5.0: {}
-
-    confbox@0.1.8: {}
-
-    configstore@8.0.0:
-        dependencies:
-            atomically: 2.1.1
-            dot-prop: 10.2.0
-            graceful-fs: 4.2.11
-            is-safe-filename: 0.1.1
-            xdg-basedir: 5.1.0
-
-    consola@3.4.2: {}
-
-    convert-source-map@2.0.0: {}
-
-    cross-spawn@7.0.6:
-        dependencies:
-            path-key: 3.1.1
-            shebang-command: 2.0.0
-            which: 2.0.2
-
-    crossws@0.4.10(srvx@0.11.22):
-        optionalDependencies:
-            srvx: 0.11.22
-
-    css-select@5.2.2:
-        dependencies:
-            boolbase: 1.0.0
-            css-what: 6.2.2
-            domhandler: 5.0.3
-            domutils: 3.2.2
-            nth-check: 2.1.1
-
-    css-tree@2.2.1:
-        dependencies:
-            mdn-data: 2.0.28
-            source-map-js: 1.2.1
-
-    css-tree@3.2.1:
-        dependencies:
-            mdn-data: 2.27.1
-            source-map-js: 1.2.1
-
-    css-what@6.2.2: {}
-
-    css.escape@1.5.1: {}
-
-    cssesc@3.0.0: {}
-
-    cssnano-preset-default@8.0.2(postcss@8.5.25):
-        dependencies:
-            browserslist: 4.28.7
-            cssnano-utils: 6.0.1(postcss@8.5.25)
-            postcss: 8.5.25
-            postcss-calc: 10.1.1(postcss@8.5.25)
-            postcss-colormin: 8.0.1(postcss@8.5.25)
-            postcss-convert-values: 8.0.1(postcss@8.5.25)
-            postcss-discard-comments: 8.0.1(postcss@8.5.25)
-            postcss-discard-duplicates: 8.0.1(postcss@8.5.25)
-            postcss-discard-empty: 8.0.1(postcss@8.5.25)
-            postcss-discard-overridden: 8.0.1(postcss@8.5.25)
-            postcss-merge-longhand: 8.0.1(postcss@8.5.25)
-            postcss-merge-rules: 8.0.1(postcss@8.5.25)
-            postcss-minify-font-values: 8.0.1(postcss@8.5.25)
-            postcss-minify-gradients: 8.0.1(postcss@8.5.25)
-            postcss-minify-params: 8.0.1(postcss@8.5.25)
-            postcss-minify-selectors: 8.0.2(postcss@8.5.25)
-            postcss-normalize-charset: 8.0.1(postcss@8.5.25)
-            postcss-normalize-display-values: 8.0.1(postcss@8.5.25)
-            postcss-normalize-positions: 8.0.1(postcss@8.5.25)
-            postcss-normalize-repeat-style: 8.0.1(postcss@8.5.25)
-            postcss-normalize-string: 8.0.1(postcss@8.5.25)
-            postcss-normalize-timing-functions: 8.0.1(postcss@8.5.25)
-            postcss-normalize-unicode: 8.0.1(postcss@8.5.25)
-            postcss-normalize-url: 8.0.1(postcss@8.5.25)
-            postcss-normalize-whitespace: 8.0.1(postcss@8.5.25)
-            postcss-ordered-values: 8.0.1(postcss@8.5.25)
-            postcss-reduce-initial: 8.0.1(postcss@8.5.25)
-            postcss-reduce-transforms: 8.0.1(postcss@8.5.25)
-            postcss-svgo: 8.0.1(postcss@8.5.25)
-            postcss-unique-selectors: 8.0.1(postcss@8.5.25)
-
-    cssnano-utils@6.0.1(postcss@8.5.25):
-        dependencies:
-            postcss: 8.5.25
-
-    cssnano@8.0.2(postcss@8.5.25):
-        dependencies:
-            cssnano-preset-default: 8.0.2(postcss@8.5.25)
-            lilconfig: 3.1.3
-            postcss: 8.5.25
-
-    csso@5.0.5:
-        dependencies:
-            css-tree: 2.2.1
-
-    csstype@3.2.3: {}
-
-    dataloader@1.4.0: {}
-
-    db0@0.3.4: {}
-
-    debug@4.4.3(supports-color@7.2.0):
-        dependencies:
-            ms: 2.1.3
-        optionalDependencies:
-            supports-color: 7.2.0
-
-    decode-named-character-reference@1.3.0:
-        dependencies:
-            character-entities: 2.0.2
-
-    deep-eql@5.0.2: {}
-
-    default-browser-id@5.0.1: {}
-
-    default-browser@5.5.0:
-        dependencies:
-            bundle-name: 4.1.0
-            default-browser-id: 5.0.1
-
-    define-lazy-prop@3.0.0: {}
-
-    defu@6.1.7: {}
-
-    dequal@2.0.3: {}
-
-    detect-indent@6.1.0: {}
-
-    detect-libc@2.1.2: {}
-
-    devlop@1.1.0:
-        dependencies:
-            dequal: 2.0.3
-
-    dir-glob@3.0.1:
-        dependencies:
-            path-type: 4.0.0
-
-    dom-accessibility-api@0.5.16: {}
-
-    dom-accessibility-api@0.6.3: {}
-
-    dom-serializer@2.0.0:
-        dependencies:
-            domelementtype: 2.3.0
-            domhandler: 5.0.3
-            entities: 4.5.0
-
-    domelementtype@2.3.0: {}
-
-    domhandler@5.0.3:
-        dependencies:
-            domelementtype: 2.3.0
-
-    domutils@3.2.2:
-        dependencies:
-            dom-serializer: 2.0.0
-            domelementtype: 2.3.0
-            domhandler: 5.0.3
-
-    dot-prop@10.2.0:
-        dependencies:
-            type-fest: 5.8.0
-
-    dotenv@8.6.0: {}
-
-    ecopages@0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(bun-types@1.3.14)(typescript@7.0.2):
-        dependencies:
-            '@ecopages/core': 0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(typescript@7.0.2)
-            '@ecopages/logger': 0.2.3(typescript@7.0.2)
-            bun-types: 1.3.14
-            giget: 2.0.0
-            tsx: 4.23.1
-            typescript: 7.0.2
-        transitivePeerDependencies:
-            - '@ecopages/dev-toolbar'
-            - bufferutil
-            - utf-8-validate
-
-    electron-to-chromium@1.5.399: {}
-
-    enhanced-resolve@5.24.5:
-        dependencies:
-            graceful-fs: 4.2.11
-            tapable: 2.3.3
-
-    enquirer@2.4.1:
-        dependencies:
-            ansi-colors: 4.1.3
-            strip-ansi: 6.0.1
-
-    entities@4.5.0: {}
-
-    entities@6.0.1: {}
-
-    entities@7.0.1: {}
-
-    env-runner@0.1.16:
-        dependencies:
-            crossws: 0.4.10(srvx@0.11.22)
-            exsolve: 1.1.1
-            httpxy: 0.5.5
-            srvx: 0.11.22
-
-    es-errors@1.3.0: {}
-
-    es-module-lexer@2.3.1: {}
-
-    esast-util-from-estree@2.0.0:
-        dependencies:
-            '@types/estree-jsx': 1.0.5
-            devlop: 1.1.0
-            estree-util-visit: 2.0.0
-            unist-util-position-from-estree: 2.0.0
-
-    esast-util-from-js@2.0.1:
-        dependencies:
-            '@types/estree-jsx': 1.0.5
-            acorn: 8.18.0
-            esast-util-from-estree: 2.0.0
-            vfile-message: 4.0.3
-
-    esbuild@0.27.7:
-        optionalDependencies:
-            '@esbuild/aix-ppc64': 0.27.7
-            '@esbuild/android-arm': 0.27.7
-            '@esbuild/android-arm64': 0.27.7
-            '@esbuild/android-x64': 0.27.7
-            '@esbuild/darwin-arm64': 0.27.7
-            '@esbuild/darwin-x64': 0.27.7
-            '@esbuild/freebsd-arm64': 0.27.7
-            '@esbuild/freebsd-x64': 0.27.7
-            '@esbuild/linux-arm': 0.27.7
-            '@esbuild/linux-arm64': 0.27.7
-            '@esbuild/linux-ia32': 0.27.7
-            '@esbuild/linux-loong64': 0.27.7
-            '@esbuild/linux-mips64el': 0.27.7
-            '@esbuild/linux-ppc64': 0.27.7
-            '@esbuild/linux-riscv64': 0.27.7
-            '@esbuild/linux-s390x': 0.27.7
-            '@esbuild/linux-x64': 0.27.7
-            '@esbuild/netbsd-arm64': 0.27.7
-            '@esbuild/netbsd-x64': 0.27.7
-            '@esbuild/openbsd-arm64': 0.27.7
-            '@esbuild/openbsd-x64': 0.27.7
-            '@esbuild/openharmony-arm64': 0.27.7
-            '@esbuild/sunos-x64': 0.27.7
-            '@esbuild/win32-arm64': 0.27.7
-            '@esbuild/win32-ia32': 0.27.7
-            '@esbuild/win32-x64': 0.27.7
-
-    esbuild@0.28.1:
-        optionalDependencies:
-            '@esbuild/aix-ppc64': 0.28.1
-            '@esbuild/android-arm': 0.28.1
-            '@esbuild/android-arm64': 0.28.1
-            '@esbuild/android-x64': 0.28.1
-            '@esbuild/darwin-arm64': 0.28.1
-            '@esbuild/darwin-x64': 0.28.1
-            '@esbuild/freebsd-arm64': 0.28.1
-            '@esbuild/freebsd-x64': 0.28.1
-            '@esbuild/linux-arm': 0.28.1
-            '@esbuild/linux-arm64': 0.28.1
-            '@esbuild/linux-ia32': 0.28.1
-            '@esbuild/linux-loong64': 0.28.1
-            '@esbuild/linux-mips64el': 0.28.1
-            '@esbuild/linux-ppc64': 0.28.1
-            '@esbuild/linux-riscv64': 0.28.1
-            '@esbuild/linux-s390x': 0.28.1
-            '@esbuild/linux-x64': 0.28.1
-            '@esbuild/netbsd-arm64': 0.28.1
-            '@esbuild/netbsd-x64': 0.28.1
-            '@esbuild/openbsd-arm64': 0.28.1
-            '@esbuild/openbsd-x64': 0.28.1
-            '@esbuild/openharmony-arm64': 0.28.1
-            '@esbuild/sunos-x64': 0.28.1
-            '@esbuild/win32-arm64': 0.28.1
-            '@esbuild/win32-ia32': 0.28.1
-            '@esbuild/win32-x64': 0.28.1
-
-    escalade@3.2.0: {}
-
-    escape-string-regexp@5.0.0: {}
-
-    esprima@4.0.1: {}
-
-    estree-util-attach-comments@3.0.0:
-        dependencies:
-            '@types/estree': 1.0.9
-
-    estree-util-build-jsx@3.0.1:
-        dependencies:
-            '@types/estree-jsx': 1.0.5
-            devlop: 1.1.0
-            estree-util-is-identifier-name: 3.0.0
-            estree-walker: 3.0.3
-
-    estree-util-is-identifier-name@3.0.0: {}
-
-    estree-util-scope@1.0.0:
-        dependencies:
-            '@types/estree': 1.0.9
-            devlop: 1.1.0
-
-    estree-util-to-js@2.0.0:
-        dependencies:
-            '@types/estree-jsx': 1.0.5
-            astring: 1.9.0
-            source-map: 0.7.6
-
-    estree-util-visit@2.0.0:
-        dependencies:
-            '@types/estree-jsx': 1.0.5
-            '@types/unist': 3.0.3
-
-    estree-walker@3.0.3:
-        dependencies:
-            '@types/estree': 1.0.9
-
-    expect-type@1.4.0: {}
-
-    exsolve@1.1.1: {}
-
-    extend@3.0.2: {}
-
-    extendable-error@0.1.7: {}
-
-    fast-glob@3.3.3:
-        dependencies:
-            '@nodelib/fs.stat': 2.0.5
-            '@nodelib/fs.walk': 1.2.8
-            glob-parent: 5.1.2
-            merge2: 1.4.1
-            micromatch: 4.0.8
-
-    fast-string-truncated-width@3.0.3: {}
-
-    fast-string-width@3.0.2:
-        dependencies:
-            fast-string-truncated-width: 3.0.3
-
-    fast-wrap-ansi@0.2.2:
-        dependencies:
-            fast-string-width: 3.0.2
-
-    fastq@1.20.1:
-        dependencies:
-            reusify: 1.1.0
-
-    fault@2.0.1:
-        dependencies:
-            format: 0.2.2
-
-    fdir@6.5.0(picomatch@4.0.5):
-        optionalDependencies:
-            picomatch: 4.0.5
-
-    fill-range@7.1.1:
-        dependencies:
-            to-regex-range: 5.0.1
-
-    find-up@4.1.0:
-        dependencies:
-            locate-path: 5.0.0
-            path-exists: 4.0.0
-
-    fix-dts-default-cjs-exports@1.0.1:
-        dependencies:
-            magic-string: 0.30.21
-            mlly: 1.8.2
-            rollup: 4.62.4
-
-    format@0.2.2: {}
-
-    fraction.js@5.3.4: {}
-
-    fs-extra@7.0.1:
-        dependencies:
-            graceful-fs: 4.2.11
-            jsonfile: 4.0.0
-            universalify: 0.1.2
-
-    fs-extra@8.1.0:
-        dependencies:
-            graceful-fs: 4.2.11
-            jsonfile: 4.0.0
-            universalify: 0.1.2
-
-    fsevents@2.3.2:
-        optional: true
-
-    fsevents@2.3.3:
-        optional: true
-
-    function-bind@1.1.2: {}
-
-    gensync@1.0.0-beta.2: {}
-
-    ghtml@4.0.2: {}
-
-    giget@2.0.0:
-        dependencies:
-            citty: 0.1.6
-            consola: 3.4.2
-            defu: 6.1.7
-            node-fetch-native: 1.6.7
-            nypm: 0.6.9
-            pathe: 2.0.3
-
-    glob-parent@5.1.2:
-        dependencies:
-            is-glob: 4.0.3
-
-    globby@11.1.0:
-        dependencies:
-            array-union: 2.1.0
-            dir-glob: 3.0.1
-            fast-glob: 3.3.3
-            ignore: 5.3.2
-            merge2: 1.4.1
-            slash: 3.0.0
-
-    graceful-fs@4.2.11: {}
-
-    h3@2.0.1-rc.26(crossws@0.4.10(srvx@0.11.22)):
-        dependencies:
-            rou3: 0.9.1
-            srvx: 0.12.5
-        optionalDependencies:
-            crossws: 0.4.10(srvx@0.11.22)
-
-    happy-dom@20.11.1:
-        dependencies:
-            '@types/node': 24.13.3
-            '@types/whatwg-mimetype': 3.0.2
-            '@types/ws': 8.18.1
-            buffer-image-size: 0.6.4
-            entities: 7.0.1
-            whatwg-mimetype: 3.0.0
-            ws: 8.21.1
-        transitivePeerDependencies:
-            - bufferutil
-            - utf-8-validate
-
-    has-flag@4.0.0: {}
-
-    hasown@2.0.4:
-        dependencies:
-            function-bind: 1.1.2
-
-    hast-util-from-html@2.0.3:
-        dependencies:
-            '@types/hast': 3.0.5
-            devlop: 1.1.0
-            hast-util-from-parse5: 8.0.3
-            parse5: 7.3.0
-            vfile: 6.0.3
-            vfile-message: 4.0.3
-
-    hast-util-from-parse5@8.0.3:
-        dependencies:
-            '@types/hast': 3.0.5
-            '@types/unist': 3.0.3
-            devlop: 1.1.0
-            hastscript: 9.0.1
-            property-information: 7.2.0
-            vfile: 6.0.3
-            vfile-location: 5.0.3
-            web-namespaces: 2.0.1
-
-    hast-util-parse-selector@4.0.0:
-        dependencies:
-            '@types/hast': 3.0.5
-
-    hast-util-to-estree@3.1.3(supports-color@7.2.0):
-        dependencies:
-            '@types/estree': 1.0.9
-            '@types/estree-jsx': 1.0.5
-            '@types/hast': 3.0.5
-            comma-separated-tokens: 2.0.3
-            devlop: 1.1.0
-            estree-util-attach-comments: 3.0.0
-            estree-util-is-identifier-name: 3.0.0
-            hast-util-whitespace: 3.0.0
-            mdast-util-mdx-expression: 2.0.1(supports-color@7.2.0)
-            mdast-util-mdx-jsx: 3.2.0(supports-color@7.2.0)
-            mdast-util-mdxjs-esm: 2.0.1(supports-color@7.2.0)
-            property-information: 7.2.0
-            space-separated-tokens: 2.0.2
-            style-to-js: 1.1.21
-            unist-util-position: 5.0.0
-            zwitch: 2.0.4
-        transitivePeerDependencies:
-            - supports-color
-
-    hast-util-to-html@9.0.5:
-        dependencies:
-            '@types/hast': 3.0.5
-            '@types/unist': 3.0.3
-            ccount: 2.0.1
-            comma-separated-tokens: 2.0.3
-            hast-util-whitespace: 3.0.0
-            html-void-elements: 3.0.0
-            mdast-util-to-hast: 13.2.1
-            property-information: 7.2.0
-            space-separated-tokens: 2.0.2
-            stringify-entities: 4.0.4
-            zwitch: 2.0.4
-
-    hast-util-to-jsx-runtime@2.3.6(supports-color@7.2.0):
-        dependencies:
-            '@types/estree': 1.0.9
-            '@types/hast': 3.0.5
-            '@types/unist': 3.0.3
-            comma-separated-tokens: 2.0.3
-            devlop: 1.1.0
-            estree-util-is-identifier-name: 3.0.0
-            hast-util-whitespace: 3.0.0
-            mdast-util-mdx-expression: 2.0.1(supports-color@7.2.0)
-            mdast-util-mdx-jsx: 3.2.0(supports-color@7.2.0)
-            mdast-util-mdxjs-esm: 2.0.1(supports-color@7.2.0)
-            property-information: 7.2.0
-            space-separated-tokens: 2.0.2
-            style-to-js: 1.1.21
-            unist-util-position: 5.0.0
-            vfile-message: 4.0.3
-        transitivePeerDependencies:
-            - supports-color
-
-    hast-util-to-string@3.0.1:
-        dependencies:
-            '@types/hast': 3.0.5
-
-    hast-util-whitespace@3.0.0:
-        dependencies:
-            '@types/hast': 3.0.5
-
-    hastscript@9.0.1:
-        dependencies:
-            '@types/hast': 3.0.5
-            comma-separated-tokens: 2.0.3
-            hast-util-parse-selector: 4.0.0
-            property-information: 7.2.0
-            space-separated-tokens: 2.0.2
-
-    hookable@6.1.1: {}
-
-    html-escaper@2.0.2: {}
-
-    html-void-elements@3.0.0: {}
-
-    httpxy@0.5.5: {}
-
-    human-id@4.2.0: {}
-
-    iconv-lite@0.7.3:
-        dependencies:
-            safer-buffer: 2.1.2
-
-    ignore@5.3.2: {}
-
-    indent-string@4.0.0: {}
-
-    inline-style-parser@0.2.7: {}
-
-    is-alphabetical@2.0.1: {}
-
-    is-alphanumerical@2.0.1:
-        dependencies:
-            is-alphabetical: 2.0.1
-            is-decimal: 2.0.1
-
-    is-binary-path@2.1.0:
-        dependencies:
-            binary-extensions: 2.3.0
-
-    is-core-module@2.16.2:
-        dependencies:
-            hasown: 2.0.4
-
-    is-decimal@2.0.1: {}
-
-    is-docker@3.0.0: {}
-
-    is-extglob@2.1.1: {}
-
-    is-glob@4.0.3:
-        dependencies:
-            is-extglob: 2.1.1
-
-    is-hexadecimal@2.0.1: {}
-
-    is-inside-container@1.0.0:
-        dependencies:
-            is-docker: 3.0.0
-
-    is-number@7.0.0: {}
-
-    is-plain-obj@4.1.0: {}
-
-    is-safe-filename@0.1.1: {}
-
-    is-subdir@1.2.0:
-        dependencies:
-            better-path-resolve: 1.0.0
-
-    is-windows@1.0.2: {}
-
-    is-wsl@3.1.1:
-        dependencies:
-            is-inside-container: 1.0.0
-
-    isexe@2.0.0: {}
-
-    istanbul-lib-coverage@3.2.2: {}
-
-    istanbul-lib-report@3.0.1:
-        dependencies:
-            istanbul-lib-coverage: 3.2.2
-            make-dir: 4.0.0
-            supports-color: 7.2.0
-
-    istanbul-reports@3.2.0:
-        dependencies:
-            html-escaper: 2.0.2
-            istanbul-lib-report: 3.0.1
-
-    jiti@2.7.0: {}
-
-    joycon@3.1.1: {}
-
-    js-tokens@10.0.0: {}
-
-    js-tokens@4.0.0: {}
-
-    js-yaml@3.15.1:
-        dependencies:
-            argparse: 1.0.10
-            esprima: 4.0.1
-
-    js-yaml@4.3.1:
-        dependencies:
-            argparse: 2.0.1
-
-    jsesc@3.1.0: {}
-
-    json5@2.2.3: {}
-
-    jsonc-parser@3.3.1: {}
-
-    jsonfile@4.0.0:
-        optionalDependencies:
-            graceful-fs: 4.2.11
-
-    jsonfile@6.2.1:
-        dependencies:
-            universalify: 2.0.1
-        optionalDependencies:
-            graceful-fs: 4.2.11
-
-    lightningcss-android-arm64@1.32.0:
-        optional: true
-
-    lightningcss-android-arm64@1.33.0:
-        optional: true
-
-    lightningcss-darwin-arm64@1.32.0:
-        optional: true
-
-    lightningcss-darwin-arm64@1.33.0:
-        optional: true
-
-    lightningcss-darwin-x64@1.32.0:
-        optional: true
-
-    lightningcss-darwin-x64@1.33.0:
-        optional: true
-
-    lightningcss-freebsd-x64@1.32.0:
-        optional: true
-
-    lightningcss-freebsd-x64@1.33.0:
-        optional: true
-
-    lightningcss-linux-arm-gnueabihf@1.32.0:
-        optional: true
-
-    lightningcss-linux-arm-gnueabihf@1.33.0:
-        optional: true
-
-    lightningcss-linux-arm64-gnu@1.32.0:
-        optional: true
-
-    lightningcss-linux-arm64-gnu@1.33.0:
-        optional: true
-
-    lightningcss-linux-arm64-musl@1.32.0:
-        optional: true
-
-    lightningcss-linux-arm64-musl@1.33.0:
-        optional: true
-
-    lightningcss-linux-x64-gnu@1.32.0:
-        optional: true
-
-    lightningcss-linux-x64-gnu@1.33.0:
-        optional: true
-
-    lightningcss-linux-x64-musl@1.32.0:
-        optional: true
-
-    lightningcss-linux-x64-musl@1.33.0:
-        optional: true
-
-    lightningcss-win32-arm64-msvc@1.32.0:
-        optional: true
-
-    lightningcss-win32-arm64-msvc@1.33.0:
-        optional: true
-
-    lightningcss-win32-x64-msvc@1.32.0:
-        optional: true
-
-    lightningcss-win32-x64-msvc@1.33.0:
-        optional: true
-
-    lightningcss@1.32.0:
-        dependencies:
-            detect-libc: 2.1.2
-        optionalDependencies:
-            lightningcss-android-arm64: 1.32.0
-            lightningcss-darwin-arm64: 1.32.0
-            lightningcss-darwin-x64: 1.32.0
-            lightningcss-freebsd-x64: 1.32.0
-            lightningcss-linux-arm-gnueabihf: 1.32.0
-            lightningcss-linux-arm64-gnu: 1.32.0
-            lightningcss-linux-arm64-musl: 1.32.0
-            lightningcss-linux-x64-gnu: 1.32.0
-            lightningcss-linux-x64-musl: 1.32.0
-            lightningcss-win32-arm64-msvc: 1.32.0
-            lightningcss-win32-x64-msvc: 1.32.0
-
-    lightningcss@1.33.0:
-        dependencies:
-            detect-libc: 2.1.2
-        optionalDependencies:
-            lightningcss-android-arm64: 1.33.0
-            lightningcss-darwin-arm64: 1.33.0
-            lightningcss-darwin-x64: 1.33.0
-            lightningcss-freebsd-x64: 1.33.0
-            lightningcss-linux-arm-gnueabihf: 1.33.0
-            lightningcss-linux-arm64-gnu: 1.33.0
-            lightningcss-linux-arm64-musl: 1.33.0
-            lightningcss-linux-x64-gnu: 1.33.0
-            lightningcss-linux-x64-musl: 1.33.0
-            lightningcss-win32-arm64-msvc: 1.33.0
-            lightningcss-win32-x64-msvc: 1.33.0
-
-    lilconfig@3.1.3: {}
-
-    lines-and-columns@1.2.4: {}
-
-    load-tsconfig@0.2.5: {}
-
-    locate-path@5.0.0:
-        dependencies:
-            p-locate: 4.1.0
-
-    lodash.startcase@4.4.0: {}
-
-    longest-streak@3.1.0: {}
-
-    loupe@3.2.1: {}
-
-    lru-cache@5.1.1:
-        dependencies:
-            yallist: 3.1.1
-
-    lz-string@1.5.0: {}
-
-    magic-string@0.30.21:
-        dependencies:
-            '@jridgewell/sourcemap-codec': 1.5.5
-
-    magicast@0.5.4:
-        dependencies:
-            '@babel/parser': 7.29.8
-            '@babel/types': 7.29.8
-            source-map-js: 1.2.1
-
-    make-dir@4.0.0:
-        dependencies:
-            semver: 7.8.5
-
-    markdown-extensions@2.0.0: {}
-
-    markdown-table@3.0.4: {}
-
-    mdast-util-find-and-replace@3.0.2:
-        dependencies:
-            '@types/mdast': 4.0.4
-            escape-string-regexp: 5.0.0
-            unist-util-is: 6.0.1
-            unist-util-visit-parents: 6.0.2
-
-    mdast-util-from-markdown@2.0.3(supports-color@7.2.0):
-        dependencies:
-            '@types/mdast': 4.0.4
-            '@types/unist': 3.0.3
-            decode-named-character-reference: 1.3.0
-            devlop: 1.1.0
-            mdast-util-to-string: 4.0.0
-            micromark: 4.0.2(supports-color@7.2.0)
-            micromark-util-decode-numeric-character-reference: 2.0.2
-            micromark-util-decode-string: 2.0.1
-            micromark-util-normalize-identifier: 2.0.1
-            micromark-util-symbol: 2.0.1
-            micromark-util-types: 2.0.2
-            unist-util-stringify-position: 4.0.0
-        transitivePeerDependencies:
-            - supports-color
-
-    mdast-util-frontmatter@2.0.1(supports-color@7.2.0):
-        dependencies:
-            '@types/mdast': 4.0.4
-            devlop: 1.1.0
-            escape-string-regexp: 5.0.0
-            mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
-            mdast-util-to-markdown: 2.1.2
-            micromark-extension-frontmatter: 2.0.0
-        transitivePeerDependencies:
-            - supports-color
-
-    mdast-util-gfm-autolink-literal@2.0.1:
-        dependencies:
-            '@types/mdast': 4.0.4
-            ccount: 2.0.1
-            devlop: 1.1.0
-            mdast-util-find-and-replace: 3.0.2
-            micromark-util-character: 2.1.1
-
-    mdast-util-gfm-footnote@2.1.0(supports-color@7.2.0):
-        dependencies:
-            '@types/mdast': 4.0.4
-            devlop: 1.1.0
-            mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
-            mdast-util-to-markdown: 2.1.2
-            micromark-util-normalize-identifier: 2.0.1
-        transitivePeerDependencies:
-            - supports-color
-
-    mdast-util-gfm-strikethrough@2.0.0(supports-color@7.2.0):
-        dependencies:
-            '@types/mdast': 4.0.4
-            mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
-            mdast-util-to-markdown: 2.1.2
-        transitivePeerDependencies:
-            - supports-color
-
-    mdast-util-gfm-table@2.0.0(supports-color@7.2.0):
-        dependencies:
-            '@types/mdast': 4.0.4
-            devlop: 1.1.0
-            markdown-table: 3.0.4
-            mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
-            mdast-util-to-markdown: 2.1.2
-        transitivePeerDependencies:
-            - supports-color
-
-    mdast-util-gfm-task-list-item@2.0.0(supports-color@7.2.0):
-        dependencies:
-            '@types/mdast': 4.0.4
-            devlop: 1.1.0
-            mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
-            mdast-util-to-markdown: 2.1.2
-        transitivePeerDependencies:
-            - supports-color
-
-    mdast-util-gfm@3.1.0(supports-color@7.2.0):
-        dependencies:
-            mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
-            mdast-util-gfm-autolink-literal: 2.0.1
-            mdast-util-gfm-footnote: 2.1.0(supports-color@7.2.0)
-            mdast-util-gfm-strikethrough: 2.0.0(supports-color@7.2.0)
-            mdast-util-gfm-table: 2.0.0(supports-color@7.2.0)
-            mdast-util-gfm-task-list-item: 2.0.0(supports-color@7.2.0)
-            mdast-util-to-markdown: 2.1.2
-        transitivePeerDependencies:
-            - supports-color
-
-    mdast-util-mdx-expression@2.0.1(supports-color@7.2.0):
-        dependencies:
-            '@types/estree-jsx': 1.0.5
-            '@types/hast': 3.0.5
-            '@types/mdast': 4.0.4
-            devlop: 1.1.0
-            mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
-            mdast-util-to-markdown: 2.1.2
-        transitivePeerDependencies:
-            - supports-color
-
-    mdast-util-mdx-jsx@3.2.0(supports-color@7.2.0):
-        dependencies:
-            '@types/estree-jsx': 1.0.5
-            '@types/hast': 3.0.5
-            '@types/mdast': 4.0.4
-            '@types/unist': 3.0.3
-            ccount: 2.0.1
-            devlop: 1.1.0
-            mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
-            mdast-util-to-markdown: 2.1.2
-            parse-entities: 4.0.2
-            stringify-entities: 4.0.4
-            unist-util-stringify-position: 4.0.0
-            vfile-message: 4.0.3
-        transitivePeerDependencies:
-            - supports-color
-
-    mdast-util-mdx@3.0.0(supports-color@7.2.0):
-        dependencies:
-            mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
-            mdast-util-mdx-expression: 2.0.1(supports-color@7.2.0)
-            mdast-util-mdx-jsx: 3.2.0(supports-color@7.2.0)
-            mdast-util-mdxjs-esm: 2.0.1(supports-color@7.2.0)
-            mdast-util-to-markdown: 2.1.2
-        transitivePeerDependencies:
-            - supports-color
-
-    mdast-util-mdxjs-esm@2.0.1(supports-color@7.2.0):
-        dependencies:
-            '@types/estree-jsx': 1.0.5
-            '@types/hast': 3.0.5
-            '@types/mdast': 4.0.4
-            devlop: 1.1.0
-            mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
-            mdast-util-to-markdown: 2.1.2
-        transitivePeerDependencies:
-            - supports-color
-
-    mdast-util-phrasing@4.1.0:
-        dependencies:
-            '@types/mdast': 4.0.4
-            unist-util-is: 6.0.1
-
-    mdast-util-to-hast@13.2.1:
-        dependencies:
-            '@types/hast': 3.0.5
-            '@types/mdast': 4.0.4
-            '@ungap/structured-clone': 1.3.3
-            devlop: 1.1.0
-            micromark-util-sanitize-uri: 2.0.1
-            trim-lines: 3.0.1
-            unist-util-position: 5.0.0
-            unist-util-visit: 5.1.0
-            vfile: 6.0.3
-
-    mdast-util-to-markdown@2.1.2:
-        dependencies:
-            '@types/mdast': 4.0.4
-            '@types/unist': 3.0.3
-            longest-streak: 3.1.0
-            mdast-util-phrasing: 4.1.0
-            mdast-util-to-string: 4.0.0
-            micromark-util-classify-character: 2.0.1
-            micromark-util-decode-string: 2.0.1
-            unist-util-visit: 5.1.0
-            zwitch: 2.0.4
-
-    mdast-util-to-string@4.0.0:
-        dependencies:
-            '@types/mdast': 4.0.4
-
-    mdn-data@2.0.28: {}
-
-    mdn-data@2.27.1: {}
-
-    merge2@1.4.1: {}
-
-    micromark-core-commonmark@2.0.3:
-        dependencies:
-            decode-named-character-reference: 1.3.0
-            devlop: 1.1.0
-            micromark-factory-destination: 2.0.1
-            micromark-factory-label: 2.0.1
-            micromark-factory-space: 2.0.1
-            micromark-factory-title: 2.0.1
-            micromark-factory-whitespace: 2.0.1
-            micromark-util-character: 2.1.1
-            micromark-util-chunked: 2.0.1
-            micromark-util-classify-character: 2.0.1
-            micromark-util-html-tag-name: 2.0.1
-            micromark-util-normalize-identifier: 2.0.1
-            micromark-util-resolve-all: 2.0.1
-            micromark-util-subtokenize: 2.1.0
-            micromark-util-symbol: 2.0.1
-            micromark-util-types: 2.0.2
-
-    micromark-extension-frontmatter@2.0.0:
-        dependencies:
-            fault: 2.0.1
-            micromark-util-character: 2.1.1
-            micromark-util-symbol: 2.0.1
-            micromark-util-types: 2.0.2
-
-    micromark-extension-gfm-autolink-literal@2.1.0:
-        dependencies:
-            micromark-util-character: 2.1.1
-            micromark-util-sanitize-uri: 2.0.1
-            micromark-util-symbol: 2.0.1
-            micromark-util-types: 2.0.2
-
-    micromark-extension-gfm-footnote@2.1.0:
-        dependencies:
-            devlop: 1.1.0
-            micromark-core-commonmark: 2.0.3
-            micromark-factory-space: 2.0.1
-            micromark-util-character: 2.1.1
-            micromark-util-normalize-identifier: 2.0.1
-            micromark-util-sanitize-uri: 2.0.1
-            micromark-util-symbol: 2.0.1
-            micromark-util-types: 2.0.2
-
-    micromark-extension-gfm-strikethrough@2.1.0:
-        dependencies:
-            devlop: 1.1.0
-            micromark-util-chunked: 2.0.1
-            micromark-util-classify-character: 2.0.1
-            micromark-util-resolve-all: 2.0.1
-            micromark-util-symbol: 2.0.1
-            micromark-util-types: 2.0.2
-
-    micromark-extension-gfm-table@2.1.1:
-        dependencies:
-            devlop: 1.1.0
-            micromark-factory-space: 2.0.1
-            micromark-util-character: 2.1.1
-            micromark-util-symbol: 2.0.1
-            micromark-util-types: 2.0.2
-
-    micromark-extension-gfm-tagfilter@2.0.0:
-        dependencies:
-            micromark-util-types: 2.0.2
-
-    micromark-extension-gfm-task-list-item@2.1.0:
-        dependencies:
-            devlop: 1.1.0
-            micromark-factory-space: 2.0.1
-            micromark-util-character: 2.1.1
-            micromark-util-symbol: 2.0.1
-            micromark-util-types: 2.0.2
-
-    micromark-extension-gfm@3.0.0:
-        dependencies:
-            micromark-extension-gfm-autolink-literal: 2.1.0
-            micromark-extension-gfm-footnote: 2.1.0
-            micromark-extension-gfm-strikethrough: 2.1.0
-            micromark-extension-gfm-table: 2.1.1
-            micromark-extension-gfm-tagfilter: 2.0.0
-            micromark-extension-gfm-task-list-item: 2.1.0
-            micromark-util-combine-extensions: 2.0.1
-            micromark-util-types: 2.0.2
-
-    micromark-extension-mdx-expression@3.0.1:
-        dependencies:
-            '@types/estree': 1.0.9
-            devlop: 1.1.0
-            micromark-factory-mdx-expression: 2.0.3
-            micromark-factory-space: 2.0.1
-            micromark-util-character: 2.1.1
-            micromark-util-events-to-acorn: 2.0.3
-            micromark-util-symbol: 2.0.1
-            micromark-util-types: 2.0.2
-
-    micromark-extension-mdx-jsx@3.0.2:
-        dependencies:
-            '@types/estree': 1.0.9
-            devlop: 1.1.0
-            estree-util-is-identifier-name: 3.0.0
-            micromark-factory-mdx-expression: 2.0.3
-            micromark-factory-space: 2.0.1
-            micromark-util-character: 2.1.1
-            micromark-util-events-to-acorn: 2.0.3
-            micromark-util-symbol: 2.0.1
-            micromark-util-types: 2.0.2
-            vfile-message: 4.0.3
-
-    micromark-extension-mdx-md@2.0.0:
-        dependencies:
-            micromark-util-types: 2.0.2
-
-    micromark-extension-mdxjs-esm@3.0.0:
-        dependencies:
-            '@types/estree': 1.0.9
-            devlop: 1.1.0
-            micromark-core-commonmark: 2.0.3
-            micromark-util-character: 2.1.1
-            micromark-util-events-to-acorn: 2.0.3
-            micromark-util-symbol: 2.0.1
-            micromark-util-types: 2.0.2
-            unist-util-position-from-estree: 2.0.0
-            vfile-message: 4.0.3
-
-    micromark-extension-mdxjs@3.0.0:
-        dependencies:
-            acorn: 8.18.0
-            acorn-jsx: 5.3.2(acorn@8.18.0)
-            micromark-extension-mdx-expression: 3.0.1
-            micromark-extension-mdx-jsx: 3.0.2
-            micromark-extension-mdx-md: 2.0.0
-            micromark-extension-mdxjs-esm: 3.0.0
-            micromark-util-combine-extensions: 2.0.1
-            micromark-util-types: 2.0.2
-
-    micromark-factory-destination@2.0.1:
-        dependencies:
-            micromark-util-character: 2.1.1
-            micromark-util-symbol: 2.0.1
-            micromark-util-types: 2.0.2
-
-    micromark-factory-label@2.0.1:
-        dependencies:
-            devlop: 1.1.0
-            micromark-util-character: 2.1.1
-            micromark-util-symbol: 2.0.1
-            micromark-util-types: 2.0.2
-
-    micromark-factory-mdx-expression@2.0.3:
-        dependencies:
-            '@types/estree': 1.0.9
-            devlop: 1.1.0
-            micromark-factory-space: 2.0.1
-            micromark-util-character: 2.1.1
-            micromark-util-events-to-acorn: 2.0.3
-            micromark-util-symbol: 2.0.1
-            micromark-util-types: 2.0.2
-            unist-util-position-from-estree: 2.0.0
-            vfile-message: 4.0.3
-
-    micromark-factory-space@2.0.1:
-        dependencies:
-            micromark-util-character: 2.1.1
-            micromark-util-types: 2.0.2
-
-    micromark-factory-title@2.0.1:
-        dependencies:
-            micromark-factory-space: 2.0.1
-            micromark-util-character: 2.1.1
-            micromark-util-symbol: 2.0.1
-            micromark-util-types: 2.0.2
-
-    micromark-factory-whitespace@2.0.1:
-        dependencies:
-            micromark-factory-space: 2.0.1
-            micromark-util-character: 2.1.1
-            micromark-util-symbol: 2.0.1
-            micromark-util-types: 2.0.2
-
-    micromark-util-character@2.1.1:
-        dependencies:
-            micromark-util-symbol: 2.0.1
-            micromark-util-types: 2.0.2
-
-    micromark-util-chunked@2.0.1:
-        dependencies:
-            micromark-util-symbol: 2.0.1
-
-    micromark-util-classify-character@2.0.1:
-        dependencies:
-            micromark-util-character: 2.1.1
-            micromark-util-symbol: 2.0.1
-            micromark-util-types: 2.0.2
-
-    micromark-util-combine-extensions@2.0.1:
-        dependencies:
-            micromark-util-chunked: 2.0.1
-            micromark-util-types: 2.0.2
-
-    micromark-util-decode-numeric-character-reference@2.0.2:
-        dependencies:
-            micromark-util-symbol: 2.0.1
-
-    micromark-util-decode-string@2.0.1:
-        dependencies:
-            decode-named-character-reference: 1.3.0
-            micromark-util-character: 2.1.1
-            micromark-util-decode-numeric-character-reference: 2.0.2
-            micromark-util-symbol: 2.0.1
-
-    micromark-util-encode@2.0.1: {}
-
-    micromark-util-events-to-acorn@2.0.3:
-        dependencies:
-            '@types/estree': 1.0.9
-            '@types/unist': 3.0.3
-            devlop: 1.1.0
-            estree-util-visit: 2.0.0
-            micromark-util-symbol: 2.0.1
-            micromark-util-types: 2.0.2
-            vfile-message: 4.0.3
-
-    micromark-util-html-tag-name@2.0.1: {}
-
-    micromark-util-normalize-identifier@2.0.1:
-        dependencies:
-            micromark-util-symbol: 2.0.1
-
-    micromark-util-resolve-all@2.0.1:
-        dependencies:
-            micromark-util-types: 2.0.2
-
-    micromark-util-sanitize-uri@2.0.1:
-        dependencies:
-            micromark-util-character: 2.1.1
-            micromark-util-encode: 2.0.1
-            micromark-util-symbol: 2.0.1
-
-    micromark-util-subtokenize@2.1.0:
-        dependencies:
-            devlop: 1.1.0
-            micromark-util-chunked: 2.0.1
-            micromark-util-symbol: 2.0.1
-            micromark-util-types: 2.0.2
-
-    micromark-util-symbol@2.0.1: {}
-
-    micromark-util-types@2.0.2: {}
-
-    micromark@4.0.2(supports-color@7.2.0):
-        dependencies:
-            '@types/debug': 4.1.13
-            debug: 4.4.3(supports-color@7.2.0)
-            decode-named-character-reference: 1.3.0
-            devlop: 1.1.0
-            micromark-core-commonmark: 2.0.3
-            micromark-factory-space: 2.0.1
-            micromark-util-character: 2.1.1
-            micromark-util-chunked: 2.0.1
-            micromark-util-combine-extensions: 2.0.1
-            micromark-util-decode-numeric-character-reference: 2.0.2
-            micromark-util-encode: 2.0.1
-            micromark-util-normalize-identifier: 2.0.1
-            micromark-util-resolve-all: 2.0.1
-            micromark-util-sanitize-uri: 2.0.1
-            micromark-util-subtokenize: 2.1.0
-            micromark-util-symbol: 2.0.1
-            micromark-util-types: 2.0.2
-        transitivePeerDependencies:
-            - supports-color
-
-    micromatch@4.0.8:
-        dependencies:
-            braces: 3.0.3
-            picomatch: 2.3.2
-
-    min-indent@1.0.1: {}
-
-    mitata@1.0.34: {}
-
-    mlly@1.8.2:
-        dependencies:
-            acorn: 8.18.0
-            pathe: 2.0.3
-            pkg-types: 1.3.1
-            ufo: 1.6.4
-
-    morphdom@2.7.8: {}
-
-    mri@1.2.0: {}
-
-    mrmime@2.0.1: {}
-
-    ms@2.1.3: {}
-
-    mylas@2.1.14: {}
-
-    mz@2.7.0:
-        dependencies:
-            any-promise: 1.3.0
-            object-assign: 4.1.1
-            thenify-all: 1.6.0
-
-    nanoid@3.3.16: {}
-
-    nf3@0.3.23: {}
-
-    nitro@3.0.260311-beta(chokidar@5.0.0)(dotenv@8.6.0)(giget@2.0.0)(jiti@2.7.0)(rollup@4.62.4)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)):
-        dependencies:
-            consola: 3.4.2
-            crossws: 0.4.10(srvx@0.11.22)
-            db0: 0.3.4
-            env-runner: 0.1.16
-            h3: 2.0.1-rc.26(crossws@0.4.10(srvx@0.11.22))
-            hookable: 6.1.1
-            nf3: 0.3.23
-            ocache: 0.1.5
-            ofetch: 2.0.0-alpha.3
-            ohash: 2.0.11
-            rolldown: 1.2.1
-            srvx: 0.11.22
-            unenv: 2.0.0-rc.24
-            unstorage: 2.0.0-alpha.7(chokidar@5.0.0)(db0@0.3.4)(ofetch@2.0.0-alpha.3)
-        optionalDependencies:
-            dotenv: 8.6.0
-            giget: 2.0.0
-            jiti: 2.7.0
-            rollup: 4.62.4
-            vite: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
-        transitivePeerDependencies:
-            - '@azure/app-configuration'
-            - '@azure/cosmos'
-            - '@azure/data-tables'
-            - '@azure/identity'
-            - '@azure/keyvault-secrets'
-            - '@azure/storage-blob'
-            - '@capacitor/preferences'
-            - '@deno/kv'
-            - '@electric-sql/pglite'
-            - '@libsql/client'
-            - '@netlify/blobs'
-            - '@netlify/runtime'
-            - '@planetscale/database'
-            - '@upstash/redis'
-            - '@vercel/blob'
-            - '@vercel/functions'
-            - '@vercel/kv'
-            - '@vercel/queue'
-            - aws4fetch
-            - better-sqlite3
-            - chokidar
-            - drizzle-orm
-            - idb-keyval
-            - ioredis
-            - lru-cache
-            - miniflare
-            - mongodb
-            - mysql2
-            - sqlite3
-            - uploadthing
-            - wrangler
-
-    node-fetch-native@1.6.7: {}
-
-    node-fetch@2.7.0:
-        dependencies:
-            whatwg-url: 5.0.0
-
-    node-releases@2.0.51: {}
-
-    normalize-path@3.0.0: {}
-
-    nth-check@2.1.1:
-        dependencies:
-            boolbase: 1.0.0
-
-    nypm@0.6.9:
-        dependencies:
-            citty: 0.2.2
-            pathe: 2.0.3
-            tinyexec: 1.3.0
-
-    object-assign@4.1.1: {}
-
-    obug@2.1.4: {}
-
-    ocache@0.1.5:
-        dependencies:
-            ohash: 2.0.11
-
-    ofetch@2.0.0-alpha.3: {}
-
-    ohash@2.0.11: {}
-
-    oniguruma-parser@0.12.2: {}
-
-    oniguruma-to-es@4.3.6:
-        dependencies:
-            oniguruma-parser: 0.12.2
-            regex: 6.1.0
-            regex-recursion: 6.0.2
-
-    open@10.2.0:
-        dependencies:
-            default-browser: 5.5.0
-            define-lazy-prop: 3.0.0
-            is-inside-container: 1.0.0
-            wsl-utils: 0.1.0
-
-    outdent@0.5.0: {}
-
-    oxc-parser@0.127.0:
-        dependencies:
-            '@oxc-project/types': 0.127.0
-        optionalDependencies:
-            '@oxc-parser/binding-android-arm-eabi': 0.127.0
-            '@oxc-parser/binding-android-arm64': 0.127.0
-            '@oxc-parser/binding-darwin-arm64': 0.127.0
-            '@oxc-parser/binding-darwin-x64': 0.127.0
-            '@oxc-parser/binding-freebsd-x64': 0.127.0
-            '@oxc-parser/binding-linux-arm-gnueabihf': 0.127.0
-            '@oxc-parser/binding-linux-arm-musleabihf': 0.127.0
-            '@oxc-parser/binding-linux-arm64-gnu': 0.127.0
-            '@oxc-parser/binding-linux-arm64-musl': 0.127.0
-            '@oxc-parser/binding-linux-ppc64-gnu': 0.127.0
-            '@oxc-parser/binding-linux-riscv64-gnu': 0.127.0
-            '@oxc-parser/binding-linux-riscv64-musl': 0.127.0
-            '@oxc-parser/binding-linux-s390x-gnu': 0.127.0
-            '@oxc-parser/binding-linux-x64-gnu': 0.127.0
-            '@oxc-parser/binding-linux-x64-musl': 0.127.0
-            '@oxc-parser/binding-openharmony-arm64': 0.127.0
-            '@oxc-parser/binding-wasm32-wasi': 0.127.0
-            '@oxc-parser/binding-win32-arm64-msvc': 0.127.0
-            '@oxc-parser/binding-win32-ia32-msvc': 0.127.0
-            '@oxc-parser/binding-win32-x64-msvc': 0.127.0
-
-    oxc-parser@0.141.0:
-        dependencies:
-            '@oxc-project/types': 0.141.0
-        optionalDependencies:
-            '@oxc-parser/binding-android-arm-eabi': 0.141.0
-            '@oxc-parser/binding-android-arm64': 0.141.0
-            '@oxc-parser/binding-darwin-arm64': 0.141.0
-            '@oxc-parser/binding-darwin-x64': 0.141.0
-            '@oxc-parser/binding-freebsd-x64': 0.141.0
-            '@oxc-parser/binding-linux-arm-gnueabihf': 0.141.0
-            '@oxc-parser/binding-linux-arm-musleabihf': 0.141.0
-            '@oxc-parser/binding-linux-arm64-gnu': 0.141.0
-            '@oxc-parser/binding-linux-arm64-musl': 0.141.0
-            '@oxc-parser/binding-linux-ppc64-gnu': 0.141.0
-            '@oxc-parser/binding-linux-riscv64-gnu': 0.141.0
-            '@oxc-parser/binding-linux-riscv64-musl': 0.141.0
-            '@oxc-parser/binding-linux-s390x-gnu': 0.141.0
-            '@oxc-parser/binding-linux-x64-gnu': 0.141.0
-            '@oxc-parser/binding-linux-x64-musl': 0.141.0
-            '@oxc-parser/binding-openharmony-arm64': 0.141.0
-            '@oxc-parser/binding-wasm32-wasi': 0.141.0
-            '@oxc-parser/binding-win32-arm64-msvc': 0.141.0
-            '@oxc-parser/binding-win32-ia32-msvc': 0.141.0
-            '@oxc-parser/binding-win32-x64-msvc': 0.141.0
-
-    oxc-resolver@11.24.2:
-        optionalDependencies:
-            '@oxc-resolver/binding-android-arm-eabi': 11.24.2
-            '@oxc-resolver/binding-android-arm64': 11.24.2
-            '@oxc-resolver/binding-darwin-arm64': 11.24.2
-            '@oxc-resolver/binding-darwin-x64': 11.24.2
-            '@oxc-resolver/binding-freebsd-x64': 11.24.2
-            '@oxc-resolver/binding-linux-arm-gnueabihf': 11.24.2
-            '@oxc-resolver/binding-linux-arm-musleabihf': 11.24.2
-            '@oxc-resolver/binding-linux-arm64-gnu': 11.24.2
-            '@oxc-resolver/binding-linux-arm64-musl': 11.24.2
-            '@oxc-resolver/binding-linux-ppc64-gnu': 11.24.2
-            '@oxc-resolver/binding-linux-riscv64-gnu': 11.24.2
-            '@oxc-resolver/binding-linux-riscv64-musl': 11.24.2
-            '@oxc-resolver/binding-linux-s390x-gnu': 11.24.2
-            '@oxc-resolver/binding-linux-x64-gnu': 11.24.2
-            '@oxc-resolver/binding-linux-x64-musl': 11.24.2
-            '@oxc-resolver/binding-openharmony-arm64': 11.24.2
-            '@oxc-resolver/binding-wasm32-wasi': 11.24.2
-            '@oxc-resolver/binding-win32-arm64-msvc': 11.24.2
-            '@oxc-resolver/binding-win32-x64-msvc': 11.24.2
-
-    oxlint@1.76.0:
-        optionalDependencies:
-            '@oxlint/binding-android-arm-eabi': 1.76.0
-            '@oxlint/binding-android-arm64': 1.76.0
-            '@oxlint/binding-darwin-arm64': 1.76.0
-            '@oxlint/binding-darwin-x64': 1.76.0
-            '@oxlint/binding-freebsd-x64': 1.76.0
-            '@oxlint/binding-linux-arm-gnueabihf': 1.76.0
-            '@oxlint/binding-linux-arm-musleabihf': 1.76.0
-            '@oxlint/binding-linux-arm64-gnu': 1.76.0
-            '@oxlint/binding-linux-arm64-musl': 1.76.0
-            '@oxlint/binding-linux-ppc64-gnu': 1.76.0
-            '@oxlint/binding-linux-riscv64-gnu': 1.76.0
-            '@oxlint/binding-linux-riscv64-musl': 1.76.0
-            '@oxlint/binding-linux-s390x-gnu': 1.76.0
-            '@oxlint/binding-linux-x64-gnu': 1.76.0
-            '@oxlint/binding-linux-x64-musl': 1.76.0
-            '@oxlint/binding-openharmony-arm64': 1.76.0
-            '@oxlint/binding-win32-arm64-msvc': 1.76.0
-            '@oxlint/binding-win32-ia32-msvc': 1.76.0
-            '@oxlint/binding-win32-x64-msvc': 1.76.0
-
-    p-filter@2.1.0:
-        dependencies:
-            p-map: 2.1.0
-
-    p-limit@2.3.0:
-        dependencies:
-            p-try: 2.2.0
-
-    p-locate@4.1.0:
-        dependencies:
-            p-limit: 2.3.0
-
-    p-map@2.1.0: {}
-
-    p-try@2.2.0: {}
-
-    package-manager-detector@0.2.11:
-        dependencies:
-            quansync: 0.2.11
-
-    parse-entities@4.0.2:
-        dependencies:
-            '@types/unist': 2.0.11
-            character-entities-legacy: 3.0.0
-            character-reference-invalid: 2.0.1
-            decode-named-character-reference: 1.3.0
-            is-alphanumerical: 2.0.1
-            is-decimal: 2.0.1
-            is-hexadecimal: 2.0.1
-
-    parse-numeric-range@1.3.0: {}
-
-    parse5@7.3.0:
-        dependencies:
-            entities: 6.0.1
-
-    path-exists@4.0.0: {}
-
-    path-key@3.1.1: {}
-
-    path-parse@1.0.7: {}
-
-    path-type@4.0.0: {}
-
-    pathe@2.0.3: {}
-
-    pathval@2.0.1: {}
-
-    picocolors@1.1.1: {}
-
-    picomatch@2.3.2: {}
-
-    picomatch@4.0.5: {}
-
-    pify@2.3.0: {}
-
-    pify@4.0.1: {}
-
-    pirates@4.0.7: {}
-
-    pkg-types@1.3.1:
-        dependencies:
-            confbox: 0.1.8
-            mlly: 1.8.2
-            pathe: 2.0.3
-
-    playwright-core@1.62.1: {}
-
-    playwright@1.62.1:
-        dependencies:
-            playwright-core: 1.62.1
-        optionalDependencies:
-            fsevents: 2.3.2
-
-    plimit-lit@1.6.1:
-        dependencies:
-            queue-lit: 1.5.2
-
-    pngjs@7.0.0: {}
-
-    postcss-calc@10.1.1(postcss@8.5.25):
-        dependencies:
-            postcss: 8.5.25
-            postcss-selector-parser: 7.1.4
-            postcss-value-parser: 4.2.0
-
-    postcss-colormin@8.0.1(postcss@8.5.25):
-        dependencies:
-            '@colordx/core': 5.5.0
-            browserslist: 4.28.7
-            caniuse-api: 4.0.0
-            postcss: 8.5.25
-            postcss-value-parser: 4.2.0
-
-    postcss-convert-values@8.0.1(postcss@8.5.25):
-        dependencies:
-            browserslist: 4.28.7
-            postcss: 8.5.25
-            postcss-value-parser: 4.2.0
-
-    postcss-discard-comments@8.0.1(postcss@8.5.25):
-        dependencies:
-            postcss: 8.5.25
-            postcss-selector-parser: 7.1.4
-
-    postcss-discard-duplicates@8.0.1(postcss@8.5.25):
-        dependencies:
-            postcss: 8.5.25
-
-    postcss-discard-empty@8.0.1(postcss@8.5.25):
-        dependencies:
-            postcss: 8.5.25
-
-    postcss-discard-overridden@8.0.1(postcss@8.5.25):
-        dependencies:
-            postcss: 8.5.25
-
-    postcss-import@16.1.1(postcss@8.5.25):
-        dependencies:
-            postcss: 8.5.25
-            postcss-value-parser: 4.2.0
-            read-cache: 1.0.0
-            resolve: 1.22.12
-
-    postcss-load-config@6.0.1(jiti@2.7.0)(postcss@8.5.25)(tsx@4.23.1)(yaml@2.9.0):
-        dependencies:
-            lilconfig: 3.1.3
-        optionalDependencies:
-            jiti: 2.7.0
-            postcss: 8.5.25
-            tsx: 4.23.1
-            yaml: 2.9.0
-
-    postcss-merge-longhand@8.0.1(postcss@8.5.25):
-        dependencies:
-            postcss: 8.5.25
-            postcss-value-parser: 4.2.0
-            stylehacks: 8.0.1(postcss@8.5.25)
-
-    postcss-merge-rules@8.0.1(postcss@8.5.25):
-        dependencies:
-            browserslist: 4.28.7
-            caniuse-api: 4.0.0
-            cssnano-utils: 6.0.1(postcss@8.5.25)
-            postcss: 8.5.25
-            postcss-selector-parser: 7.1.4
-
-    postcss-minify-font-values@8.0.1(postcss@8.5.25):
-        dependencies:
-            postcss: 8.5.25
-            postcss-value-parser: 4.2.0
-
-    postcss-minify-gradients@8.0.1(postcss@8.5.25):
-        dependencies:
-            '@colordx/core': 5.5.0
-            cssnano-utils: 6.0.1(postcss@8.5.25)
-            postcss: 8.5.25
-            postcss-value-parser: 4.2.0
-
-    postcss-minify-params@8.0.1(postcss@8.5.25):
-        dependencies:
-            browserslist: 4.28.7
-            cssnano-utils: 6.0.1(postcss@8.5.25)
-            postcss: 8.5.25
-            postcss-value-parser: 4.2.0
-
-    postcss-minify-selectors@8.0.2(postcss@8.5.25):
-        dependencies:
-            browserslist: 4.28.7
-            caniuse-api: 4.0.0
-            cssesc: 3.0.0
-            postcss: 8.5.25
-            postcss-selector-parser: 7.1.4
-
-    postcss-nested@8.0.1(postcss@8.5.25):
-        dependencies:
-            postcss: 8.5.25
-            postcss-selector-parser: 7.1.4
-
-    postcss-normalize-charset@8.0.1(postcss@8.5.25):
-        dependencies:
-            postcss: 8.5.25
-
-    postcss-normalize-display-values@8.0.1(postcss@8.5.25):
-        dependencies:
-            postcss: 8.5.25
-            postcss-value-parser: 4.2.0
-
-    postcss-normalize-positions@8.0.1(postcss@8.5.25):
-        dependencies:
-            postcss: 8.5.25
-            postcss-value-parser: 4.2.0
-
-    postcss-normalize-repeat-style@8.0.1(postcss@8.5.25):
-        dependencies:
-            postcss: 8.5.25
-            postcss-value-parser: 4.2.0
-
-    postcss-normalize-string@8.0.1(postcss@8.5.25):
-        dependencies:
-            postcss: 8.5.25
-            postcss-value-parser: 4.2.0
-
-    postcss-normalize-timing-functions@8.0.1(postcss@8.5.25):
-        dependencies:
-            postcss: 8.5.25
-            postcss-value-parser: 4.2.0
-
-    postcss-normalize-unicode@8.0.1(postcss@8.5.25):
-        dependencies:
-            browserslist: 4.28.7
-            postcss: 8.5.25
-            postcss-value-parser: 4.2.0
-
-    postcss-normalize-url@8.0.1(postcss@8.5.25):
-        dependencies:
-            postcss: 8.5.25
-            postcss-value-parser: 4.2.0
-
-    postcss-normalize-whitespace@8.0.1(postcss@8.5.25):
-        dependencies:
-            postcss: 8.5.25
-            postcss-value-parser: 4.2.0
-
-    postcss-ordered-values@8.0.1(postcss@8.5.25):
-        dependencies:
-            cssnano-utils: 6.0.1(postcss@8.5.25)
-            postcss: 8.5.25
-            postcss-value-parser: 4.2.0
-
-    postcss-reduce-initial@8.0.1(postcss@8.5.25):
-        dependencies:
-            browserslist: 4.28.7
-            caniuse-api: 4.0.0
-            postcss: 8.5.25
-
-    postcss-reduce-transforms@8.0.1(postcss@8.5.25):
-        dependencies:
-            postcss: 8.5.25
-            postcss-value-parser: 4.2.0
-
-    postcss-selector-parser@7.1.4:
-        dependencies:
-            cssesc: 3.0.0
-            util-deprecate: 1.0.2
-
-    postcss-svgo@8.0.1(postcss@8.5.25):
-        dependencies:
-            postcss: 8.5.25
-            postcss-value-parser: 4.2.0
-            svgo: 4.0.2
-
-    postcss-unique-selectors@8.0.1(postcss@8.5.25):
-        dependencies:
-            postcss: 8.5.25
-            postcss-selector-parser: 7.1.4
-
-    postcss-value-parser@4.2.0: {}
-
-    postcss@8.5.25:
-        dependencies:
-            nanoid: 3.3.16
-            picocolors: 1.1.1
-            source-map-js: 1.2.1
-
-    prettier@2.8.8: {}
-
-    prettier@3.9.6: {}
-
-    pretty-format@27.5.1:
-        dependencies:
-            ansi-regex: 5.0.1
-            ansi-styles: 5.2.0
-            react-is: 17.0.2
-
-    property-information@7.2.0: {}
-
-    quansync@0.2.11: {}
-
-    queue-lit@1.5.2: {}
-
-    queue-microtask@1.2.3: {}
-
-    react-dom@19.2.8(react@19.2.8):
-        dependencies:
-            react: 19.2.8
-            scheduler: 0.27.0
-
-    react-is@17.0.2: {}
-
-    react@19.2.8: {}
-
-    read-cache@1.0.0:
-        dependencies:
-            pify: 2.3.0
-
-    read-yaml-file@1.1.0:
-        dependencies:
-            graceful-fs: 4.2.11
-            js-yaml: 3.15.1
-            pify: 4.0.1
-            strip-bom: 3.0.0
-
-    readdirp@3.6.0:
-        dependencies:
-            picomatch: 2.3.2
-
-    readdirp@4.1.2: {}
-
-    readdirp@5.0.0: {}
-
-    recast@0.23.19:
-        dependencies:
-            ast-types: 0.16.1
-            esprima: 4.0.1
-            source-map: 0.6.1
-            tiny-invariant: 1.3.3
-            tslib: 2.8.1
-
-    recma-build-jsx@1.0.0:
-        dependencies:
-            '@types/estree': 1.0.9
-            estree-util-build-jsx: 3.0.1
-            vfile: 6.0.3
-
-    recma-jsx@1.0.1(acorn@8.18.0):
-        dependencies:
-            acorn: 8.18.0
-            acorn-jsx: 5.3.2(acorn@8.18.0)
-            estree-util-to-js: 2.0.0
-            recma-parse: 1.0.0
-            recma-stringify: 1.0.0
-            unified: 11.0.5
-
-    recma-parse@1.0.0:
-        dependencies:
-            '@types/estree': 1.0.9
-            esast-util-from-js: 2.0.1
-            unified: 11.0.5
-            vfile: 6.0.3
-
-    recma-stringify@1.0.0:
-        dependencies:
-            '@types/estree': 1.0.9
-            estree-util-to-js: 2.0.0
-            unified: 11.0.5
-            vfile: 6.0.3
-
-    redent@3.0.0:
-        dependencies:
-            indent-string: 4.0.0
-            strip-indent: 3.0.0
-
-    regex-recursion@6.0.2:
-        dependencies:
-            regex-utilities: 2.3.0
-
-    regex-utilities@2.3.0: {}
-
-    regex@6.1.0:
-        dependencies:
-            regex-utilities: 2.3.0
-
-    rehype-parse@9.0.1:
-        dependencies:
-            '@types/hast': 3.0.5
-            hast-util-from-html: 2.0.3
-            unified: 11.0.5
-
-    rehype-pretty-code@0.14.5(shiki@3.23.0):
-        dependencies:
-            '@types/hast': 3.0.5
-            hast-util-to-string: 3.0.1
-            parse-numeric-range: 1.3.0
-            rehype-parse: 9.0.1
-            shiki: 3.23.0
-            unified: 11.0.5
-            unist-util-visit: 5.1.0
-
-    rehype-recma@1.0.0(supports-color@7.2.0):
-        dependencies:
-            '@types/estree': 1.0.9
-            '@types/hast': 3.0.5
-            hast-util-to-estree: 3.1.3(supports-color@7.2.0)
-        transitivePeerDependencies:
-            - supports-color
-
-    remark-frontmatter@5.0.0(supports-color@7.2.0):
-        dependencies:
-            '@types/mdast': 4.0.4
-            mdast-util-frontmatter: 2.0.1(supports-color@7.2.0)
-            micromark-extension-frontmatter: 2.0.0
-            unified: 11.0.5
-        transitivePeerDependencies:
-            - supports-color
-
-    remark-gfm@4.0.1(supports-color@7.2.0):
-        dependencies:
-            '@types/mdast': 4.0.4
-            mdast-util-gfm: 3.1.0(supports-color@7.2.0)
-            micromark-extension-gfm: 3.0.0
-            remark-parse: 11.0.0(supports-color@7.2.0)
-            remark-stringify: 11.0.0
-            unified: 11.0.5
-        transitivePeerDependencies:
-            - supports-color
-
-    remark-mdx@3.1.1(supports-color@7.2.0):
-        dependencies:
-            mdast-util-mdx: 3.0.0(supports-color@7.2.0)
-            micromark-extension-mdxjs: 3.0.0
-        transitivePeerDependencies:
-            - supports-color
-
-    remark-parse@11.0.0(supports-color@7.2.0):
-        dependencies:
-            '@types/mdast': 4.0.4
-            mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
-            micromark-util-types: 2.0.2
-            unified: 11.0.5
-        transitivePeerDependencies:
-            - supports-color
-
-    remark-rehype@11.1.2:
-        dependencies:
-            '@types/hast': 3.0.5
-            '@types/mdast': 4.0.4
-            mdast-util-to-hast: 13.2.1
-            unified: 11.0.5
-            vfile: 6.0.3
-
-    remark-stringify@11.0.0:
-        dependencies:
-            '@types/mdast': 4.0.4
-            mdast-util-to-markdown: 2.1.2
-            unified: 11.0.5
-
-    resolve-from@5.0.0: {}
-
-    resolve@1.22.12:
-        dependencies:
-            es-errors: 1.3.0
-            is-core-module: 2.16.2
-            path-parse: 1.0.7
-            supports-preserve-symlinks-flag: 1.0.0
-
-    reusify@1.1.0: {}
-
-    rolldown@1.2.1:
-        dependencies:
-            '@oxc-project/types': 0.142.0
-            '@rolldown/pluginutils': 1.0.1
-        optionalDependencies:
-            '@rolldown/binding-android-arm64': 1.2.1
-            '@rolldown/binding-darwin-arm64': 1.2.1
-            '@rolldown/binding-darwin-x64': 1.2.1
-            '@rolldown/binding-freebsd-x64': 1.2.1
-            '@rolldown/binding-linux-arm-gnueabihf': 1.2.1
-            '@rolldown/binding-linux-arm64-gnu': 1.2.1
-            '@rolldown/binding-linux-arm64-musl': 1.2.1
-            '@rolldown/binding-linux-ppc64-gnu': 1.2.1
-            '@rolldown/binding-linux-s390x-gnu': 1.2.1
-            '@rolldown/binding-linux-x64-gnu': 1.2.1
-            '@rolldown/binding-linux-x64-musl': 1.2.1
-            '@rolldown/binding-openharmony-arm64': 1.2.1
-            '@rolldown/binding-wasm32-wasi': 1.2.1
-            '@rolldown/binding-win32-arm64-msvc': 1.2.1
-            '@rolldown/binding-win32-x64-msvc': 1.2.1
-
-    rollup@4.62.4:
-        dependencies:
-            '@types/estree': 1.0.9
-        optionalDependencies:
-            '@napi-rs/lzma-linux-x64-gnu': 1.5.1
-            '@rollup/rollup-android-arm-eabi': 4.62.4
-            '@rollup/rollup-android-arm64': 4.62.4
-            '@rollup/rollup-darwin-arm64': 4.62.4
-            '@rollup/rollup-darwin-x64': 4.62.4
-            '@rollup/rollup-freebsd-arm64': 4.62.4
-            '@rollup/rollup-freebsd-x64': 4.62.4
-            '@rollup/rollup-linux-arm-gnueabihf': 4.62.4
-            '@rollup/rollup-linux-arm-musleabihf': 4.62.4
-            '@rollup/rollup-linux-arm64-gnu': 4.62.4
-            '@rollup/rollup-linux-arm64-musl': 4.62.4
-            '@rollup/rollup-linux-loong64-gnu': 4.62.4
-            '@rollup/rollup-linux-loong64-musl': 4.62.4
-            '@rollup/rollup-linux-ppc64-gnu': 4.62.4
-            '@rollup/rollup-linux-ppc64-musl': 4.62.4
-            '@rollup/rollup-linux-riscv64-gnu': 4.62.4
-            '@rollup/rollup-linux-riscv64-musl': 4.62.4
-            '@rollup/rollup-linux-s390x-gnu': 4.62.4
-            '@rollup/rollup-linux-x64-gnu': 4.62.4
-            '@rollup/rollup-linux-x64-musl': 4.62.4
-            '@rollup/rollup-openbsd-x64': 4.62.4
-            '@rollup/rollup-openharmony-arm64': 4.62.4
-            '@rollup/rollup-win32-arm64-msvc': 4.62.4
-            '@rollup/rollup-win32-ia32-msvc': 4.62.4
-            '@rollup/rollup-win32-x64-gnu': 4.62.4
-            '@rollup/rollup-win32-x64-msvc': 4.62.4
-            fsevents: 2.3.3
-
-    rou3@0.9.1: {}
-
-    run-applescript@7.1.0: {}
-
-    run-parallel@1.2.0:
-        dependencies:
-            queue-microtask: 1.2.3
-
-    safer-buffer@2.1.2: {}
-
-    sax@1.6.1: {}
-
-    scheduler@0.27.0: {}
-
-    semver@6.3.1: {}
-
-    semver@7.8.5: {}
-
-    shebang-command@2.0.0:
-        dependencies:
-            shebang-regex: 3.0.0
-
-    shebang-regex@3.0.0: {}
-
-    shiki@3.23.0:
-        dependencies:
-            '@shikijs/core': 3.23.0
-            '@shikijs/engine-javascript': 3.23.0
-            '@shikijs/engine-oniguruma': 3.23.0
-            '@shikijs/langs': 3.23.0
-            '@shikijs/themes': 3.23.0
-            '@shikijs/types': 3.23.0
-            '@shikijs/vscode-textmate': 10.0.2
-            '@types/hast': 3.0.5
-
-    siginfo@2.0.0: {}
-
-    signal-exit@4.1.0: {}
-
-    sirv@3.0.2:
-        dependencies:
-            '@polka/url': 1.0.0-next.29
-            mrmime: 2.0.1
-            totalist: 3.0.1
-
-    sisteransi@1.0.5: {}
-
-    slash@3.0.0: {}
-
-    source-map-js@1.2.1: {}
-
-    source-map@0.6.1: {}
-
-    source-map@0.7.6: {}
-
-    source-map@0.8.0: {}
-
-    space-separated-tokens@2.0.2: {}
-
-    spawndamnit@3.0.1:
-        dependencies:
-            cross-spawn: 7.0.6
-            signal-exit: 4.1.0
-
-    sprintf-js@1.0.3: {}
-
-    srvx@0.11.22: {}
-
-    srvx@0.12.5: {}
-
-    stackback@0.0.2: {}
-
-    std-env@4.2.0: {}
-
-    storybook@10.5.5(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8):
-        dependencies:
-            '@storybook/global': 5.0.0
-            '@storybook/icons': 2.1.0(react@19.2.8)
-            '@testing-library/dom': 10.4.1
-            '@testing-library/jest-dom': 6.9.1
-            '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
-            '@vitest/expect': 3.2.4
-            '@vitest/spy': 3.2.4
-            '@webcontainer/env': 1.1.1
-            esbuild: 0.28.1
-            jsonc-parser: 3.3.1
-            open: 10.2.0
-            oxc-parser: 0.127.0
-            oxc-resolver: 11.24.2
-            recast: 0.23.19
-            semver: 7.8.5
-            use-sync-external-store: 1.6.0(react@19.2.8)
-            ws: 8.21.1
-        optionalDependencies:
-            '@types/react': 19.2.18
-            prettier: 3.9.6
-        transitivePeerDependencies:
-            - bufferutil
-            - react
-            - utf-8-validate
-
-    stringify-entities@4.0.4:
-        dependencies:
-            character-entities-html4: 2.1.0
-            character-entities-legacy: 3.0.0
-
-    strip-ansi@6.0.1:
-        dependencies:
-            ansi-regex: 5.0.1
-
-    strip-ansi@7.2.0:
-        dependencies:
-            ansi-regex: 6.2.2
-
-    strip-bom@3.0.0: {}
-
-    strip-indent@3.0.0:
-        dependencies:
-            min-indent: 1.0.1
-
-    stubborn-fs@2.0.0:
-        dependencies:
-            stubborn-utils: 1.0.2
-
-    stubborn-utils@1.0.2: {}
-
-    style-to-js@1.1.21:
-        dependencies:
-            style-to-object: 1.0.14
-
-    style-to-object@1.0.14:
-        dependencies:
-            inline-style-parser: 0.2.7
-
-    stylehacks@8.0.1(postcss@8.5.25):
-        dependencies:
-            browserslist: 4.28.7
-            postcss: 8.5.25
-            postcss-selector-parser: 7.1.4
-
-    sucrase@3.35.1:
-        dependencies:
-            '@jridgewell/gen-mapping': 0.3.13
-            commander: 4.1.1
-            lines-and-columns: 1.2.4
-            mz: 2.7.0
-            pirates: 4.0.7
-            tinyglobby: 0.2.17
-            ts-interface-checker: 0.1.13
-
-    supports-color@7.2.0:
-        dependencies:
-            has-flag: 4.0.0
-
-    supports-preserve-symlinks-flag@1.0.0: {}
-
-    svgo@4.0.2:
-        dependencies:
-            commander: 11.1.0
-            css-select: 5.2.2
-            css-tree: 3.2.1
-            css-what: 6.2.2
-            csso: 5.0.5
-            picocolors: 1.1.1
-            sax: 1.6.1
-
-    tagged-tag@1.0.0: {}
-
-    tailwindcss@4.3.3: {}
-
-    tapable@2.3.3: {}
-
-    term-size@2.2.1: {}
-
-    thenify-all@1.6.0:
-        dependencies:
-            thenify: 3.3.1
-
-    thenify@3.3.1:
-        dependencies:
-            any-promise: 1.3.0
-
-    tiny-invariant@1.3.3: {}
-
-    tinybench@2.9.0: {}
-
-    tinyexec@0.3.2: {}
-
-    tinyexec@1.3.0: {}
-
-    tinyglobby@0.2.17:
-        dependencies:
-            fdir: 6.5.0(picomatch@4.0.5)
-            picomatch: 4.0.5
-
-    tinyrainbow@2.0.0: {}
-
-    tinyrainbow@3.1.1: {}
-
-    tinyspy@4.0.4: {}
-
-    to-regex-range@5.0.1:
-        dependencies:
-            is-number: 7.0.0
-
-    totalist@3.0.1: {}
-
-    tr46@0.0.3: {}
-
-    tree-kill@1.2.2: {}
-
-    trim-lines@3.0.1: {}
-
-    trough@2.2.0: {}
-
-    ts-dedent@2.3.0: {}
-
-    ts-interface-checker@0.1.13: {}
-
-    tsc-alias@1.8.10:
-        dependencies:
-            chokidar: 3.6.0
-            commander: 9.5.0
-            globby: 11.1.0
-            mylas: 2.1.14
-            normalize-path: 3.0.0
-            plimit-lit: 1.6.1
-
-    tslib@2.8.1: {}
-
-    tsup@8.5.1(jiti@2.7.0)(postcss@8.5.25)(supports-color@7.2.0)(tsx@4.23.1)(typescript@7.0.2)(yaml@2.9.0):
-        dependencies:
-            bundle-require: 5.1.0(esbuild@0.27.7)
-            cac: 6.7.14
-            chokidar: 4.0.3
-            consola: 3.4.2
-            debug: 4.4.3(supports-color@7.2.0)
-            esbuild: 0.27.7
-            fix-dts-default-cjs-exports: 1.0.1
-            joycon: 3.1.1
-            picocolors: 1.1.1
-            postcss-load-config: 6.0.1(jiti@2.7.0)(postcss@8.5.25)(tsx@4.23.1)(yaml@2.9.0)
-            resolve-from: 5.0.0
-            rollup: 4.62.4
-            source-map: 0.7.6
-            sucrase: 3.35.1
-            tinyexec: 0.3.2
-            tinyglobby: 0.2.17
-            tree-kill: 1.2.2
-        optionalDependencies:
-            postcss: 8.5.25
-            typescript: 7.0.2
-        transitivePeerDependencies:
-            - jiti
-            - supports-color
-            - tsx
-            - yaml
-
-    tsx@4.23.1:
-        dependencies:
-            esbuild: 0.28.1
-        optionalDependencies:
-            fsevents: 2.3.3
-
-    type-fest@5.8.0:
-        dependencies:
-            tagged-tag: 1.0.0
-
-    typescript@7.0.2:
-        optionalDependencies:
-            '@typescript/typescript-aix-ppc64': 7.0.2
-            '@typescript/typescript-darwin-arm64': 7.0.2
-            '@typescript/typescript-darwin-x64': 7.0.2
-            '@typescript/typescript-freebsd-arm64': 7.0.2
-            '@typescript/typescript-freebsd-x64': 7.0.2
-            '@typescript/typescript-linux-arm': 7.0.2
-            '@typescript/typescript-linux-arm64': 7.0.2
-            '@typescript/typescript-linux-loong64': 7.0.2
-            '@typescript/typescript-linux-mips64el': 7.0.2
-            '@typescript/typescript-linux-ppc64': 7.0.2
-            '@typescript/typescript-linux-riscv64': 7.0.2
-            '@typescript/typescript-linux-s390x': 7.0.2
-            '@typescript/typescript-linux-x64': 7.0.2
-            '@typescript/typescript-netbsd-arm64': 7.0.2
-            '@typescript/typescript-netbsd-x64': 7.0.2
-            '@typescript/typescript-openbsd-arm64': 7.0.2
-            '@typescript/typescript-openbsd-x64': 7.0.2
-            '@typescript/typescript-sunos-x64': 7.0.2
-            '@typescript/typescript-win32-arm64': 7.0.2
-            '@typescript/typescript-win32-x64': 7.0.2
-
-    ufo@1.6.4: {}
-
-    undici-types@7.18.2: {}
-
-    unenv@2.0.0-rc.24:
-        dependencies:
-            pathe: 2.0.3
-
-    unified@11.0.5:
-        dependencies:
-            '@types/unist': 3.0.3
-            bail: 2.0.2
-            devlop: 1.1.0
-            extend: 3.0.2
-            is-plain-obj: 4.1.0
-            trough: 2.2.0
-            vfile: 6.0.3
-
-    unist-util-is@6.0.1:
-        dependencies:
-            '@types/unist': 3.0.3
-
-    unist-util-position-from-estree@2.0.0:
-        dependencies:
-            '@types/unist': 3.0.3
-
-    unist-util-position@5.0.0:
-        dependencies:
-            '@types/unist': 3.0.3
-
-    unist-util-stringify-position@4.0.0:
-        dependencies:
-            '@types/unist': 3.0.3
-
-    unist-util-visit-parents@6.0.2:
-        dependencies:
-            '@types/unist': 3.0.3
-            unist-util-is: 6.0.1
-
-    unist-util-visit@5.1.0:
-        dependencies:
-            '@types/unist': 3.0.3
-            unist-util-is: 6.0.1
-            unist-util-visit-parents: 6.0.2
-
-    universalify@0.1.2: {}
-
-    universalify@2.0.1: {}
-
-    unplugin@2.3.11:
-        dependencies:
-            '@jridgewell/remapping': 2.3.5
-            acorn: 8.18.0
-            picomatch: 4.0.5
-            webpack-virtual-modules: 0.6.2
-
-    unstorage@2.0.0-alpha.7(chokidar@5.0.0)(db0@0.3.4)(ofetch@2.0.0-alpha.3):
-        optionalDependencies:
-            chokidar: 5.0.0
-            db0: 0.3.4
-            ofetch: 2.0.0-alpha.3
-
-    update-browserslist-db@1.2.3(browserslist@4.28.7):
-        dependencies:
-            browserslist: 4.28.7
-            escalade: 3.2.0
-            picocolors: 1.1.1
-
-    use-sync-external-store@1.6.0(react@19.2.8):
-        dependencies:
-            react: 19.2.8
-
-    util-deprecate@1.0.2: {}
-
-    valibot@1.4.2(typescript@7.0.2):
-        optionalDependencies:
-            typescript: 7.0.2
-
-    vfile-location@5.0.3:
-        dependencies:
-            '@types/unist': 3.0.3
-            vfile: 6.0.3
-
-    vfile-matter@5.0.1:
-        dependencies:
-            vfile: 6.0.3
-            yaml: 2.9.0
-
-    vfile-message@4.0.3:
-        dependencies:
-            '@types/unist': 3.0.3
-            unist-util-stringify-position: 4.0.0
-
-    vfile@6.0.3:
-        dependencies:
-            '@types/unist': 3.0.3
-            vfile-message: 4.0.3
-
-    vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0):
-        dependencies:
-            lightningcss: 1.33.0
-            picomatch: 4.0.5
-            postcss: 8.5.25
-            rolldown: 1.2.1
-            tinyglobby: 0.2.17
-        optionalDependencies:
-            '@types/node': 24.13.3
-            esbuild: 0.28.1
-            fsevents: 2.3.3
-            jiti: 2.7.0
-            tsx: 4.23.1
-            yaml: 2.9.0
-
-    vitest@4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)):
-        dependencies:
-            '@vitest/expect': 4.1.10
-            '@vitest/mocker': 4.1.10(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
-            '@vitest/pretty-format': 4.1.10
-            '@vitest/runner': 4.1.10
-            '@vitest/snapshot': 4.1.10
-            '@vitest/spy': 4.1.10
-            '@vitest/utils': 4.1.10
-            es-module-lexer: 2.3.1
-            expect-type: 1.4.0
-            magic-string: 0.30.21
-            obug: 2.1.4
-            pathe: 2.0.3
-            picomatch: 4.0.5
-            std-env: 4.2.0
-            tinybench: 2.9.0
-            tinyexec: 1.3.0
-            tinyglobby: 0.2.17
-            tinyrainbow: 3.1.1
-            vite: 8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
-            why-is-node-running: 2.3.0
-        optionalDependencies:
-            '@types/node': 24.13.3
-            '@vitest/browser-playwright': 4.1.10(playwright@1.62.1)(vite@8.2.0(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(vitest@4.1.10)
-            '@vitest/coverage-istanbul': 4.1.10(supports-color@7.2.0)(vitest@4.1.10)
-            '@vitest/coverage-v8': 4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)
-            happy-dom: 20.11.1
-        transitivePeerDependencies:
-            - msw
-
-    web-namespaces@2.0.1: {}
-
-    webidl-conversions@3.0.1: {}
-
-    webpack-virtual-modules@0.6.2: {}
-
-    whatwg-mimetype@3.0.0: {}
-
-    whatwg-url@5.0.0:
-        dependencies:
-            tr46: 0.0.3
-            webidl-conversions: 3.0.1
-
-    when-exit@2.1.5: {}
-
-    which@2.0.2:
-        dependencies:
-            isexe: 2.0.0
-
-    why-is-node-running@2.3.0:
-        dependencies:
-            siginfo: 2.0.0
-            stackback: 0.0.2
-
-    ws@8.21.1: {}
-
-    wsl-utils@0.1.0:
-        dependencies:
-            is-wsl: 3.1.1
-
-    xdg-basedir@5.1.0: {}
-
-    yallist@3.1.1: {}
-
-    yaml@2.9.0: {}
-
-    zod@4.4.3: {}
-
-    zwitch@2.0.4: {}
+
+  '@adobe/css-tools@4.5.0': {}
+
+  '@alloc/quick-lru@5.2.0': {}
+
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.29.7': {}
+
+  '@babel/core@7.29.7(supports-color@7.2.0)':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.8
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@7.2.0))(supports-color@7.2.0)
+      '@babel/helpers': 7.29.7
+      '@babel/parser': 7.29.8
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.8(supports-color@7.2.0)
+      '@babel/types': 7.29.8
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3(supports-color@7.2.0)
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.29.8':
+    dependencies:
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-annotate-as-pure@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.8
+
+  '@babel/helper-compilation-targets@7.29.7':
+    dependencies:
+      '@babel/compat-data': 7.29.7
+      '@babel/helper-validator-option': 7.29.7
+      browserslist: 4.28.8
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-create-class-features-plugin@7.29.7(@babel/core@7.29.7(supports-color@7.2.0))(supports-color@7.2.0)':
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@7.2.0)
+      '@babel/helper-annotate-as-pure': 7.29.7
+      '@babel/helper-member-expression-to-functions': 7.29.7(supports-color@7.2.0)
+      '@babel/helper-optimise-call-expression': 7.29.7
+      '@babel/helper-replace-supers': 7.29.7(@babel/core@7.29.7(supports-color@7.2.0))(supports-color@7.2.0)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7(supports-color@7.2.0)
+      '@babel/traverse': 7.29.8(supports-color@7.2.0)
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-globals@7.29.7': {}
+
+  '@babel/helper-member-expression-to-functions@7.29.7(supports-color@7.2.0)':
+    dependencies:
+      '@babel/traverse': 7.29.8(supports-color@7.2.0)
+      '@babel/types': 7.29.8
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-imports@7.29.7(supports-color@7.2.0)':
+    dependencies:
+      '@babel/traverse': 7.29.8(supports-color@7.2.0)
+      '@babel/types': 7.29.8
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7(supports-color@7.2.0))(supports-color@7.2.0)':
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@7.2.0)
+      '@babel/helper-module-imports': 7.29.7(supports-color@7.2.0)
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.8(supports-color@7.2.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-optimise-call-expression@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.8
+
+  '@babel/helper-plugin-utils@7.29.7': {}
+
+  '@babel/helper-replace-supers@7.29.7(@babel/core@7.29.7(supports-color@7.2.0))(supports-color@7.2.0)':
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@7.2.0)
+      '@babel/helper-member-expression-to-functions': 7.29.7(supports-color@7.2.0)
+      '@babel/helper-optimise-call-expression': 7.29.7
+      '@babel/traverse': 7.29.8(supports-color@7.2.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-skip-transparent-expression-wrappers@7.29.7(supports-color@7.2.0)':
+    dependencies:
+      '@babel/traverse': 7.29.8(supports-color@7.2.0)
+      '@babel/types': 7.29.8
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-string-parser@7.29.7': {}
+
+  '@babel/helper-string-parser@8.0.0': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/helper-validator-identifier@8.0.4': {}
+
+  '@babel/helper-validator-option@7.29.7': {}
+
+  '@babel/helpers@7.29.7':
+    dependencies:
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.8
+
+  '@babel/parser@7.29.8':
+    dependencies:
+      '@babel/types': 7.29.8
+
+  '@babel/plugin-proposal-decorators@7.29.7(@babel/core@7.29.7(supports-color@7.2.0))(supports-color@7.2.0)':
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@7.2.0)
+      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7(supports-color@7.2.0))(supports-color@7.2.0)
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/plugin-syntax-decorators': 7.29.7(@babel/core@7.29.7(supports-color@7.2.0))
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-syntax-decorators@7.29.7(@babel/core@7.29.7(supports-color@7.2.0))':
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@7.2.0)
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7(supports-color@7.2.0))':
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@7.2.0)
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-class-properties@7.29.7(@babel/core@7.29.7(supports-color@7.2.0))(supports-color@7.2.0)':
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@7.2.0)
+      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7(supports-color@7.2.0))(supports-color@7.2.0)
+      '@babel/helper-plugin-utils': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/runtime@7.29.7': {}
+
+  '@babel/template@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
+
+  '@babel/traverse@7.29.8(supports-color@7.2.0)':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.8
+      '@babel/helper-globals': 7.29.7
+      '@babel/parser': 7.29.8
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.8
+      debug: 4.4.3(supports-color@7.2.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/types@7.29.8':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+
+  '@babel/types@8.0.4':
+    dependencies:
+      '@babel/helper-string-parser': 8.0.0
+      '@babel/helper-validator-identifier': 8.0.4
+
+  '@bcoe/v8-coverage@1.0.2': {}
+
+  '@blazediff/core@1.9.1': {}
+
+  '@bomb.sh/args@0.3.1': {}
+
+  '@changesets/apply-release-plan@7.1.1':
+    dependencies:
+      '@changesets/config': 3.1.4
+      '@changesets/get-version-range-type': 0.4.0
+      '@changesets/git': 3.0.4
+      '@changesets/should-skip-package': 0.1.2
+      '@changesets/types': 6.1.0
+      '@manypkg/get-packages': 1.1.3
+      detect-indent: 6.1.0
+      fs-extra: 7.0.1
+      lodash.startcase: 4.4.0
+      outdent: 0.5.0
+      prettier: 2.8.8
+      resolve-from: 5.0.0
+      semver: 7.8.5
+
+  '@changesets/assemble-release-plan@6.0.10':
+    dependencies:
+      '@changesets/errors': 0.2.0
+      '@changesets/get-dependents-graph': 2.1.4
+      '@changesets/should-skip-package': 0.1.2
+      '@changesets/types': 6.1.0
+      '@manypkg/get-packages': 1.1.3
+      semver: 7.8.5
+
+  '@changesets/changelog-git@0.2.1':
+    dependencies:
+      '@changesets/types': 6.1.0
+
+  '@changesets/changelog-github@0.5.2':
+    dependencies:
+      '@changesets/get-github-info': 0.7.0
+      '@changesets/types': 6.1.0
+      dotenv: 8.6.0
+    transitivePeerDependencies:
+      - encoding
+
+  '@changesets/cli@2.31.1(@types/node@24.13.3)':
+    dependencies:
+      '@changesets/apply-release-plan': 7.1.1
+      '@changesets/assemble-release-plan': 6.0.10
+      '@changesets/changelog-git': 0.2.1
+      '@changesets/config': 3.1.4
+      '@changesets/errors': 0.2.0
+      '@changesets/get-dependents-graph': 2.1.4
+      '@changesets/get-release-plan': 4.0.16
+      '@changesets/git': 3.0.4
+      '@changesets/logger': 0.1.1
+      '@changesets/pre': 2.0.2
+      '@changesets/read': 0.6.7
+      '@changesets/should-skip-package': 0.1.2
+      '@changesets/types': 6.1.0
+      '@changesets/write': 0.4.0
+      '@inquirer/external-editor': 1.0.3(@types/node@24.13.3)
+      '@manypkg/get-packages': 1.1.3
+      ansi-colors: 4.1.3
+      enquirer: 2.4.1
+      fs-extra: 7.0.1
+      mri: 1.2.0
+      package-manager-detector: 0.2.11
+      picocolors: 1.1.1
+      resolve-from: 5.0.0
+      semver: 7.8.5
+      spawndamnit: 3.0.1
+      term-size: 2.2.1
+    transitivePeerDependencies:
+      - '@types/node'
+
+  '@changesets/config@3.1.4':
+    dependencies:
+      '@changesets/errors': 0.2.0
+      '@changesets/get-dependents-graph': 2.1.4
+      '@changesets/logger': 0.1.1
+      '@changesets/should-skip-package': 0.1.2
+      '@changesets/types': 6.1.0
+      '@manypkg/get-packages': 1.1.3
+      fs-extra: 7.0.1
+      micromatch: 4.0.8
+
+  '@changesets/errors@0.2.0':
+    dependencies:
+      extendable-error: 0.1.7
+
+  '@changesets/get-dependents-graph@2.1.4':
+    dependencies:
+      '@changesets/types': 6.1.0
+      '@manypkg/get-packages': 1.1.3
+      picocolors: 1.1.1
+      semver: 7.8.5
+
+  '@changesets/get-github-info@0.7.0':
+    dependencies:
+      dataloader: 1.4.0
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
+
+  '@changesets/get-release-plan@4.0.16':
+    dependencies:
+      '@changesets/assemble-release-plan': 6.0.10
+      '@changesets/config': 3.1.4
+      '@changesets/pre': 2.0.2
+      '@changesets/read': 0.6.7
+      '@changesets/types': 6.1.0
+      '@manypkg/get-packages': 1.1.3
+
+  '@changesets/get-version-range-type@0.4.0': {}
+
+  '@changesets/git@3.0.4':
+    dependencies:
+      '@changesets/errors': 0.2.0
+      '@manypkg/get-packages': 1.1.3
+      is-subdir: 1.2.0
+      micromatch: 4.0.8
+      spawndamnit: 3.0.1
+
+  '@changesets/logger@0.1.1':
+    dependencies:
+      picocolors: 1.1.1
+
+  '@changesets/parse@0.4.3':
+    dependencies:
+      '@changesets/types': 6.1.0
+      js-yaml: 4.3.1
+
+  '@changesets/pre@2.0.2':
+    dependencies:
+      '@changesets/errors': 0.2.0
+      '@changesets/types': 6.1.0
+      '@manypkg/get-packages': 1.1.3
+      fs-extra: 7.0.1
+
+  '@changesets/read@0.6.7':
+    dependencies:
+      '@changesets/git': 3.0.4
+      '@changesets/logger': 0.1.1
+      '@changesets/parse': 0.4.3
+      '@changesets/types': 6.1.0
+      fs-extra: 7.0.1
+      p-filter: 2.1.0
+      picocolors: 1.1.1
+
+  '@changesets/should-skip-package@0.1.2':
+    dependencies:
+      '@changesets/types': 6.1.0
+      '@manypkg/get-packages': 1.1.3
+
+  '@changesets/types@4.1.0': {}
+
+  '@changesets/types@6.1.0': {}
+
+  '@changesets/write@0.4.0':
+    dependencies:
+      '@changesets/types': 6.1.0
+      fs-extra: 7.0.1
+      human-id: 4.2.0
+      prettier: 2.8.8
+
+  '@chromatic-com/storybook@5.3.0(storybook@10.5.7(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))':
+    dependencies:
+      '@neoconfetti/react': 1.0.0
+      chromatic: 18.2.0
+      jsonfile: 6.2.1
+      storybook: 10.5.7(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8)
+      strip-ansi: 7.2.0
+    transitivePeerDependencies:
+      - '@chromatic-com/cypress'
+      - '@chromatic-com/playwright'
+      - '@chromatic-com/vitest'
+
+  '@clack/core@1.4.3':
+    dependencies:
+      fast-wrap-ansi: 0.2.2
+      sisteransi: 1.0.5
+
+  '@clack/prompts@1.7.0':
+    dependencies:
+      '@clack/core': 1.4.3
+      fast-string-width: 3.0.2
+      fast-wrap-ansi: 0.2.2
+      sisteransi: 1.0.5
+
+  '@colordx/core@5.5.0': {}
+
+  '@ecopages/browser-router@0.2.0-beta.43(@ecopages/core@0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(typescript@7.0.2))':
+    dependencies:
+      '@ecopages/core': 0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(typescript@7.0.2)
+      morphdom: 2.7.8
+
+  '@ecopages/content-processor@0.2.0-beta.43(@ecopages/core@0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(typescript@7.0.2))(supports-color@7.2.0)(typescript@7.0.2)':
+    dependencies:
+      '@ecopages/core': 0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(typescript@7.0.2)
+      '@ecopages/file-system': 0.2.0-beta.43
+      '@ecopages/logger': 0.2.3(typescript@7.0.2)
+      remark-frontmatter: 5.0.0(supports-color@7.2.0)
+      unified: 11.0.5
+      vfile: 6.0.3
+      vfile-matter: 5.0.1
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  '@ecopages/core@0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(typescript@7.0.2)':
+    dependencies:
+      '@ecopages/file-system': 0.2.0-beta.43
+      '@ecopages/logger': 0.2.3(typescript@7.0.2)
+      '@ecopages/scripts-injector': 0.1.5(typescript@7.0.2)
+      '@oxc-project/runtime': 0.141.0
+      '@standard-schema/spec': 1.1.0
+      '@standard-schema/utils': 0.3.0
+      '@worker-tools/html-rewriter': 0.1.0-pre.19
+      chokidar: 5.0.0
+      ghtml: 4.0.2
+      oxc-parser: 0.141.0
+      oxc-resolver: 11.24.2
+      rolldown: 1.2.4
+      ws: 8.21.3
+    optionalDependencies:
+      '@ecopages/dev-toolbar': 0.2.0-beta.43
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
+
+  '@ecopages/dev-toolbar@0.2.0-beta.43':
+    dependencies:
+      '@ecopages/jsx': 0.3.0-beta.6(@ecopages/signals@0.3.0-beta.6)
+      '@ecopages/radiant': 0.3.0-beta.6(@ecopages/jsx@0.3.0-beta.6(@ecopages/signals@0.3.0-beta.6))
+      '@ecopages/signals': 0.3.0-beta.6
+      axe-core: 4.13.0
+
+  '@ecopages/ecopages-jsx@0.2.0-beta.43(@ecopages/core@0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(typescript@7.0.2))(@ecopages/jsx@packages+jsx+dist)(@ecopages/radiant@packages+radiant+dist)(supports-color@7.2.0)(typescript@7.0.2)':
+    dependencies:
+      '@ecopages/core': 0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(typescript@7.0.2)
+      '@ecopages/jsx': link:packages/jsx/dist
+      '@ecopages/mdx': 0.2.0-beta.43(@ecopages/core@0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(typescript@7.0.2))(@mdx-js/mdx@3.1.1(supports-color@7.2.0))(typescript@7.0.2)
+      '@ecopages/radiant': link:packages/radiant/dist
+      '@mdx-js/mdx': 3.1.1(supports-color@7.2.0)
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  '@ecopages/file-system@0.2.0-beta.43': {}
+
+  '@ecopages/jsx@0.3.0-beta.6(@ecopages/signals@0.3.0-beta.6)':
+    dependencies:
+      '@ecopages/signals': 0.3.0-beta.6
+
+  '@ecopages/logger@0.2.3(typescript@7.0.2)':
+    dependencies:
+      typescript: 7.0.2
+
+  '@ecopages/mdx@0.2.0-beta.43(@ecopages/core@0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(typescript@7.0.2))(@mdx-js/mdx@3.1.1(supports-color@7.2.0))(typescript@7.0.2)':
+    dependencies:
+      '@ecopages/core': 0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(typescript@7.0.2)
+      '@ecopages/logger': 0.2.3(typescript@7.0.2)
+      '@mdx-js/mdx': 3.1.1(supports-color@7.2.0)
+      source-map: 0.8.0
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - typescript
+
+  '@ecopages/postcss-processor@0.2.0-beta.43(@ecopages/core@0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(typescript@7.0.2))(@tailwindcss/postcss@4.3.3)(tailwindcss@4.3.3)(typescript@7.0.2)':
+    dependencies:
+      '@ecopages/core': 0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(typescript@7.0.2)
+      '@ecopages/file-system': 0.2.0-beta.43
+      '@ecopages/logger': 0.2.3(typescript@7.0.2)
+      autoprefixer: 10.5.4(postcss@8.5.26)
+      browserslist: 4.28.8
+      cssnano: 8.0.5(postcss@8.5.26)
+      postcss: 8.5.26
+      postcss-import: 16.2.0(postcss@8.5.26)
+      postcss-nested: 8.0.1(postcss@8.5.26)
+    optionalDependencies:
+      '@tailwindcss/postcss': 4.3.3
+      tailwindcss: 4.3.3
+    transitivePeerDependencies:
+      - typescript
+
+  '@ecopages/radiant@0.3.0-beta.6(@ecopages/jsx@0.3.0-beta.6(@ecopages/signals@0.3.0-beta.6))':
+    dependencies:
+      '@ecopages/jsx': 0.3.0-beta.6(@ecopages/signals@0.3.0-beta.6)
+
+  '@ecopages/radiant@0.3.0-beta.8(@ecopages/jsx@packages+jsx+dist)':
+    dependencies:
+      '@ecopages/jsx': link:packages/jsx/dist
+
+  '@ecopages/scripts-injector@0.1.5(typescript@7.0.2)':
+    dependencies:
+      typescript: 7.0.2
+
+  '@ecopages/signals@0.3.0-beta.6': {}
+
+  '@ecopages/signals@0.3.0-beta.8': {}
+
+  '@emnapi/core@1.11.2':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.2
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/core@1.9.2':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.11.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.9.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/aix-ppc64@0.28.2':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm@0.28.2':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.28.2':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.2':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.2':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.2':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.2':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.2':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.2':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.2':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.2':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.2':
+    optional: true
+
+  '@inquirer/external-editor@1.0.3(@types/node@24.13.3)':
+    dependencies:
+      chardet: 2.2.0
+      iconv-lite: 0.7.3
+    optionalDependencies:
+      '@types/node': 24.13.3
+
+  '@istanbuljs/schema@0.1.6': {}
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@manypkg/find-root@1.1.0':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@types/node': 12.20.55
+      find-up: 4.1.0
+      fs-extra: 8.1.0
+
+  '@manypkg/get-packages@1.1.3':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@changesets/types': 4.1.0
+      '@manypkg/find-root': 1.1.0
+      fs-extra: 8.1.0
+      globby: 11.1.0
+      read-yaml-file: 1.1.0
+
+  '@mdx-js/esbuild@3.1.1(esbuild@0.28.2)(supports-color@7.2.0)':
+    dependencies:
+      '@mdx-js/mdx': 3.1.1(supports-color@7.2.0)
+      '@types/unist': 3.0.3
+      esbuild: 0.28.2
+      source-map: 0.7.6
+      vfile: 6.0.3
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@mdx-js/mdx@3.1.1(supports-color@7.2.0)':
+    dependencies:
+      '@types/estree': 1.0.9
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.5
+      '@types/mdx': 2.0.14
+      acorn: 8.18.0
+      collapse-white-space: 2.1.0
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      estree-util-scope: 1.0.0
+      estree-walker: 3.0.3
+      hast-util-to-jsx-runtime: 2.3.6(supports-color@7.2.0)
+      markdown-extensions: 2.0.0
+      recma-build-jsx: 1.0.0
+      recma-jsx: 1.0.1(acorn@8.18.0)
+      recma-stringify: 1.0.0
+      rehype-recma: 1.0.0(supports-color@7.2.0)
+      remark-mdx: 3.1.1(supports-color@7.2.0)
+      remark-parse: 11.0.0(supports-color@7.2.0)
+      remark-rehype: 11.1.2
+      source-map: 0.7.6
+      unified: 11.0.5
+      unist-util-position-from-estree: 2.0.0
+      unist-util-stringify-position: 4.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@mdx-js/react@3.1.1(@types/react@19.2.18)(react@19.2.8)':
+    dependencies:
+      '@types/mdx': 2.0.14
+      '@types/react': 19.2.18
+      react: 19.2.8
+
+  '@napi-rs/lzma-linux-x64-gnu@1.5.1':
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.2.3(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
+    dependencies:
+      '@emnapi/core': 1.11.2
+      '@emnapi/runtime': 1.11.2
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.2.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
+    dependencies:
+      '@emnapi/core': 1.9.2
+      '@emnapi/runtime': 1.9.2
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
+  '@neoconfetti/react@1.0.0': {}
+
+  '@nodelib/fs.scandir@2.1.5':
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      run-parallel: 1.2.0
+
+  '@nodelib/fs.stat@2.0.5': {}
+
+  '@nodelib/fs.walk@1.2.8':
+    dependencies:
+      '@nodelib/fs.scandir': 2.1.5
+      fastq: 1.20.1
+
+  '@oxc-parser/binding-android-arm-eabi@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-android-arm-eabi@0.141.0':
+    optional: true
+
+  '@oxc-parser/binding-android-arm64@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-android-arm64@0.141.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-arm64@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-arm64@0.141.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-x64@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-x64@0.141.0':
+    optional: true
+
+  '@oxc-parser/binding-freebsd-x64@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-freebsd-x64@0.141.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.141.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-musleabihf@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-musleabihf@0.141.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.141.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-musl@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-musl@0.141.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-ppc64-gnu@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-ppc64-gnu@0.141.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-riscv64-gnu@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-riscv64-gnu@0.141.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.141.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-s390x-gnu@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-s390x-gnu@0.141.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-gnu@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-gnu@0.141.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-musl@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-musl@0.141.0':
+    optional: true
+
+  '@oxc-parser/binding-openharmony-arm64@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-openharmony-arm64@0.141.0':
+    optional: true
+
+  '@oxc-parser/binding-wasm32-wasi@0.127.0':
+    dependencies:
+      '@emnapi/core': 1.9.2
+      '@emnapi/runtime': 1.9.2
+      '@napi-rs/wasm-runtime': 1.2.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+    optional: true
+
+  '@oxc-parser/binding-wasm32-wasi@0.141.0':
+    dependencies:
+      '@emnapi/core': 1.11.2
+      '@emnapi/runtime': 1.11.2
+      '@napi-rs/wasm-runtime': 1.2.3(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+    optional: true
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.141.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-ia32-msvc@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-ia32-msvc@0.141.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-x64-msvc@0.127.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-x64-msvc@0.141.0':
+    optional: true
+
+  '@oxc-project/runtime@0.141.0': {}
+
+  '@oxc-project/types@0.127.0': {}
+
+  '@oxc-project/types@0.141.0': {}
+
+  '@oxc-project/types@0.144.0': {}
+
+  '@oxc-resolver/binding-android-arm-eabi@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-android-arm64@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-darwin-arm64@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-darwin-x64@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-freebsd-x64@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-linux-arm-gnueabihf@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-linux-arm-musleabihf@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-linux-arm64-gnu@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-linux-arm64-musl@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-linux-ppc64-gnu@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-linux-riscv64-gnu@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-linux-riscv64-musl@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-linux-s390x-gnu@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-linux-x64-gnu@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-linux-x64-musl@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-openharmony-arm64@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-wasm32-wasi@11.24.2':
+    dependencies:
+      '@emnapi/core': 1.11.2
+      '@emnapi/runtime': 1.11.2
+      '@napi-rs/wasm-runtime': 1.2.3(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+    optional: true
+
+  '@oxc-resolver/binding-win32-arm64-msvc@11.24.2':
+    optional: true
+
+  '@oxc-resolver/binding-win32-x64-msvc@11.24.2':
+    optional: true
+
+  '@oxlint/binding-android-arm-eabi@1.78.0':
+    optional: true
+
+  '@oxlint/binding-android-arm64@1.78.0':
+    optional: true
+
+  '@oxlint/binding-darwin-arm64@1.78.0':
+    optional: true
+
+  '@oxlint/binding-darwin-x64@1.78.0':
+    optional: true
+
+  '@oxlint/binding-freebsd-x64@1.78.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm-gnueabihf@1.78.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm-musleabihf@1.78.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm64-gnu@1.78.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm64-musl@1.78.0':
+    optional: true
+
+  '@oxlint/binding-linux-ppc64-gnu@1.78.0':
+    optional: true
+
+  '@oxlint/binding-linux-riscv64-gnu@1.78.0':
+    optional: true
+
+  '@oxlint/binding-linux-riscv64-musl@1.78.0':
+    optional: true
+
+  '@oxlint/binding-linux-s390x-gnu@1.78.0':
+    optional: true
+
+  '@oxlint/binding-linux-x64-gnu@1.78.0':
+    optional: true
+
+  '@oxlint/binding-linux-x64-musl@1.78.0':
+    optional: true
+
+  '@oxlint/binding-openharmony-arm64@1.78.0':
+    optional: true
+
+  '@oxlint/binding-win32-arm64-msvc@1.78.0':
+    optional: true
+
+  '@oxlint/binding-win32-ia32-msvc@1.78.0':
+    optional: true
+
+  '@oxlint/binding-win32-x64-msvc@1.78.0':
+    optional: true
+
+  '@polka/url@1.0.0-next.29': {}
+
+  '@rolldown/binding-android-arm64@1.2.4':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.2.4':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.2.4':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.2.4':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.4':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.2.4':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.2.4':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.2.4':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.2.4':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.2.4':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.2.4':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.2.4':
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.2.4':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.2.4':
+    optional: true
+
+  '@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7(supports-color@7.2.0))(@babel/runtime@7.29.7)(rolldown@1.2.4)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))':
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@7.2.0)
+      picomatch: 4.0.5
+      rolldown: 1.2.4
+    optionalDependencies:
+      '@babel/runtime': 7.29.7
+      vite: 8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
+
+  '@rolldown/pluginutils@1.0.1': {}
+
+  '@rollup/rollup-android-arm-eabi@4.62.4':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.62.4':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.62.4':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.4':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.62.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.62.4':
+    optional: true
+
+  '@shikijs/core@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.5
+      hast-util-to-html: 9.0.5
+
+  '@shikijs/engine-javascript@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
+      oniguruma-to-es: 4.3.6
+
+  '@shikijs/engine-oniguruma@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
+
+  '@shikijs/langs@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+
+  '@shikijs/themes@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+
+  '@shikijs/types@3.23.0':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.5
+
+  '@shikijs/vscode-textmate@10.0.2': {}
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@standard-schema/utils@0.3.0': {}
+
+  '@stardazed/streams-compression@1.0.0':
+    dependencies:
+      '@stardazed/zlib': 1.0.1
+
+  '@stardazed/zlib@1.0.1': {}
+
+  '@storybook/addon-a11y@10.5.7(storybook@10.5.7(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))':
+    dependencies:
+      '@storybook/global': 5.0.0
+      axe-core: 4.13.0
+      storybook: 10.5.7(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8)
+
+  '@storybook/addon-docs@10.5.7(@types/react@19.2.18)(esbuild@0.28.2)(rollup@4.62.4)(storybook@10.5.7(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))':
+    dependencies:
+      '@mdx-js/react': 3.1.1(@types/react@19.2.18)(react@19.2.8)
+      '@storybook/csf-plugin': 10.5.7(esbuild@0.28.2)(rollup@4.62.4)(storybook@10.5.7(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+      '@storybook/icons': 2.1.0(react@19.2.8)
+      '@storybook/react-dom-shim': 10.5.7(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(storybook@10.5.7(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      storybook: 10.5.7(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8)
+      ts-dedent: 2.3.0
+    optionalDependencies:
+      '@types/react': 19.2.18
+    transitivePeerDependencies:
+      - '@types/react-dom'
+      - esbuild
+      - rollup
+      - vite
+      - webpack
+
+  '@storybook/addon-vitest@10.5.7(@vitest/browser-playwright@4.1.10)(@vitest/browser@4.1.10)(@vitest/runner@4.1.10)(react@19.2.8)(storybook@10.5.7(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))(vitest@4.1.10)':
+    dependencies:
+      '@storybook/global': 5.0.0
+      '@storybook/icons': 2.1.0(react@19.2.8)
+      storybook: 10.5.7(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8)
+    optionalDependencies:
+      '@vitest/browser': 4.1.10(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))(vitest@4.1.10)
+      '@vitest/browser-playwright': 4.1.10(playwright@1.62.1)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))(vitest@4.1.10)
+      '@vitest/runner': 4.1.10
+      vitest: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+    transitivePeerDependencies:
+      - react
+
+  '@storybook/builder-vite@10.5.7(esbuild@0.28.2)(rollup@4.62.4)(storybook@10.5.7(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))':
+    dependencies:
+      '@storybook/csf-plugin': 10.5.7(esbuild@0.28.2)(rollup@4.62.4)(storybook@10.5.7(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+      storybook: 10.5.7(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8)
+      ts-dedent: 2.3.0
+      vite: 8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - esbuild
+      - rollup
+      - webpack
+
+  '@storybook/csf-plugin@10.5.7(esbuild@0.28.2)(rollup@4.62.4)(storybook@10.5.7(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))':
+    dependencies:
+      storybook: 10.5.7(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8)
+      unplugin: 2.3.11
+    optionalDependencies:
+      esbuild: 0.28.2
+      rollup: 4.62.4
+      vite: 8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
+
+  '@storybook/global@5.0.0': {}
+
+  '@storybook/icons@2.1.0(react@19.2.8)':
+    dependencies:
+      react: 19.2.8
+
+  '@storybook/react-dom-shim@10.5.7(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(storybook@10.5.7(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))':
+    dependencies:
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      storybook: 10.5.7(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8)
+    optionalDependencies:
+      '@types/react': 19.2.18
+
+  '@tailwindcss/node@4.3.3':
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      enhanced-resolve: 5.24.5
+      jiti: 2.7.0
+      lightningcss: 1.32.0
+      magic-string: 0.30.21
+      source-map-js: 1.2.1
+      tailwindcss: 4.3.3
+
+  '@tailwindcss/oxide-android-arm64@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-arm64@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-x64@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-freebsd-x64@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-musl@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-wasm32-wasi@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide@4.3.3':
+    optionalDependencies:
+      '@tailwindcss/oxide-android-arm64': 4.3.3
+      '@tailwindcss/oxide-darwin-arm64': 4.3.3
+      '@tailwindcss/oxide-darwin-x64': 4.3.3
+      '@tailwindcss/oxide-freebsd-x64': 4.3.3
+      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.3.3
+      '@tailwindcss/oxide-linux-arm64-gnu': 4.3.3
+      '@tailwindcss/oxide-linux-arm64-musl': 4.3.3
+      '@tailwindcss/oxide-linux-x64-gnu': 4.3.3
+      '@tailwindcss/oxide-linux-x64-musl': 4.3.3
+      '@tailwindcss/oxide-wasm32-wasi': 4.3.3
+      '@tailwindcss/oxide-win32-arm64-msvc': 4.3.3
+      '@tailwindcss/oxide-win32-x64-msvc': 4.3.3
+
+  '@tailwindcss/postcss@4.3.3':
+    dependencies:
+      '@alloc/quick-lru': 5.2.0
+      '@tailwindcss/node': 4.3.3
+      '@tailwindcss/oxide': 4.3.3
+      postcss: 8.5.26
+      tailwindcss: 4.3.3
+
+  '@tailwindcss/vite@4.3.3(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))':
+    dependencies:
+      '@tailwindcss/node': 4.3.3
+      '@tailwindcss/oxide': 4.3.3
+      tailwindcss: 4.3.3
+      vite: 8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
+
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/runtime': 7.29.7
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.9.1':
+    dependencies:
+      '@adobe/css-tools': 4.5.0
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/user-event@14.6.4(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+
+  '@tybys/wasm-util@0.10.3':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@types/aria-query@5.0.4': {}
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.29.8
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/debug@4.1.13':
+    dependencies:
+      '@types/ms': 2.1.0
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree-jsx@1.0.5':
+    dependencies:
+      '@types/estree': 1.0.9
+
+  '@types/estree@1.0.9': {}
+
+  '@types/hast@3.0.5':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/mdx@2.0.14': {}
+
+  '@types/ms@2.1.0': {}
+
+  '@types/node@12.20.55': {}
+
+  '@types/node@24.13.3':
+    dependencies:
+      undici-types: 7.18.2
+
+  '@types/picomatch@4.0.3': {}
+
+  '@types/react@19.2.18':
+    dependencies:
+      csstype: 3.2.3
+
+  '@types/unist@2.0.11': {}
+
+  '@types/unist@3.0.3': {}
+
+  '@types/whatwg-mimetype@3.0.2': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 24.13.3
+
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    optional: true
+
+  '@ungap/structured-clone@1.3.3': {}
+
+  '@vitest/browser-playwright@4.1.10(playwright@1.62.1)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))(vitest@4.1.10)':
+    dependencies:
+      '@vitest/browser': 4.1.10(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))(vitest@4.1.10)
+      '@vitest/mocker': 4.1.10(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+      playwright: 1.62.1
+      tinyrainbow: 3.1.1
+      vitest: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+
+  '@vitest/browser@4.1.10(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))(vitest@4.1.10)':
+    dependencies:
+      '@blazediff/core': 1.9.1
+      '@vitest/mocker': 4.1.10(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pngjs: 7.0.0
+      sirv: 3.0.2
+      tinyrainbow: 3.1.1
+      vitest: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+      ws: 8.21.3
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+
+  '@vitest/coverage-istanbul@4.1.10(supports-color@7.2.0)(vitest@4.1.10)':
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@7.2.0)
+      '@istanbuljs/schema': 0.1.6
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.4
+      obug: 2.1.4
+      tinyrainbow: 3.1.1
+      vitest: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+    transitivePeerDependencies:
+      - supports-color
+
+  '@vitest/coverage-v8@4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.1.10
+      ast-v8-to-istanbul: 1.0.5
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.4
+      obug: 2.1.4
+      std-env: 4.2.0
+      tinyrainbow: 3.1.1
+      vitest: 4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+    optionalDependencies:
+      '@vitest/browser': 4.1.10(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))(vitest@4.1.10)
+
+  '@vitest/expect@3.2.4':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/expect@4.1.10':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      chai: 6.2.2
+      tinyrainbow: 3.1.1
+
+  '@vitest/mocker@4.1.10(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
+
+  '@vitest/pretty-format@3.2.4':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/pretty-format@4.1.10':
+    dependencies:
+      tinyrainbow: 3.1.1
+
+  '@vitest/runner@4.1.10':
+    dependencies:
+      '@vitest/utils': 4.1.10
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.4':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/spy@4.1.10': {}
+
+  '@vitest/utils@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
+
+  '@vitest/utils@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.1
+
+  '@webcontainer/env@1.1.1': {}
+
+  '@worker-tools/html-rewriter@0.1.0-pre.19':
+    dependencies:
+      '@stardazed/streams-compression': 1.0.0
+      '@worker-tools/resolvable-promise': 0.2.0-pre.6
+
+  '@worker-tools/resolvable-promise@0.2.0-pre.6': {}
+
+  acorn-jsx@5.3.2(acorn@8.18.0):
+    dependencies:
+      acorn: 8.18.0
+
+  acorn@8.18.0: {}
+
+  ansi-colors@4.1.3: {}
+
+  ansi-regex@5.0.1: {}
+
+  ansi-regex@6.3.0: {}
+
+  ansi-styles@5.2.0: {}
+
+  any-promise@1.3.0: {}
+
+  anymatch@3.1.3:
+    dependencies:
+      normalize-path: 3.0.0
+      picomatch: 2.3.2
+
+  argparse@1.0.10:
+    dependencies:
+      sprintf-js: 1.0.3
+
+  argparse@2.0.1: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
+
+  aria-query@5.3.2: {}
+
+  array-union@2.1.0: {}
+
+  assertion-error@2.0.1: {}
+
+  ast-types@0.16.1:
+    dependencies:
+      tslib: 2.8.1
+
+  ast-v8-to-istanbul@1.0.5:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
+
+  astring@1.9.0: {}
+
+  atomically@2.1.1:
+    dependencies:
+      stubborn-fs: 2.0.0
+      when-exit: 2.1.5
+
+  autoprefixer@10.5.4(postcss@8.5.26):
+    dependencies:
+      browserslist: 4.28.8
+      caniuse-lite: 1.0.30001809
+      fraction.js: 5.3.4
+      picocolors: 1.1.1
+      postcss: 8.5.26
+      postcss-value-parser: 4.2.0
+
+  axe-core@4.13.0: {}
+
+  bail@2.0.2: {}
+
+  baseline-browser-mapping@2.11.13: {}
+
+  better-commits@1.24.0(typescript@7.0.2):
+    dependencies:
+      '@bomb.sh/args': 0.3.1
+      '@clack/core': 1.4.3
+      '@clack/prompts': 1.7.0
+      configstore: 8.0.0
+      jsonc-parser: 3.3.1
+      picocolors: 1.1.1
+      valibot: 1.4.2(typescript@7.0.2)
+    transitivePeerDependencies:
+      - typescript
+
+  better-path-resolve@1.0.0:
+    dependencies:
+      is-windows: 1.0.2
+
+  binary-extensions@2.3.0: {}
+
+  boolbase@1.0.0: {}
+
+  braces@3.0.3:
+    dependencies:
+      fill-range: 7.1.1
+
+  browserslist@4.28.8:
+    dependencies:
+      baseline-browser-mapping: 2.11.13
+      caniuse-lite: 1.0.30001809
+      electron-to-chromium: 1.5.405
+      node-releases: 2.0.53
+      update-browserslist-db: 1.3.1(browserslist@4.28.8)
+
+  buffer-image-size@0.6.4:
+    dependencies:
+      '@types/node': 24.13.3
+
+  bun-types@1.3.14:
+    dependencies:
+      '@types/node': 24.13.3
+
+  bundle-name@4.1.0:
+    dependencies:
+      run-applescript: 7.1.0
+
+  bundle-require@5.1.0(esbuild@0.27.7):
+    dependencies:
+      esbuild: 0.27.7
+      load-tsconfig: 0.2.5
+
+  cac@6.7.14: {}
+
+  caniuse-api@4.0.0:
+    dependencies:
+      browserslist: 4.28.8
+      caniuse-lite: 1.0.30001809
+
+  caniuse-lite@1.0.30001809: {}
+
+  ccount@2.0.1: {}
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
+  chai@6.2.2: {}
+
+  character-entities-html4@2.1.0: {}
+
+  character-entities-legacy@3.0.0: {}
+
+  character-entities@2.0.2: {}
+
+  character-reference-invalid@2.0.1: {}
+
+  chardet@2.2.0: {}
+
+  check-error@2.1.3: {}
+
+  chokidar@3.6.0:
+    dependencies:
+      anymatch: 3.1.3
+      braces: 3.0.3
+      glob-parent: 5.1.2
+      is-binary-path: 2.1.0
+      is-glob: 4.0.3
+      normalize-path: 3.0.0
+      readdirp: 3.6.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
+  chokidar@5.0.0:
+    dependencies:
+      readdirp: 5.1.1
+
+  chromatic@18.2.0:
+    dependencies:
+      semver: 7.8.5
+
+  citty@0.1.6:
+    dependencies:
+      consola: 3.4.2
+
+  citty@0.2.2: {}
+
+  collapse-white-space@2.1.0: {}
+
+  comma-separated-tokens@2.0.3: {}
+
+  commander@11.1.0: {}
+
+  commander@4.1.1: {}
+
+  commander@9.5.0: {}
+
+  confbox@0.1.8: {}
+
+  configstore@8.0.0:
+    dependencies:
+      atomically: 2.1.1
+      dot-prop: 10.2.0
+      graceful-fs: 4.2.11
+      is-safe-filename: 0.1.1
+      xdg-basedir: 5.1.0
+
+  consola@3.4.2: {}
+
+  convert-source-map@2.0.0: {}
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  crossws@0.4.10(srvx@0.11.22):
+    optionalDependencies:
+      srvx: 0.11.22
+
+  css-select@5.2.2:
+    dependencies:
+      boolbase: 1.0.0
+      css-what: 6.2.2
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      nth-check: 2.1.1
+
+  css-tree@2.2.1:
+    dependencies:
+      mdn-data: 2.0.28
+      source-map-js: 1.2.1
+
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
+  css-what@6.2.2: {}
+
+  css.escape@1.5.1: {}
+
+  cssesc@3.0.0: {}
+
+  cssnano-preset-default@8.0.5(postcss@8.5.26):
+    dependencies:
+      browserslist: 4.28.8
+      cssnano-utils: 6.0.3(postcss@8.5.26)
+      postcss: 8.5.26
+      postcss-calc: 10.1.1(postcss@8.5.26)
+      postcss-colormin: 8.0.3(postcss@8.5.26)
+      postcss-convert-values: 8.0.3(postcss@8.5.26)
+      postcss-discard-comments: 8.0.3(postcss@8.5.26)
+      postcss-discard-duplicates: 8.0.3(postcss@8.5.26)
+      postcss-discard-empty: 8.0.3(postcss@8.5.26)
+      postcss-discard-overridden: 8.0.3(postcss@8.5.26)
+      postcss-merge-longhand: 8.0.3(postcss@8.5.26)
+      postcss-merge-rules: 8.0.3(postcss@8.5.26)
+      postcss-minify-font-values: 8.0.3(postcss@8.5.26)
+      postcss-minify-gradients: 8.0.3(postcss@8.5.26)
+      postcss-minify-params: 8.0.3(postcss@8.5.26)
+      postcss-minify-selectors: 8.0.4(postcss@8.5.26)
+      postcss-normalize-charset: 8.0.3(postcss@8.5.26)
+      postcss-normalize-display-values: 8.0.3(postcss@8.5.26)
+      postcss-normalize-positions: 8.0.3(postcss@8.5.26)
+      postcss-normalize-repeat-style: 8.0.3(postcss@8.5.26)
+      postcss-normalize-string: 8.0.3(postcss@8.5.26)
+      postcss-normalize-timing-functions: 8.0.3(postcss@8.5.26)
+      postcss-normalize-unicode: 8.0.3(postcss@8.5.26)
+      postcss-normalize-url: 8.0.3(postcss@8.5.26)
+      postcss-normalize-whitespace: 8.0.3(postcss@8.5.26)
+      postcss-ordered-values: 8.0.3(postcss@8.5.26)
+      postcss-reduce-initial: 8.0.3(postcss@8.5.26)
+      postcss-reduce-transforms: 8.0.3(postcss@8.5.26)
+      postcss-svgo: 8.0.4(postcss@8.5.26)
+      postcss-unique-selectors: 8.0.3(postcss@8.5.26)
+
+  cssnano-utils@6.0.3(postcss@8.5.26):
+    dependencies:
+      postcss: 8.5.26
+
+  cssnano@8.0.5(postcss@8.5.26):
+    dependencies:
+      cssnano-preset-default: 8.0.5(postcss@8.5.26)
+      lilconfig: 3.1.3
+      postcss: 8.5.26
+
+  csso@5.0.5:
+    dependencies:
+      css-tree: 2.2.1
+
+  csstype@3.2.3: {}
+
+  dataloader@1.4.0: {}
+
+  db0@0.3.4: {}
+
+  debug@4.4.3(supports-color@7.2.0):
+    dependencies:
+      ms: 2.1.3
+    optionalDependencies:
+      supports-color: 7.2.0
+
+  decode-named-character-reference@1.3.0:
+    dependencies:
+      character-entities: 2.0.2
+
+  deep-eql@5.0.2: {}
+
+  default-browser-id@5.0.1: {}
+
+  default-browser@5.5.0:
+    dependencies:
+      bundle-name: 4.1.0
+      default-browser-id: 5.0.1
+
+  define-lazy-prop@3.0.0: {}
+
+  defu@6.1.7: {}
+
+  dequal@2.0.3: {}
+
+  detect-indent@6.1.0: {}
+
+  detect-libc@2.1.2: {}
+
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
+
+  dir-glob@3.0.1:
+    dependencies:
+      path-type: 4.0.0
+
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
+
+  dom-serializer@2.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+
+  domelementtype@2.3.0: {}
+
+  domhandler@5.0.3:
+    dependencies:
+      domelementtype: 2.3.0
+
+  domutils@3.2.2:
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+
+  dot-prop@10.2.0:
+    dependencies:
+      type-fest: 5.8.0
+
+  dotenv@8.6.0: {}
+
+  ecopages@0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(bun-types@1.3.14)(typescript@7.0.2):
+    dependencies:
+      '@ecopages/core': 0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(typescript@7.0.2)
+      '@ecopages/logger': 0.2.3(typescript@7.0.2)
+      bun-types: 1.3.14
+      giget: 2.0.0
+      tsx: 4.23.12
+      typescript: 7.0.2
+    transitivePeerDependencies:
+      - '@ecopages/dev-toolbar'
+      - bufferutil
+      - utf-8-validate
+
+  electron-to-chromium@1.5.405: {}
+
+  enhanced-resolve@5.24.5:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.3.3
+
+  enquirer@2.4.1:
+    dependencies:
+      ansi-colors: 4.1.3
+      strip-ansi: 6.0.1
+
+  entities@4.5.0: {}
+
+  entities@6.0.1: {}
+
+  entities@7.0.1: {}
+
+  env-runner@0.1.16:
+    dependencies:
+      crossws: 0.4.10(srvx@0.11.22)
+      exsolve: 1.1.1
+      httpxy: 0.5.5
+      srvx: 0.11.22
+
+  es-errors@1.3.0: {}
+
+  es-module-lexer@2.3.1: {}
+
+  esast-util-from-estree@2.0.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      devlop: 1.1.0
+      estree-util-visit: 2.0.0
+      unist-util-position-from-estree: 2.0.0
+
+  esast-util-from-js@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      acorn: 8.18.0
+      esast-util-from-estree: 2.0.0
+      vfile-message: 4.0.3
+
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
+
+  esbuild@0.28.2:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.2
+      '@esbuild/android-arm': 0.28.2
+      '@esbuild/android-arm64': 0.28.2
+      '@esbuild/android-x64': 0.28.2
+      '@esbuild/darwin-arm64': 0.28.2
+      '@esbuild/darwin-x64': 0.28.2
+      '@esbuild/freebsd-arm64': 0.28.2
+      '@esbuild/freebsd-x64': 0.28.2
+      '@esbuild/linux-arm': 0.28.2
+      '@esbuild/linux-arm64': 0.28.2
+      '@esbuild/linux-ia32': 0.28.2
+      '@esbuild/linux-loong64': 0.28.2
+      '@esbuild/linux-mips64el': 0.28.2
+      '@esbuild/linux-ppc64': 0.28.2
+      '@esbuild/linux-riscv64': 0.28.2
+      '@esbuild/linux-s390x': 0.28.2
+      '@esbuild/linux-x64': 0.28.2
+      '@esbuild/netbsd-arm64': 0.28.2
+      '@esbuild/netbsd-x64': 0.28.2
+      '@esbuild/openbsd-arm64': 0.28.2
+      '@esbuild/openbsd-x64': 0.28.2
+      '@esbuild/openharmony-arm64': 0.28.2
+      '@esbuild/sunos-x64': 0.28.2
+      '@esbuild/win32-arm64': 0.28.2
+      '@esbuild/win32-ia32': 0.28.2
+      '@esbuild/win32-x64': 0.28.2
+
+  escalade@3.2.0: {}
+
+  escape-string-regexp@5.0.0: {}
+
+  esprima@4.0.1: {}
+
+  estree-util-attach-comments@3.0.0:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  estree-util-build-jsx@3.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      estree-walker: 3.0.3
+
+  estree-util-is-identifier-name@3.0.0: {}
+
+  estree-util-scope@1.0.0:
+    dependencies:
+      '@types/estree': 1.0.9
+      devlop: 1.1.0
+
+  estree-util-to-js@2.0.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      astring: 1.9.0
+      source-map: 0.7.6
+
+  estree-util-visit@2.0.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/unist': 3.0.3
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  expect-type@1.4.0: {}
+
+  exsolve@1.1.1: {}
+
+  extend@3.0.2: {}
+
+  extendable-error@0.1.7: {}
+
+  fast-glob@3.3.3:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.8
+
+  fast-string-truncated-width@3.0.3: {}
+
+  fast-string-width@3.0.2:
+    dependencies:
+      fast-string-truncated-width: 3.0.3
+
+  fast-wrap-ansi@0.2.2:
+    dependencies:
+      fast-string-width: 3.0.2
+
+  fastq@1.20.1:
+    dependencies:
+      reusify: 1.1.0
+
+  fault@2.0.1:
+    dependencies:
+      format: 0.2.2
+
+  fdir@6.5.0(picomatch@4.0.5):
+    optionalDependencies:
+      picomatch: 4.0.5
+
+  fill-range@7.1.1:
+    dependencies:
+      to-regex-range: 5.0.1
+
+  find-up@4.1.0:
+    dependencies:
+      locate-path: 5.0.0
+      path-exists: 4.0.0
+
+  fix-dts-default-cjs-exports@1.0.1:
+    dependencies:
+      magic-string: 0.30.21
+      mlly: 1.8.2
+      rollup: 4.62.4
+
+  format@0.2.2: {}
+
+  fraction.js@5.3.4: {}
+
+  fs-extra@7.0.1:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 4.0.0
+      universalify: 0.1.2
+
+  fs-extra@8.1.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 4.0.0
+      universalify: 0.1.2
+
+  fsevents@2.3.2:
+    optional: true
+
+  fsevents@2.3.3:
+    optional: true
+
+  function-bind@1.1.2: {}
+
+  gensync@1.0.0-beta.2: {}
+
+  ghtml@4.0.2: {}
+
+  giget@2.0.0:
+    dependencies:
+      citty: 0.1.6
+      consola: 3.4.2
+      defu: 6.1.7
+      node-fetch-native: 1.6.7
+      nypm: 0.6.9
+      pathe: 2.0.3
+
+  glob-parent@5.1.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  globby@11.1.0:
+    dependencies:
+      array-union: 2.1.0
+      dir-glob: 3.0.1
+      fast-glob: 3.3.3
+      ignore: 5.3.2
+      merge2: 1.4.1
+      slash: 3.0.0
+
+  graceful-fs@4.2.11: {}
+
+  h3@2.0.1-rc.26(crossws@0.4.10(srvx@0.11.22)):
+    dependencies:
+      rou3: 0.9.2
+      srvx: 0.12.5
+    optionalDependencies:
+      crossws: 0.4.10(srvx@0.11.22)
+
+  happy-dom@20.11.2:
+    dependencies:
+      '@types/node': 24.13.3
+      '@types/whatwg-mimetype': 3.0.2
+      '@types/ws': 8.18.1
+      buffer-image-size: 0.6.4
+      entities: 7.0.1
+      whatwg-mimetype: 3.0.0
+      ws: 8.21.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  has-flag@4.0.0: {}
+
+  hasown@2.0.4:
+    dependencies:
+      function-bind: 1.1.2
+
+  hast-util-from-html@2.0.3:
+    dependencies:
+      '@types/hast': 3.0.5
+      devlop: 1.1.0
+      hast-util-from-parse5: 8.0.3
+      parse5: 7.3.0
+      vfile: 6.0.3
+      vfile-message: 4.0.3
+
+  hast-util-from-parse5@8.0.3:
+    dependencies:
+      '@types/hast': 3.0.5
+      '@types/unist': 3.0.3
+      devlop: 1.1.0
+      hastscript: 9.0.1
+      property-information: 7.2.0
+      vfile: 6.0.3
+      vfile-location: 5.0.3
+      web-namespaces: 2.0.1
+
+  hast-util-parse-selector@4.0.0:
+    dependencies:
+      '@types/hast': 3.0.5
+
+  hast-util-to-estree@3.1.3(supports-color@7.2.0):
+    dependencies:
+      '@types/estree': 1.0.9
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.5
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      estree-util-attach-comments: 3.0.0
+      estree-util-is-identifier-name: 3.0.0
+      hast-util-whitespace: 3.0.0
+      mdast-util-mdx-expression: 2.0.1(supports-color@7.2.0)
+      mdast-util-mdx-jsx: 3.2.0(supports-color@7.2.0)
+      mdast-util-mdxjs-esm: 2.0.1(supports-color@7.2.0)
+      property-information: 7.2.0
+      space-separated-tokens: 2.0.2
+      style-to-js: 1.1.21
+      unist-util-position: 5.0.0
+      zwitch: 2.0.4
+    transitivePeerDependencies:
+      - supports-color
+
+  hast-util-to-html@9.0.5:
+    dependencies:
+      '@types/hast': 3.0.5
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      comma-separated-tokens: 2.0.3
+      hast-util-whitespace: 3.0.0
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.1
+      property-information: 7.2.0
+      space-separated-tokens: 2.0.2
+      stringify-entities: 4.0.4
+      zwitch: 2.0.4
+
+  hast-util-to-jsx-runtime@2.3.6(supports-color@7.2.0):
+    dependencies:
+      '@types/estree': 1.0.9
+      '@types/hast': 3.0.5
+      '@types/unist': 3.0.3
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      hast-util-whitespace: 3.0.0
+      mdast-util-mdx-expression: 2.0.1(supports-color@7.2.0)
+      mdast-util-mdx-jsx: 3.2.0(supports-color@7.2.0)
+      mdast-util-mdxjs-esm: 2.0.1(supports-color@7.2.0)
+      property-information: 7.2.0
+      space-separated-tokens: 2.0.2
+      style-to-js: 1.1.21
+      unist-util-position: 5.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  hast-util-to-string@3.0.1:
+    dependencies:
+      '@types/hast': 3.0.5
+
+  hast-util-whitespace@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.5
+
+  hastscript@9.0.1:
+    dependencies:
+      '@types/hast': 3.0.5
+      comma-separated-tokens: 2.0.3
+      hast-util-parse-selector: 4.0.0
+      property-information: 7.2.0
+      space-separated-tokens: 2.0.2
+
+  hookable@6.1.1: {}
+
+  html-escaper@2.0.2: {}
+
+  html-void-elements@3.0.0: {}
+
+  httpxy@0.5.5: {}
+
+  human-id@4.2.0: {}
+
+  iconv-lite@0.7.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  ignore@5.3.2: {}
+
+  indent-string@4.0.0: {}
+
+  inline-style-parser@0.2.7: {}
+
+  is-alphabetical@2.0.1: {}
+
+  is-alphanumerical@2.0.1:
+    dependencies:
+      is-alphabetical: 2.0.1
+      is-decimal: 2.0.1
+
+  is-binary-path@2.1.0:
+    dependencies:
+      binary-extensions: 2.3.0
+
+  is-core-module@2.16.2:
+    dependencies:
+      hasown: 2.0.4
+
+  is-decimal@2.0.1: {}
+
+  is-docker@3.0.0: {}
+
+  is-extglob@2.1.1: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
+  is-hexadecimal@2.0.1: {}
+
+  is-inside-container@1.0.0:
+    dependencies:
+      is-docker: 3.0.0
+
+  is-number@7.0.0: {}
+
+  is-plain-obj@4.1.0: {}
+
+  is-safe-filename@0.1.1: {}
+
+  is-subdir@1.2.0:
+    dependencies:
+      better-path-resolve: 1.0.0
+
+  is-windows@1.0.2: {}
+
+  is-wsl@3.1.1:
+    dependencies:
+      is-inside-container: 1.0.0
+
+  isexe@2.0.0: {}
+
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
+  jiti@2.7.0: {}
+
+  joycon@3.1.1: {}
+
+  js-tokens@10.0.0: {}
+
+  js-tokens@4.0.0: {}
+
+  js-yaml@3.15.1:
+    dependencies:
+      argparse: 1.0.10
+      esprima: 4.0.1
+
+  js-yaml@4.3.1:
+    dependencies:
+      argparse: 2.0.1
+
+  jsesc@3.1.0: {}
+
+  json5@2.2.3: {}
+
+  jsonc-parser@3.3.1: {}
+
+  jsonfile@4.0.0:
+    optionalDependencies:
+      graceful-fs: 4.2.11
+
+  jsonfile@6.2.1:
+    dependencies:
+      universalify: 2.0.1
+    optionalDependencies:
+      graceful-fs: 4.2.11
+
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-android-arm64@1.33.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.33.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.33.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.33.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.33.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.33.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.33.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.33.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.33.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.33.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
+  lightningcss@1.33.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.33.0
+      lightningcss-darwin-arm64: 1.33.0
+      lightningcss-darwin-x64: 1.33.0
+      lightningcss-freebsd-x64: 1.33.0
+      lightningcss-linux-arm-gnueabihf: 1.33.0
+      lightningcss-linux-arm64-gnu: 1.33.0
+      lightningcss-linux-arm64-musl: 1.33.0
+      lightningcss-linux-x64-gnu: 1.33.0
+      lightningcss-linux-x64-musl: 1.33.0
+      lightningcss-win32-arm64-msvc: 1.33.0
+      lightningcss-win32-x64-msvc: 1.33.0
+
+  lilconfig@3.1.3: {}
+
+  lines-and-columns@1.2.4: {}
+
+  load-tsconfig@0.2.5: {}
+
+  locate-path@5.0.0:
+    dependencies:
+      p-locate: 4.1.0
+
+  lodash.startcase@4.4.0: {}
+
+  longest-streak@3.1.0: {}
+
+  loupe@3.2.1: {}
+
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
+
+  lz-string@1.5.0: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.5.4:
+    dependencies:
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.8.5
+
+  markdown-extensions@2.0.0: {}
+
+  markdown-table@3.0.4: {}
+
+  mdast-util-find-and-replace@3.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      escape-string-regexp: 5.0.0
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
+  mdast-util-from-markdown@2.0.3(supports-color@7.2.0):
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      mdast-util-to-string: 4.0.0
+      micromark: 4.0.2(supports-color@7.2.0)
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-decode-string: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-frontmatter@2.0.1(supports-color@7.2.0):
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      escape-string-regexp: 5.0.0
+      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
+      mdast-util-to-markdown: 2.1.2
+      micromark-extension-frontmatter: 2.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-find-and-replace: 3.0.2
+      micromark-util-character: 2.1.1
+
+  mdast-util-gfm-footnote@2.1.0(supports-color@7.2.0):
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
+      mdast-util-to-markdown: 2.1.2
+      micromark-util-normalize-identifier: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-strikethrough@2.0.0(supports-color@7.2.0):
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-table@2.0.0(supports-color@7.2.0):
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      markdown-table: 3.0.4
+      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-task-list-item@2.0.0(supports-color@7.2.0):
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm@3.1.0(supports-color@7.2.0):
+    dependencies:
+      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
+      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-footnote: 2.1.0(supports-color@7.2.0)
+      mdast-util-gfm-strikethrough: 2.0.0(supports-color@7.2.0)
+      mdast-util-gfm-table: 2.0.0(supports-color@7.2.0)
+      mdast-util-gfm-task-list-item: 2.0.0(supports-color@7.2.0)
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-expression@2.0.1(supports-color@7.2.0):
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-jsx@3.2.0(supports-color@7.2.0):
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
+      mdast-util-to-markdown: 2.1.2
+      parse-entities: 4.0.2
+      stringify-entities: 4.0.4
+      unist-util-stringify-position: 4.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx@3.0.0(supports-color@7.2.0):
+    dependencies:
+      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
+      mdast-util-mdx-expression: 2.0.1(supports-color@7.2.0)
+      mdast-util-mdx-jsx: 3.2.0(supports-color@7.2.0)
+      mdast-util-mdxjs-esm: 2.0.1(supports-color@7.2.0)
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdxjs-esm@2.0.1(supports-color@7.2.0):
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-phrasing@4.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      unist-util-is: 6.0.1
+
+  mdast-util-to-hast@13.2.1:
+    dependencies:
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.3
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.1
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+
+  mdast-util-to-markdown@2.1.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      longest-streak: 3.1.0
+      mdast-util-phrasing: 4.1.0
+      mdast-util-to-string: 4.0.0
+      micromark-util-classify-character: 2.0.1
+      micromark-util-decode-string: 2.0.1
+      unist-util-visit: 5.1.0
+      zwitch: 2.0.4
+
+  mdast-util-to-string@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+
+  mdn-data@2.0.28: {}
+
+  mdn-data@2.27.1: {}
+
+  merge2@1.4.1: {}
+
+  micromark-core-commonmark@2.0.3:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-factory-destination: 2.0.1
+      micromark-factory-label: 2.0.1
+      micromark-factory-space: 2.0.1
+      micromark-factory-title: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-html-tag-name: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-frontmatter@2.0.0:
+    dependencies:
+      fault: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-footnote@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-table@2.1.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm@3.0.0:
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-strikethrough: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-gfm-tagfilter: 2.0.0
+      micromark-extension-gfm-task-list-item: 2.1.0
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-mdx-expression@3.0.1:
+    dependencies:
+      '@types/estree': 1.0.9
+      devlop: 1.1.0
+      micromark-factory-mdx-expression: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-mdx-jsx@3.0.2:
+    dependencies:
+      '@types/estree': 1.0.9
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      micromark-factory-mdx-expression: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      vfile-message: 4.0.3
+
+  micromark-extension-mdx-md@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-mdxjs-esm@3.0.0:
+    dependencies:
+      '@types/estree': 1.0.9
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-position-from-estree: 2.0.0
+      vfile-message: 4.0.3
+
+  micromark-extension-mdxjs@3.0.0:
+    dependencies:
+      acorn: 8.18.0
+      acorn-jsx: 5.3.2(acorn@8.18.0)
+      micromark-extension-mdx-expression: 3.0.1
+      micromark-extension-mdx-jsx: 3.0.2
+      micromark-extension-mdx-md: 2.0.0
+      micromark-extension-mdxjs-esm: 3.0.0
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-destination@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-label@2.0.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-mdx-expression@2.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-events-to-acorn: 2.0.3
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-position-from-estree: 2.0.0
+      vfile-message: 4.0.3
+
+  micromark-factory-space@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-title@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-whitespace@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-chunked@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-classify-character@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-combine-extensions@2.0.1:
+    dependencies:
+      micromark-util-chunked: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-decode-string@2.0.1:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      micromark-util-character: 2.1.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-events-to-acorn@2.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+      '@types/unist': 3.0.3
+      devlop: 1.1.0
+      estree-util-visit: 2.0.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      vfile-message: 4.0.3
+
+  micromark-util-html-tag-name@2.0.1: {}
+
+  micromark-util-normalize-identifier@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-resolve-all@2.0.1:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-subtokenize@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
+
+  micromark@4.0.2(supports-color@7.2.0):
+    dependencies:
+      '@types/debug': 4.1.13
+      debug: 4.4.3(supports-color@7.2.0)
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-encode: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  micromatch@4.0.8:
+    dependencies:
+      braces: 3.0.3
+      picomatch: 2.3.2
+
+  min-indent@1.0.1: {}
+
+  mitata@1.0.34: {}
+
+  mlly@1.8.2:
+    dependencies:
+      acorn: 8.18.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.4
+
+  morphdom@2.7.8: {}
+
+  mri@1.2.0: {}
+
+  mrmime@2.0.1: {}
+
+  ms@2.1.3: {}
+
+  mylas@2.1.14: {}
+
+  mz@2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
+
+  nanoid@3.3.18: {}
+
+  nf3@0.3.23: {}
+
+  nitro@3.0.260311-beta(chokidar@5.0.0)(dotenv@8.6.0)(giget@2.0.0)(jiti@2.7.0)(rollup@4.62.4)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)):
+    dependencies:
+      consola: 3.4.2
+      crossws: 0.4.10(srvx@0.11.22)
+      db0: 0.3.4
+      env-runner: 0.1.16
+      h3: 2.0.1-rc.26(crossws@0.4.10(srvx@0.11.22))
+      hookable: 6.1.1
+      nf3: 0.3.23
+      ocache: 0.1.5
+      ofetch: 2.0.0-alpha.3
+      ohash: 2.0.11
+      rolldown: 1.2.4
+      srvx: 0.11.22
+      unenv: 2.0.0-rc.24
+      unstorage: 2.0.0-alpha.7(chokidar@5.0.0)(db0@0.3.4)(ofetch@2.0.0-alpha.3)
+    optionalDependencies:
+      dotenv: 8.6.0
+      giget: 2.0.0
+      jiti: 2.7.0
+      rollup: 4.62.4
+      vite: 8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@electric-sql/pglite'
+      - '@libsql/client'
+      - '@netlify/blobs'
+      - '@netlify/runtime'
+      - '@planetscale/database'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - '@vercel/queue'
+      - aws4fetch
+      - better-sqlite3
+      - chokidar
+      - drizzle-orm
+      - idb-keyval
+      - ioredis
+      - lru-cache
+      - miniflare
+      - mongodb
+      - mysql2
+      - sqlite3
+      - uploadthing
+      - wrangler
+
+  node-fetch-native@1.6.7: {}
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+
+  node-releases@2.0.53: {}
+
+  normalize-path@3.0.0: {}
+
+  nth-check@2.1.1:
+    dependencies:
+      boolbase: 1.0.0
+
+  nypm@0.6.9:
+    dependencies:
+      citty: 0.2.2
+      pathe: 2.0.3
+      tinyexec: 1.3.0
+
+  object-assign@4.1.1: {}
+
+  obug@2.1.4: {}
+
+  ocache@0.1.5:
+    dependencies:
+      ohash: 2.0.11
+
+  ofetch@2.0.0-alpha.3: {}
+
+  ohash@2.0.11: {}
+
+  oniguruma-parser@0.12.2: {}
+
+  oniguruma-to-es@4.3.6:
+    dependencies:
+      oniguruma-parser: 0.12.2
+      regex: 6.1.0
+      regex-recursion: 6.0.2
+
+  open@10.2.0:
+    dependencies:
+      default-browser: 5.5.0
+      define-lazy-prop: 3.0.0
+      is-inside-container: 1.0.0
+      wsl-utils: 0.1.0
+
+  outdent@0.5.0: {}
+
+  oxc-parser@0.127.0:
+    dependencies:
+      '@oxc-project/types': 0.127.0
+    optionalDependencies:
+      '@oxc-parser/binding-android-arm-eabi': 0.127.0
+      '@oxc-parser/binding-android-arm64': 0.127.0
+      '@oxc-parser/binding-darwin-arm64': 0.127.0
+      '@oxc-parser/binding-darwin-x64': 0.127.0
+      '@oxc-parser/binding-freebsd-x64': 0.127.0
+      '@oxc-parser/binding-linux-arm-gnueabihf': 0.127.0
+      '@oxc-parser/binding-linux-arm-musleabihf': 0.127.0
+      '@oxc-parser/binding-linux-arm64-gnu': 0.127.0
+      '@oxc-parser/binding-linux-arm64-musl': 0.127.0
+      '@oxc-parser/binding-linux-ppc64-gnu': 0.127.0
+      '@oxc-parser/binding-linux-riscv64-gnu': 0.127.0
+      '@oxc-parser/binding-linux-riscv64-musl': 0.127.0
+      '@oxc-parser/binding-linux-s390x-gnu': 0.127.0
+      '@oxc-parser/binding-linux-x64-gnu': 0.127.0
+      '@oxc-parser/binding-linux-x64-musl': 0.127.0
+      '@oxc-parser/binding-openharmony-arm64': 0.127.0
+      '@oxc-parser/binding-wasm32-wasi': 0.127.0
+      '@oxc-parser/binding-win32-arm64-msvc': 0.127.0
+      '@oxc-parser/binding-win32-ia32-msvc': 0.127.0
+      '@oxc-parser/binding-win32-x64-msvc': 0.127.0
+
+  oxc-parser@0.141.0:
+    dependencies:
+      '@oxc-project/types': 0.141.0
+    optionalDependencies:
+      '@oxc-parser/binding-android-arm-eabi': 0.141.0
+      '@oxc-parser/binding-android-arm64': 0.141.0
+      '@oxc-parser/binding-darwin-arm64': 0.141.0
+      '@oxc-parser/binding-darwin-x64': 0.141.0
+      '@oxc-parser/binding-freebsd-x64': 0.141.0
+      '@oxc-parser/binding-linux-arm-gnueabihf': 0.141.0
+      '@oxc-parser/binding-linux-arm-musleabihf': 0.141.0
+      '@oxc-parser/binding-linux-arm64-gnu': 0.141.0
+      '@oxc-parser/binding-linux-arm64-musl': 0.141.0
+      '@oxc-parser/binding-linux-ppc64-gnu': 0.141.0
+      '@oxc-parser/binding-linux-riscv64-gnu': 0.141.0
+      '@oxc-parser/binding-linux-riscv64-musl': 0.141.0
+      '@oxc-parser/binding-linux-s390x-gnu': 0.141.0
+      '@oxc-parser/binding-linux-x64-gnu': 0.141.0
+      '@oxc-parser/binding-linux-x64-musl': 0.141.0
+      '@oxc-parser/binding-openharmony-arm64': 0.141.0
+      '@oxc-parser/binding-wasm32-wasi': 0.141.0
+      '@oxc-parser/binding-win32-arm64-msvc': 0.141.0
+      '@oxc-parser/binding-win32-ia32-msvc': 0.141.0
+      '@oxc-parser/binding-win32-x64-msvc': 0.141.0
+
+  oxc-resolver@11.24.2:
+    optionalDependencies:
+      '@oxc-resolver/binding-android-arm-eabi': 11.24.2
+      '@oxc-resolver/binding-android-arm64': 11.24.2
+      '@oxc-resolver/binding-darwin-arm64': 11.24.2
+      '@oxc-resolver/binding-darwin-x64': 11.24.2
+      '@oxc-resolver/binding-freebsd-x64': 11.24.2
+      '@oxc-resolver/binding-linux-arm-gnueabihf': 11.24.2
+      '@oxc-resolver/binding-linux-arm-musleabihf': 11.24.2
+      '@oxc-resolver/binding-linux-arm64-gnu': 11.24.2
+      '@oxc-resolver/binding-linux-arm64-musl': 11.24.2
+      '@oxc-resolver/binding-linux-ppc64-gnu': 11.24.2
+      '@oxc-resolver/binding-linux-riscv64-gnu': 11.24.2
+      '@oxc-resolver/binding-linux-riscv64-musl': 11.24.2
+      '@oxc-resolver/binding-linux-s390x-gnu': 11.24.2
+      '@oxc-resolver/binding-linux-x64-gnu': 11.24.2
+      '@oxc-resolver/binding-linux-x64-musl': 11.24.2
+      '@oxc-resolver/binding-openharmony-arm64': 11.24.2
+      '@oxc-resolver/binding-wasm32-wasi': 11.24.2
+      '@oxc-resolver/binding-win32-arm64-msvc': 11.24.2
+      '@oxc-resolver/binding-win32-x64-msvc': 11.24.2
+
+  oxlint@1.78.0:
+    optionalDependencies:
+      '@oxlint/binding-android-arm-eabi': 1.78.0
+      '@oxlint/binding-android-arm64': 1.78.0
+      '@oxlint/binding-darwin-arm64': 1.78.0
+      '@oxlint/binding-darwin-x64': 1.78.0
+      '@oxlint/binding-freebsd-x64': 1.78.0
+      '@oxlint/binding-linux-arm-gnueabihf': 1.78.0
+      '@oxlint/binding-linux-arm-musleabihf': 1.78.0
+      '@oxlint/binding-linux-arm64-gnu': 1.78.0
+      '@oxlint/binding-linux-arm64-musl': 1.78.0
+      '@oxlint/binding-linux-ppc64-gnu': 1.78.0
+      '@oxlint/binding-linux-riscv64-gnu': 1.78.0
+      '@oxlint/binding-linux-riscv64-musl': 1.78.0
+      '@oxlint/binding-linux-s390x-gnu': 1.78.0
+      '@oxlint/binding-linux-x64-gnu': 1.78.0
+      '@oxlint/binding-linux-x64-musl': 1.78.0
+      '@oxlint/binding-openharmony-arm64': 1.78.0
+      '@oxlint/binding-win32-arm64-msvc': 1.78.0
+      '@oxlint/binding-win32-ia32-msvc': 1.78.0
+      '@oxlint/binding-win32-x64-msvc': 1.78.0
+
+  p-filter@2.1.0:
+    dependencies:
+      p-map: 2.1.0
+
+  p-limit@2.3.0:
+    dependencies:
+      p-try: 2.2.0
+
+  p-locate@4.1.0:
+    dependencies:
+      p-limit: 2.3.0
+
+  p-map@2.1.0: {}
+
+  p-try@2.2.0: {}
+
+  package-manager-detector@0.2.11:
+    dependencies:
+      quansync: 0.2.11
+
+  parse-entities@4.0.2:
+    dependencies:
+      '@types/unist': 2.0.11
+      character-entities-legacy: 3.0.0
+      character-reference-invalid: 2.0.1
+      decode-named-character-reference: 1.3.0
+      is-alphanumerical: 2.0.1
+      is-decimal: 2.0.1
+      is-hexadecimal: 2.0.1
+
+  parse-numeric-range@1.3.0: {}
+
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
+
+  path-exists@4.0.0: {}
+
+  path-key@3.1.1: {}
+
+  path-parse@1.0.7: {}
+
+  path-type@4.0.0: {}
+
+  pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@2.3.2: {}
+
+  picomatch@4.0.5: {}
+
+  pify@2.3.0: {}
+
+  pify@4.0.1: {}
+
+  pirates@4.0.7: {}
+
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.2
+      pathe: 2.0.3
+
+  playwright-core@1.62.1: {}
+
+  playwright@1.62.1:
+    dependencies:
+      playwright-core: 1.62.1
+    optionalDependencies:
+      fsevents: 2.3.2
+
+  plimit-lit@1.6.1:
+    dependencies:
+      queue-lit: 1.5.2
+
+  pngjs@7.0.0: {}
+
+  postcss-calc@10.1.1(postcss@8.5.26):
+    dependencies:
+      postcss: 8.5.26
+      postcss-selector-parser: 7.1.5
+      postcss-value-parser: 4.2.0
+
+  postcss-colormin@8.0.3(postcss@8.5.26):
+    dependencies:
+      '@colordx/core': 5.5.0
+      browserslist: 4.28.8
+      caniuse-api: 4.0.0
+      postcss: 8.5.26
+      postcss-value-parser: 4.2.0
+
+  postcss-convert-values@8.0.3(postcss@8.5.26):
+    dependencies:
+      browserslist: 4.28.8
+      postcss: 8.5.26
+      postcss-value-parser: 4.2.0
+
+  postcss-discard-comments@8.0.3(postcss@8.5.26):
+    dependencies:
+      postcss: 8.5.26
+      postcss-selector-parser: 7.1.5
+
+  postcss-discard-duplicates@8.0.3(postcss@8.5.26):
+    dependencies:
+      postcss: 8.5.26
+
+  postcss-discard-empty@8.0.3(postcss@8.5.26):
+    dependencies:
+      postcss: 8.5.26
+
+  postcss-discard-overridden@8.0.3(postcss@8.5.26):
+    dependencies:
+      postcss: 8.5.26
+
+  postcss-import@16.2.0(postcss@8.5.26):
+    dependencies:
+      postcss: 8.5.26
+      postcss-value-parser: 4.2.0
+      read-cache: 1.0.0
+      resolve: 1.22.12
+
+  postcss-load-config@6.0.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.12)(yaml@2.9.0):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      jiti: 2.7.0
+      postcss: 8.5.26
+      tsx: 4.23.12
+      yaml: 2.9.0
+
+  postcss-merge-longhand@8.0.3(postcss@8.5.26):
+    dependencies:
+      postcss: 8.5.26
+      postcss-value-parser: 4.2.0
+      stylehacks: 8.0.3(postcss@8.5.26)
+
+  postcss-merge-rules@8.0.3(postcss@8.5.26):
+    dependencies:
+      browserslist: 4.28.8
+      caniuse-api: 4.0.0
+      cssnano-utils: 6.0.3(postcss@8.5.26)
+      postcss: 8.5.26
+      postcss-selector-parser: 7.1.5
+
+  postcss-minify-font-values@8.0.3(postcss@8.5.26):
+    dependencies:
+      postcss: 8.5.26
+      postcss-value-parser: 4.2.0
+
+  postcss-minify-gradients@8.0.3(postcss@8.5.26):
+    dependencies:
+      '@colordx/core': 5.5.0
+      cssnano-utils: 6.0.3(postcss@8.5.26)
+      postcss: 8.5.26
+      postcss-value-parser: 4.2.0
+
+  postcss-minify-params@8.0.3(postcss@8.5.26):
+    dependencies:
+      browserslist: 4.28.8
+      cssnano-utils: 6.0.3(postcss@8.5.26)
+      postcss: 8.5.26
+      postcss-value-parser: 4.2.0
+
+  postcss-minify-selectors@8.0.4(postcss@8.5.26):
+    dependencies:
+      browserslist: 4.28.8
+      caniuse-api: 4.0.0
+      cssesc: 3.0.0
+      postcss: 8.5.26
+      postcss-selector-parser: 7.1.5
+
+  postcss-nested@8.0.1(postcss@8.5.26):
+    dependencies:
+      postcss: 8.5.26
+      postcss-selector-parser: 7.1.5
+
+  postcss-normalize-charset@8.0.3(postcss@8.5.26):
+    dependencies:
+      postcss: 8.5.26
+
+  postcss-normalize-display-values@8.0.3(postcss@8.5.26):
+    dependencies:
+      postcss: 8.5.26
+      postcss-value-parser: 4.2.0
+
+  postcss-normalize-positions@8.0.3(postcss@8.5.26):
+    dependencies:
+      postcss: 8.5.26
+      postcss-value-parser: 4.2.0
+
+  postcss-normalize-repeat-style@8.0.3(postcss@8.5.26):
+    dependencies:
+      postcss: 8.5.26
+      postcss-value-parser: 4.2.0
+
+  postcss-normalize-string@8.0.3(postcss@8.5.26):
+    dependencies:
+      postcss: 8.5.26
+      postcss-value-parser: 4.2.0
+
+  postcss-normalize-timing-functions@8.0.3(postcss@8.5.26):
+    dependencies:
+      postcss: 8.5.26
+      postcss-value-parser: 4.2.0
+
+  postcss-normalize-unicode@8.0.3(postcss@8.5.26):
+    dependencies:
+      browserslist: 4.28.8
+      postcss: 8.5.26
+      postcss-value-parser: 4.2.0
+
+  postcss-normalize-url@8.0.3(postcss@8.5.26):
+    dependencies:
+      postcss: 8.5.26
+      postcss-value-parser: 4.2.0
+
+  postcss-normalize-whitespace@8.0.3(postcss@8.5.26):
+    dependencies:
+      postcss: 8.5.26
+      postcss-value-parser: 4.2.0
+
+  postcss-ordered-values@8.0.3(postcss@8.5.26):
+    dependencies:
+      cssnano-utils: 6.0.3(postcss@8.5.26)
+      postcss: 8.5.26
+      postcss-value-parser: 4.2.0
+
+  postcss-reduce-initial@8.0.3(postcss@8.5.26):
+    dependencies:
+      browserslist: 4.28.8
+      caniuse-api: 4.0.0
+      postcss: 8.5.26
+
+  postcss-reduce-transforms@8.0.3(postcss@8.5.26):
+    dependencies:
+      postcss: 8.5.26
+      postcss-value-parser: 4.2.0
+
+  postcss-selector-parser@7.1.5:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
+
+  postcss-svgo@8.0.4(postcss@8.5.26):
+    dependencies:
+      postcss: 8.5.26
+      postcss-value-parser: 4.2.0
+      svgo: 4.0.2
+
+  postcss-unique-selectors@8.0.3(postcss@8.5.26):
+    dependencies:
+      postcss: 8.5.26
+      postcss-selector-parser: 7.1.5
+
+  postcss-value-parser@4.2.0: {}
+
+  postcss@8.5.26:
+    dependencies:
+      nanoid: 3.3.18
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  prettier@2.8.8: {}
+
+  prettier@3.9.6: {}
+
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
+  property-information@7.2.0: {}
+
+  quansync@0.2.11: {}
+
+  queue-lit@1.5.2: {}
+
+  queue-microtask@1.2.3: {}
+
+  react-dom@19.2.8(react@19.2.8):
+    dependencies:
+      react: 19.2.8
+      scheduler: 0.27.0
+
+  react-is@17.0.2: {}
+
+  react@19.2.8: {}
+
+  read-cache@1.0.0:
+    dependencies:
+      pify: 2.3.0
+
+  read-yaml-file@1.1.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      js-yaml: 3.15.1
+      pify: 4.0.1
+      strip-bom: 3.0.0
+
+  readdirp@3.6.0:
+    dependencies:
+      picomatch: 2.3.2
+
+  readdirp@4.1.2: {}
+
+  readdirp@5.1.1: {}
+
+  recast@0.23.21:
+    dependencies:
+      ast-types: 0.16.1
+      esprima: 4.0.1
+      source-map: 0.6.1
+      tiny-invariant: 1.3.3
+      tslib: 2.8.1
+
+  recma-build-jsx@1.0.0:
+    dependencies:
+      '@types/estree': 1.0.9
+      estree-util-build-jsx: 3.0.1
+      vfile: 6.0.3
+
+  recma-jsx@1.0.1(acorn@8.18.0):
+    dependencies:
+      acorn: 8.18.0
+      acorn-jsx: 5.3.2(acorn@8.18.0)
+      estree-util-to-js: 2.0.0
+      recma-parse: 1.0.0
+      recma-stringify: 1.0.0
+      unified: 11.0.5
+
+  recma-parse@1.0.0:
+    dependencies:
+      '@types/estree': 1.0.9
+      esast-util-from-js: 2.0.1
+      unified: 11.0.5
+      vfile: 6.0.3
+
+  recma-stringify@1.0.0:
+    dependencies:
+      '@types/estree': 1.0.9
+      estree-util-to-js: 2.0.0
+      unified: 11.0.5
+      vfile: 6.0.3
+
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
+
+  regex-recursion@6.0.2:
+    dependencies:
+      regex-utilities: 2.3.0
+
+  regex-utilities@2.3.0: {}
+
+  regex@6.1.0:
+    dependencies:
+      regex-utilities: 2.3.0
+
+  rehype-parse@9.0.1:
+    dependencies:
+      '@types/hast': 3.0.5
+      hast-util-from-html: 2.0.3
+      unified: 11.0.5
+
+  rehype-pretty-code@0.14.5(shiki@3.23.0):
+    dependencies:
+      '@types/hast': 3.0.5
+      hast-util-to-string: 3.0.1
+      parse-numeric-range: 1.3.0
+      rehype-parse: 9.0.1
+      shiki: 3.23.0
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+
+  rehype-recma@1.0.0(supports-color@7.2.0):
+    dependencies:
+      '@types/estree': 1.0.9
+      '@types/hast': 3.0.5
+      hast-util-to-estree: 3.1.3(supports-color@7.2.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-frontmatter@5.0.0(supports-color@7.2.0):
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-frontmatter: 2.0.1(supports-color@7.2.0)
+      micromark-extension-frontmatter: 2.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-gfm@4.0.1(supports-color@7.2.0):
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-gfm: 3.1.0(supports-color@7.2.0)
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0(supports-color@7.2.0)
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-mdx@3.1.1(supports-color@7.2.0):
+    dependencies:
+      mdast-util-mdx: 3.0.0(supports-color@7.2.0)
+      micromark-extension-mdxjs: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-parse@11.0.0(supports-color@7.2.0):
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3(supports-color@7.2.0)
+      micromark-util-types: 2.0.2
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-rehype@11.1.2:
+    dependencies:
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      mdast-util-to-hast: 13.2.1
+      unified: 11.0.5
+      vfile: 6.0.3
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
+
+  resolve-from@5.0.0: {}
+
+  resolve@1.22.12:
+    dependencies:
+      es-errors: 1.3.0
+      is-core-module: 2.16.2
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
+
+  reusify@1.1.0: {}
+
+  rolldown@1.2.4:
+    dependencies:
+      '@oxc-project/types': 0.144.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.2.4
+      '@rolldown/binding-darwin-arm64': 1.2.4
+      '@rolldown/binding-darwin-x64': 1.2.4
+      '@rolldown/binding-freebsd-x64': 1.2.4
+      '@rolldown/binding-linux-arm-gnueabihf': 1.2.4
+      '@rolldown/binding-linux-arm64-gnu': 1.2.4
+      '@rolldown/binding-linux-arm64-musl': 1.2.4
+      '@rolldown/binding-linux-ppc64-gnu': 1.2.4
+      '@rolldown/binding-linux-s390x-gnu': 1.2.4
+      '@rolldown/binding-linux-x64-gnu': 1.2.4
+      '@rolldown/binding-linux-x64-musl': 1.2.4
+      '@rolldown/binding-openharmony-arm64': 1.2.4
+      '@rolldown/binding-win32-arm64-msvc': 1.2.4
+      '@rolldown/binding-win32-x64-msvc': 1.2.4
+
+  rollup@4.62.4:
+    dependencies:
+      '@types/estree': 1.0.9
+    optionalDependencies:
+      '@napi-rs/lzma-linux-x64-gnu': 1.5.1
+      '@rollup/rollup-android-arm-eabi': 4.62.4
+      '@rollup/rollup-android-arm64': 4.62.4
+      '@rollup/rollup-darwin-arm64': 4.62.4
+      '@rollup/rollup-darwin-x64': 4.62.4
+      '@rollup/rollup-freebsd-arm64': 4.62.4
+      '@rollup/rollup-freebsd-x64': 4.62.4
+      '@rollup/rollup-linux-arm-gnueabihf': 4.62.4
+      '@rollup/rollup-linux-arm-musleabihf': 4.62.4
+      '@rollup/rollup-linux-arm64-gnu': 4.62.4
+      '@rollup/rollup-linux-arm64-musl': 4.62.4
+      '@rollup/rollup-linux-loong64-gnu': 4.62.4
+      '@rollup/rollup-linux-loong64-musl': 4.62.4
+      '@rollup/rollup-linux-ppc64-gnu': 4.62.4
+      '@rollup/rollup-linux-ppc64-musl': 4.62.4
+      '@rollup/rollup-linux-riscv64-gnu': 4.62.4
+      '@rollup/rollup-linux-riscv64-musl': 4.62.4
+      '@rollup/rollup-linux-s390x-gnu': 4.62.4
+      '@rollup/rollup-linux-x64-gnu': 4.62.4
+      '@rollup/rollup-linux-x64-musl': 4.62.4
+      '@rollup/rollup-openbsd-x64': 4.62.4
+      '@rollup/rollup-openharmony-arm64': 4.62.4
+      '@rollup/rollup-win32-arm64-msvc': 4.62.4
+      '@rollup/rollup-win32-ia32-msvc': 4.62.4
+      '@rollup/rollup-win32-x64-gnu': 4.62.4
+      '@rollup/rollup-win32-x64-msvc': 4.62.4
+      fsevents: 2.3.3
+
+  rou3@0.9.2: {}
+
+  run-applescript@7.1.0: {}
+
+  run-parallel@1.2.0:
+    dependencies:
+      queue-microtask: 1.2.3
+
+  safer-buffer@2.1.2: {}
+
+  sax@1.6.1: {}
+
+  scheduler@0.27.0: {}
+
+  semver@6.3.1: {}
+
+  semver@7.8.5: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  shiki@3.23.0:
+    dependencies:
+      '@shikijs/core': 3.23.0
+      '@shikijs/engine-javascript': 3.23.0
+      '@shikijs/engine-oniguruma': 3.23.0
+      '@shikijs/langs': 3.23.0
+      '@shikijs/themes': 3.23.0
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.5
+
+  siginfo@2.0.0: {}
+
+  signal-exit@4.1.0: {}
+
+  sirv@3.0.2:
+    dependencies:
+      '@polka/url': 1.0.0-next.29
+      mrmime: 2.0.1
+      totalist: 3.0.1
+
+  sisteransi@1.0.5: {}
+
+  slash@3.0.0: {}
+
+  source-map-js@1.2.1: {}
+
+  source-map@0.6.1: {}
+
+  source-map@0.7.6: {}
+
+  source-map@0.8.0: {}
+
+  space-separated-tokens@2.0.2: {}
+
+  spawndamnit@3.0.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
+  sprintf-js@1.0.3: {}
+
+  srvx@0.11.22: {}
+
+  srvx@0.12.5: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.2.0: {}
+
+  storybook@10.5.7(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8):
+    dependencies:
+      '@storybook/global': 5.0.0
+      '@storybook/icons': 2.1.0(react@19.2.8)
+      '@testing-library/dom': 10.4.1
+      '@testing-library/jest-dom': 6.9.1
+      '@testing-library/user-event': 14.6.4(@testing-library/dom@10.4.1)
+      '@vitest/expect': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@webcontainer/env': 1.1.1
+      esbuild: 0.28.2
+      jsonc-parser: 3.3.1
+      open: 10.2.0
+      oxc-parser: 0.127.0
+      oxc-resolver: 11.24.2
+      recast: 0.23.21
+      semver: 7.8.5
+      use-sync-external-store: 1.6.0(react@19.2.8)
+      ws: 8.21.3
+    optionalDependencies:
+      '@types/react': 19.2.18
+      prettier: 3.9.6
+    transitivePeerDependencies:
+      - bufferutil
+      - react
+      - utf-8-validate
+
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.3.0
+
+  strip-bom@3.0.0: {}
+
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
+
+  stubborn-fs@2.0.0:
+    dependencies:
+      stubborn-utils: 1.0.2
+
+  stubborn-utils@1.0.2: {}
+
+  style-to-js@1.1.21:
+    dependencies:
+      style-to-object: 1.0.14
+
+  style-to-object@1.0.14:
+    dependencies:
+      inline-style-parser: 0.2.7
+
+  stylehacks@8.0.3(postcss@8.5.26):
+    dependencies:
+      browserslist: 4.28.8
+      postcss: 8.5.26
+      postcss-selector-parser: 7.1.5
+
+  sucrase@3.35.1:
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      commander: 4.1.1
+      lines-and-columns: 1.2.4
+      mz: 2.7.0
+      pirates: 4.0.7
+      tinyglobby: 0.2.17
+      ts-interface-checker: 0.1.13
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  supports-preserve-symlinks-flag@1.0.0: {}
+
+  svgo@4.0.2:
+    dependencies:
+      commander: 11.1.0
+      css-select: 5.2.2
+      css-tree: 3.2.1
+      css-what: 6.2.2
+      csso: 5.0.5
+      picocolors: 1.1.1
+      sax: 1.6.1
+
+  tagged-tag@1.0.0: {}
+
+  tailwindcss@4.3.3: {}
+
+  tapable@2.3.3: {}
+
+  term-size@2.2.1: {}
+
+  thenify-all@1.6.0:
+    dependencies:
+      thenify: 3.3.1
+
+  thenify@3.3.1:
+    dependencies:
+      any-promise: 1.3.0
+
+  tiny-invariant@1.3.3: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinyexec@1.3.0: {}
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+
+  tinyrainbow@2.0.0: {}
+
+  tinyrainbow@3.1.1: {}
+
+  tinyspy@4.0.4: {}
+
+  to-regex-range@5.0.1:
+    dependencies:
+      is-number: 7.0.0
+
+  totalist@3.0.1: {}
+
+  tr46@0.0.3: {}
+
+  tree-kill@1.2.2: {}
+
+  trim-lines@3.0.1: {}
+
+  trough@2.2.0: {}
+
+  ts-dedent@2.3.0: {}
+
+  ts-interface-checker@0.1.13: {}
+
+  tsc-alias@1.8.10:
+    dependencies:
+      chokidar: 3.6.0
+      commander: 9.5.0
+      globby: 11.1.0
+      mylas: 2.1.14
+      normalize-path: 3.0.0
+      plimit-lit: 1.6.1
+
+  tslib@2.8.1: {}
+
+  tsup@8.5.1(jiti@2.7.0)(postcss@8.5.26)(supports-color@7.2.0)(tsx@4.23.12)(typescript@7.0.2)(yaml@2.9.0):
+    dependencies:
+      bundle-require: 5.1.0(esbuild@0.27.7)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      consola: 3.4.2
+      debug: 4.4.3(supports-color@7.2.0)
+      esbuild: 0.27.7
+      fix-dts-default-cjs-exports: 1.0.1
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.12)(yaml@2.9.0)
+      resolve-from: 5.0.0
+      rollup: 4.62.4
+      source-map: 0.7.6
+      sucrase: 3.35.1
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.17
+      tree-kill: 1.2.2
+    optionalDependencies:
+      postcss: 8.5.26
+      typescript: 7.0.2
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
+
+  tsx@4.23.12:
+    dependencies:
+      esbuild: 0.28.2
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  type-fest@5.8.0:
+    dependencies:
+      tagged-tag: 1.0.0
+
+  typescript@7.0.2:
+    optionalDependencies:
+      '@typescript/typescript-aix-ppc64': 7.0.2
+      '@typescript/typescript-darwin-arm64': 7.0.2
+      '@typescript/typescript-darwin-x64': 7.0.2
+      '@typescript/typescript-freebsd-arm64': 7.0.2
+      '@typescript/typescript-freebsd-x64': 7.0.2
+      '@typescript/typescript-linux-arm': 7.0.2
+      '@typescript/typescript-linux-arm64': 7.0.2
+      '@typescript/typescript-linux-loong64': 7.0.2
+      '@typescript/typescript-linux-mips64el': 7.0.2
+      '@typescript/typescript-linux-ppc64': 7.0.2
+      '@typescript/typescript-linux-riscv64': 7.0.2
+      '@typescript/typescript-linux-s390x': 7.0.2
+      '@typescript/typescript-linux-x64': 7.0.2
+      '@typescript/typescript-netbsd-arm64': 7.0.2
+      '@typescript/typescript-netbsd-x64': 7.0.2
+      '@typescript/typescript-openbsd-arm64': 7.0.2
+      '@typescript/typescript-openbsd-x64': 7.0.2
+      '@typescript/typescript-sunos-x64': 7.0.2
+      '@typescript/typescript-win32-arm64': 7.0.2
+      '@typescript/typescript-win32-x64': 7.0.2
+
+  ufo@1.6.4: {}
+
+  undici-types@7.18.2: {}
+
+  unenv@2.0.0-rc.24:
+    dependencies:
+      pathe: 2.0.3
+
+  unified@11.0.5:
+    dependencies:
+      '@types/unist': 3.0.3
+      bail: 2.0.2
+      devlop: 1.1.0
+      extend: 3.0.2
+      is-plain-obj: 4.1.0
+      trough: 2.2.0
+      vfile: 6.0.3
+
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position-from-estree@2.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
+  universalify@0.1.2: {}
+
+  universalify@2.0.1: {}
+
+  unplugin@2.3.11:
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      acorn: 8.18.0
+      picomatch: 4.0.5
+      webpack-virtual-modules: 0.6.2
+
+  unstorage@2.0.0-alpha.7(chokidar@5.0.0)(db0@0.3.4)(ofetch@2.0.0-alpha.3):
+    optionalDependencies:
+      chokidar: 5.0.0
+      db0: 0.3.4
+      ofetch: 2.0.0-alpha.3
+
+  update-browserslist-db@1.3.1(browserslist@4.28.8):
+    dependencies:
+      browserslist: 4.28.8
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
+  use-sync-external-store@1.6.0(react@19.2.8):
+    dependencies:
+      react: 19.2.8
+
+  util-deprecate@1.0.2: {}
+
+  valibot@1.4.2(typescript@7.0.2):
+    optionalDependencies:
+      typescript: 7.0.2
+
+  vfile-location@5.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile: 6.0.3
+
+  vfile-matter@5.0.1:
+    dependencies:
+      vfile: 6.0.3
+      yaml: 2.9.0
+
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
+
+  vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0):
+    dependencies:
+      lightningcss: 1.33.0
+      picomatch: 4.0.5
+      postcss: 8.5.26
+      rolldown: 1.2.4
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 24.13.3
+      esbuild: 0.28.2
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      tsx: 4.23.12
+      yaml: 2.9.0
+
+  vitest@4.1.10(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.1
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.3.0
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.1
+      vite: 8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.13.3
+      '@vitest/browser-playwright': 4.1.10(playwright@1.62.1)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))(vitest@4.1.10)
+      '@vitest/coverage-istanbul': 4.1.10(supports-color@7.2.0)(vitest@4.1.10)
+      '@vitest/coverage-v8': 4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)
+      happy-dom: 20.11.2
+    transitivePeerDependencies:
+      - msw
+
+  web-namespaces@2.0.1: {}
+
+  webidl-conversions@3.0.1: {}
+
+  webpack-virtual-modules@0.6.2: {}
+
+  whatwg-mimetype@3.0.0: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
+
+  when-exit@2.1.5: {}
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  ws@8.21.3: {}
+
+  wsl-utils@0.1.0:
+    dependencies:
+      is-wsl: 3.1.1
+
+  xdg-basedir@5.1.0: {}
+
+  yallist@3.1.1: {}
+
+  yaml@2.9.0: {}
+
+  zod@4.4.3: {}
+
+  zwitch@2.0.4: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -232,8 +232,8 @@ importers:
     packages/radiant:
         dependencies:
             '@ecopages/signals':
-                specifier: '>=0.3.0-beta.6'
-                version: 0.3.0-beta.6
+                specifier: '>=0.3.0-beta.8'
+                version: link:../signals/dist
         devDependencies:
             '@babel/core':
                 specifier: ^7.28.0
@@ -421,11 +421,11 @@ importers:
     packages/storybook-radiant-vite:
         dependencies:
             '@ecopages/radiant':
-                specifier: '>=0.3.0-beta.6'
-                version: 0.3.0-beta.6(@ecopages/jsx@packages+jsx+dist)
+                specifier: '>=0.3.0-beta.8'
+                version: link:../radiant/dist
             '@ecopages/signals':
-                specifier: '>=0.3.0-beta.6'
-                version: 0.3.0-beta.6
+                specifier: '>=0.3.0-beta.8'
+                version: link:../signals/dist
             '@ecopages/vite-plugin-radiant':
                 specifier: workspace:*
                 version: link:../vite-plugin-radiant

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,25 +1,28 @@
 packages:
-    - 'apps/*'
-    - 'packages/*'
-    - 'playground/*'
+  - 'apps/*'
+  - 'packages/*'
+  - 'playground/*'
 
 catalog:
-    typescript: ~7.0.2
+  typescript: ~7.0.2
 
 allowBuilds:
-    esbuild: true
-    '@swc/core': true
+  esbuild: true
+  '@swc/core': true
 
 minimumReleaseAgeExclude:
-    - '@ecopages/jsx@0.3.0-beta.6'
-    - '@ecopages/radiant@0.3.0-beta.6'
-    - '@ecopages/signals@0.3.0-beta.6'
-    - '@ecopages/browser-router@0.2.0-beta.43'
-    - '@ecopages/content-processor@0.2.0-beta.43'
-    - '@ecopages/core@0.2.0-beta.43'
-    - '@ecopages/dev-toolbar@0.2.0-beta.43'
-    - '@ecopages/ecopages-jsx@0.2.0-beta.43'
-    - '@ecopages/file-system@0.2.0-beta.43'
-    - '@ecopages/mdx@0.2.0-beta.43'
-    - '@ecopages/postcss-processor@0.2.0-beta.43'
-    - ecopages@0.2.0-beta.43
+  - '@ecopages/jsx@0.3.0-beta.6'
+  - '@ecopages/jsx@0.3.0-beta.8'
+  - '@ecopages/radiant@0.3.0-beta.6'
+  - '@ecopages/radiant@0.3.0-beta.8'
+  - '@ecopages/signals@0.3.0-beta.6'
+  - '@ecopages/signals@0.3.0-beta.8'
+  - '@ecopages/browser-router@0.2.0-beta.43'
+  - '@ecopages/content-processor@0.2.0-beta.43'
+  - '@ecopages/core@0.2.0-beta.43'
+  - '@ecopages/dev-toolbar@0.2.0-beta.43'
+  - '@ecopages/ecopages-jsx@0.2.0-beta.43'
+  - '@ecopages/file-system@0.2.0-beta.43'
+  - '@ecopages/mdx@0.2.0-beta.43'
+  - '@ecopages/postcss-processor@0.2.0-beta.43'
+  - ecopages@0.2.0-beta.43


### PR DESCRIPTION
## Summary
- Uncontrolled `rui-sidebar` now applies `mobileDefaultOpen` when the viewport crosses into mobile, not only on first connect.
- Docs layouts drop the `rui-sidebar-mobile-change` listener that forced the pane closed.

## What changed
Connect snapshots whether `open` is controlled before defaults are applied. After that, entering mobile sets `mobileDefaultOpen`; leaving mobile with `collapsible="off"` still reopens a closed pane. Controlled `open` is left alone.

## How to verify
1. Run sidebar tests in `@ecopages/radiant-ui`.
2. Open docs at desktop width, resize below 768px, and confirm the pane follows `mobileDefaultOpen={false}` without a page-level listener.