### PR TITLE
docs: treat Signals as default and add UI site chrome

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,6 +1,6 @@
 # Radiant Platform
 
-Radiant is a unified platform for building light-DOM custom elements with visible browser primitives, with companion packages for JSX authoring and signal-based reactivity.
+Radiant is a unified platform for building light-DOM custom elements with visible browser primitives. Signals is the default reactivity layer; JSX is the companion package for authoring.
 
 This repository documents one shared product context at the monorepo root rather than separate package-level contexts because the published packages are designed, released, and explained as one ecosystem.
 
@@ -112,7 +112,7 @@ _Avoid_: provider, selector field, local state copy
 - **Ecopages JSX** can be used independently of **Radiant**
 - **Ecopages Signals** can be used independently of **Radiant**
 - **Radiant** is the core package of the **Radiant Platform**
-- **Radiant** composes **Ecopages JSX** and **Ecopages Signals** into the core custom-element experience
+- **Radiant** depends on **Ecopages Signals** by default and composes **Ecopages JSX** as the TSX companion
 - **Reactive Host** is the shared host model inside **Radiant**
 - **Element Host** and **Controller Host** are the two host styles of a **Reactive Host**
 - A **Render-owning Element Host** is an **Element Host** that owns rendered output and the related lifecycle

--- a/apps/docs/src/content/docs/getting-started/installation.mdx
+++ b/apps/docs/src/content/docs/getting-started/installation.mdx
@@ -12,7 +12,7 @@ import { CodeTabs } from '@/components/code-tabs';
 
 # Installation
 
-Radiant is the core package. JSX and Signals are companion packages that extend it with TSX rendering and standalone signal primitives.
+Radiant is the core package. Signals ships with it as the reactive layer. JSX is the companion package for TSX rendering.
 
 For the standard Radiant setup, install `@ecopages/radiant` and `@ecopages/jsx`. `@ecopages/signals` is installed automatically with `@ecopages/radiant`.
 

--- a/apps/docs/src/data/home-code-examples.ts
+++ b/apps/docs/src/data/home-code-examples.ts
@@ -22,28 +22,3 @@ export class RadiantCounter extends RadiantElement<{ value: number }> {
     );
   }
 }`;
-
-export const counterControllerExampleCode = `import { RadiantController, controller, prop } from '@ecopages/radiant';
-
-@controller('radiant-counter')
-export class RadiantCounter extends RadiantController<{ value: number }> {
-  @prop({ type: Number, reflect: true }) value = 0;
-
-  private readonly decrement = () => {
-    if (this.value > 0) this.value -= 1;
-  };
-
-  private readonly increment = () => {
-    this.value += 1;
-  };
-
-  override render() {
-    return (
-      <>
-        <button type="button" on:click={this.decrement}>-</button>
-        <span>{this.$.value}</span>
-        <button type="button" on:click={this.increment}>+</button>
-      </>
-    );
-  }
-}`;

--- a/apps/docs/src/layouts/base-layout/base-layout.tsx
+++ b/apps/docs/src/layouts/base-layout/base-layout.tsx
@@ -51,6 +51,17 @@ export const BaseLayout = eco.component<BaseLayoutProps, JsxRenderable>({
 											Docs
 										</RuiButton>
 									</li>
+									<li class="max-md:hidden">
+										<RuiButton
+											href="https://radiant-ui.ecopages.app"
+											target="_blank"
+											rel="noopener noreferrer"
+											variant="ghost"
+											size="sm"
+										>
+											UI
+										</RuiButton>
+									</li>
 									<li>
 										<RuiButton
 											href="https://github.com/ecopages/radiant"

--- a/apps/docs/src/layouts/docs-layout/docs-layout.tsx
+++ b/apps/docs/src/layouts/docs-layout/docs-layout.tsx
@@ -87,6 +87,15 @@ const DocsSiteHeader = () => (
 		</div>
 		<nav class="rui-sidebar-provider__site-header-nav" aria-label="Site">
 			<RuiButton
+				href="https://radiant-ui.ecopages.app"
+				target="_blank"
+				rel="noopener noreferrer"
+				variant="ghost"
+				size="sm"
+			>
+				UI
+			</RuiButton>
+			<RuiButton
 				href="https://github.com/ecopages/radiant"
 				target="_blank"
 				rel="noopener noreferrer"

--- a/apps/docs/src/pages/index.css
+++ b/apps/docs/src/pages/index.css
@@ -95,22 +95,43 @@
 }
 
 .home-footer {
-	@apply col-span-full border-t border-border pt-6 text-sm text-on-background/70;
+	@apply col-span-full flex flex-col gap-5 border-t border-border pt-6 text-sm text-on-background/70;
+}
 
-	p {
-		@apply flex flex-wrap justify-center gap-x-1;
+.home-footer__nav {
+	@apply grid gap-6 sm:grid-cols-2 lg:grid-cols-4;
+}
+
+.home-footer__label {
+	@apply m-0 text-xs font-semibold uppercase tracking-wide text-on-background/60;
+}
+
+.home-footer__list {
+	@apply m-0 mt-1 flex list-none flex-col p-0;
+}
+
+.home-footer__list a,
+.home-footer__bar a {
+	@apply inline-flex min-h-8 items-center text-sm font-normal text-on-background/80 no-underline underline-offset-4 decoration-border;
+
+	@media (hover: hover) {
+		@apply hover:text-on-background hover:underline hover:decoration-on-background;
 	}
 
-	a {
-		@apply font-medium text-on-background underline decoration-border underline-offset-4 transition-colors;
+	&:focus-visible {
+		@apply rounded-sm outline-2 outline-offset-2 outline-primary;
+	}
+}
 
-		@media (hover: hover) {
-			@apply hover:decoration-on-background;
-		}
+.home-footer__list [aria-current='page'] {
+	@apply inline-flex min-h-8 items-center text-sm font-normal text-on-background;
+}
 
-		&:focus-visible {
-			@apply rounded-sm outline-2 outline-offset-2 outline-primary;
-		}
+.home-footer__bar {
+	@apply flex flex-wrap items-center justify-between gap-x-4 gap-y-1 border-t border-border/60 pt-4;
+
+	p {
+		@apply m-0 flex flex-wrap items-center gap-x-1;
 	}
 }
 

--- a/apps/docs/src/pages/index.css
+++ b/apps/docs/src/pages/index.css
@@ -7,27 +7,32 @@
 }
 
 .home-hero {
-	@apply flex flex-col gap-8 lg:col-span-12 lg:grid lg:grid-cols-subgrid lg:items-center lg:gap-12;
+	@apply flex flex-col gap-8 lg:col-span-12 lg:grid lg:grid-cols-subgrid lg:items-start lg:gap-12;
 }
 
 .home-hero__text {
-	@apply flex flex-col lg:col-span-7;
+	@apply flex flex-col lg:col-span-6;
+
 	radiant-code-tabs {
 		@apply mt-8;
 	}
 }
 
 .home-hero__code {
-	@apply flex flex-col lg:col-span-5;
-	rui-tabs {
-		@apply rounded-b-none;
-	}
+	@apply flex min-w-0 flex-col lg:col-span-6;
+
 	radiant-code-tabs {
 		@apply my-0;
+	}
+
+	radiant-code-tabs rui-tabs {
+		@apply rounded-b-none;
 	}
 }
 
 .home-hero__demo {
+	@apply min-w-0;
+
 	radiant-counter {
 		@apply w-full max-w-full rounded-t-none border-t-0;
 	}
@@ -58,7 +63,7 @@
 }
 
 .home-path {
-	@apply mt-6 rounded-sm border border-border bg-background-accent p-6 md:p-8;
+	@apply mt-6;
 }
 
 .home-path__list {

--- a/apps/docs/src/pages/index.tsx
+++ b/apps/docs/src/pages/index.tsx
@@ -1,4 +1,5 @@
 import { eco } from '@ecopages/core';
+import type { JsxRenderable } from '@ecopages/jsx';
 import { codeToHtml } from 'shiki';
 import { RuiButton } from '@ecopages/radiant-ui/button';
 import { RuiChip } from '@ecopages/radiant-ui/chip';
@@ -13,7 +14,7 @@ import { RuiHeading, RuiHeadingDescription, RuiHeadingEyebrow, RuiHeadingTitle }
 import { BaseLayout } from '@/layouts/base-layout';
 import { CodeTabs } from '@/components/code-tabs';
 import { RadiantJsxCounter as RadiantCounterDemo } from '@/components/radiant-counter/radiant-jsx-counter';
-import { counterControllerExampleCode, counterElementExampleCode } from '@/data/home-code-examples';
+import { counterElementExampleCode } from '@/data/home-code-examples';
 
 const counterElementExample = await codeToHtml(counterElementExampleCode, {
 	lang: 'tsx',
@@ -21,11 +22,186 @@ const counterElementExample = await codeToHtml(counterElementExampleCode, {
 	defaultColor: false,
 });
 
-const counterControllerExample = await codeToHtml(counterControllerExampleCode, {
-	lang: 'tsx',
-	themes: { light: 'light-plus', dark: 'dark-plus' },
-	defaultColor: false,
-});
+function highlightedCodeFigure(html: string): string {
+	return `<figure data-rehype-pretty-code-figure class="home-code-block">${html}</figure>`;
+}
+
+const INSTALL_TABS = [
+	{ id: 'npm', label: 'npm', code: 'npm install @ecopages/radiant @ecopages/jsx' },
+	{ id: 'pnpm', label: 'pnpm', code: 'pnpm add @ecopages/radiant @ecopages/jsx' },
+	{ id: 'bun', label: 'bun', code: 'bun add @ecopages/radiant @ecopages/jsx' },
+];
+
+const COUNTER_EXAMPLE_TABS = [
+	{
+		id: 'radiant-counter',
+		label: 'radiant-counter.tsx',
+		html: highlightedCodeFigure(counterElementExample),
+		content: counterElementExampleCode,
+	},
+];
+
+type HomeFeedArticleData = {
+	href: string;
+	label: string;
+	title: string;
+	description: string;
+};
+
+const EXPLORE_ARTICLES: HomeFeedArticleData[] = [
+	{
+		href: '/docs/getting-started/introduction',
+		label: 'Get Started',
+		title: 'Learn the model',
+		description:
+			'See how RadiantElement and RadiantController share one reactive host surface. Signals comes with Radiant; JSX is the TSX layer.',
+	},
+	{
+		href: '/docs/components/radiant-element',
+		label: 'Components',
+		title: 'Choose the right host',
+		description:
+			'Use RadiantElement for custom-element hosts. Reach for RadiantController when existing markup should stay authored outside the host class.',
+	},
+	{
+		href: '/docs/decorators/prop',
+		label: 'Decorators',
+		title: 'Add intent without boilerplate',
+		description:
+			'Typed decorators for public inputs, local state, DOM queries, events, and lifecycle across both host types.',
+	},
+	{
+		href: '/docs/packages/signals-overview',
+		label: 'Packages',
+		title: 'Understand the package layers',
+		description:
+			'Signals ships with radiant; jsx installs alongside radiant for TSX. Both sit on the shared reactive host model.',
+	},
+];
+
+const PATH_STEPS = [
+	'Read the overview, then install `@ecopages/radiant` and `@ecopages/jsx` for the standard setup.',
+	'Start with RadiantElement when you own the custom-element contract, then learn when RadiantController is a better fit for authored DOM.',
+	'Learn how signals, JSX bindings, and host decorators fit together.',
+	'Use the examples to see element-owned and controller-owned flows assembled end to end.',
+];
+
+type HomePathCardData = {
+	href: string;
+	title: string;
+	description: string;
+};
+
+const PATH_CARDS: HomePathCardData[] = [
+	{
+		href: '/docs/getting-started/installation',
+		title: 'Install the ecosystem',
+		description: 'Install radiant and jsx for the standard setup. Signals comes with radiant automatically.',
+	},
+	{
+		href: '/docs/context/context',
+		title: 'Share state with context',
+		description: 'Use the same context model across custom-element hosts and DOM-attached controllers.',
+	},
+	{
+		href: '/docs/examples/todo-app',
+		title: 'Study a complete example',
+		description:
+			'The todo app shows a render-owning RadiantElement host, child elements, context, and JSX working together.',
+	},
+];
+
+const AGENT_LINKS = [
+	{ href: '/skill.txt', label: 'skill.txt' },
+	{ href: '/skill/SKILL.md', label: 'SKILL.md' },
+	{ href: '/llms.txt', label: 'llms.txt' },
+];
+
+const ECOSYSTEM_PACKAGES = ['@ecopages/radiant', '@ecopages/jsx', '@ecopages/signals'];
+
+type HomeFooterLink = {
+	label: string;
+	href?: string;
+	external?: boolean;
+};
+
+type HomeFooterColumnData = {
+	title: string;
+	links: HomeFooterLink[];
+};
+
+const HOME_FOOTER_COLUMNS: HomeFooterColumnData[] = [
+	{
+		title: 'Ecosystem',
+		links: [
+			{ label: 'Ecopages', href: 'https://ecopages.app', external: true },
+			{ label: 'Radiant' },
+			{ label: 'Radiant UI', href: 'https://radiant-ui.ecopages.app', external: true },
+			{ label: 'Scripts Injector', href: 'https://scripts-injector.ecopages.app', external: true },
+			{ label: 'Logger', href: 'https://github.com/ecopages/logger', external: true },
+		],
+	},
+	{
+		title: 'Guides',
+		links: [
+			{ label: 'Introduction', href: '/docs/getting-started/introduction' },
+			{ label: 'Installation', href: '/docs/getting-started/installation' },
+			{ label: 'Signals', href: '/docs/packages/signals-overview' },
+			{ label: 'JSX', href: '/docs/packages/jsx-overview' },
+		],
+	},
+	{
+		title: 'Hosts',
+		links: [
+			{ label: 'RadiantElement', href: '/docs/components/radiant-element' },
+			{ label: 'RadiantController', href: '/docs/components/radiant-controller' },
+			{ label: 'Slots', href: '/docs/components/slots' },
+		],
+	},
+	{
+		title: 'Packages',
+		links: [
+			{ label: '@ecopages/radiant', href: 'https://www.npmjs.com/package/@ecopages/radiant', external: true },
+			{ label: '@ecopages/signals', href: 'https://www.npmjs.com/package/@ecopages/signals', external: true },
+			{ label: '@ecopages/jsx', href: 'https://www.npmjs.com/package/@ecopages/jsx', external: true },
+			{ label: '@ecopages/radiant-ui', href: 'https://www.npmjs.com/package/@ecopages/radiant-ui', external: true },
+			{
+				label: '@ecopages/vite-plugin-radiant',
+				href: 'https://www.npmjs.com/package/@ecopages/vite-plugin-radiant',
+				external: true,
+			},
+		],
+	},
+];
+
+const HomeIcon = ({ children }: { children: JsxRenderable }) => (
+	<svg
+		xmlns="http://www.w3.org/2000/svg"
+		width="16"
+		height="16"
+		viewBox="0 0 24 24"
+		fill="none"
+		stroke="currentColor"
+		stroke-width="2"
+		stroke-linecap="round"
+		stroke-linejoin="round"
+	>
+		{children}
+	</svg>
+);
+
+const GitHubIcon = () => (
+	<HomeIcon>
+		<path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"></path>
+	</HomeIcon>
+);
+
+const LockIcon = () => (
+	<HomeIcon>
+		<rect x="3" y="11" width="18" height="11" rx="2" ry="2"></rect>
+		<path d="M7 11V7a5 5 0 0 1 10 0v4"></path>
+	</HomeIcon>
+);
 
 const HomeFeedArticle = ({
 	href,
@@ -33,14 +209,9 @@ const HomeFeedArticle = ({
 	title,
 	description,
 	position,
-}: {
-	href: string;
-	label: string;
-	title: string;
-	description: string;
-	position: number;
-}) => (
-	<RuiFeedArticle posinset={position} setsize={4} tabindex={-1}>
+	setsize,
+}: HomeFeedArticleData & { position: number; setsize: number }) => (
+	<RuiFeedArticle posinset={position} setsize={setsize} tabindex={-1}>
 		<RuiFeedArticleHeader>
 			<RuiHeading size="sm">
 				<RuiHeadingEyebrow>{label}</RuiHeadingEyebrow>
@@ -58,7 +229,7 @@ const HomeFeedArticle = ({
 	</RuiFeedArticle>
 );
 
-const HomePathCard = ({ href, title, description }: { href: string; title: string; description: string }) => (
+const HomePathCard = ({ href, title, description }: HomePathCardData) => (
 	<a
 		href={href}
 		class="flex flex-col gap-1 rounded-sm border border-border bg-background p-4 text-on-background no-underline transition-colors hover:bg-secondary-container/30"
@@ -68,233 +239,187 @@ const HomePathCard = ({ href, title, description }: { href: string; title: strin
 	</a>
 );
 
-const HomePage = () => {
-	return (
-		<div class="home-layout not-prose">
-			<header class="home-header">
-				<div class="home-hero">
-					<div class="home-hero__text">
-						<RuiHeading size="xl" class="home-header__heading">
-							<RuiHeadingEyebrow>Radiant</RuiHeadingEyebrow>
-							<RuiHeadingTitle as="h1">Build reactive hosts with JSX and Signals.</RuiHeadingTitle>
-							<RuiHeadingDescription>
-								Radiant gives you one reactive host model for both custom elements and DOM-attached
-								controllers. Use RadiantElement when the host owns its contract, or RadiantController
-								when the HTML should stay authored outside the class. Signals ships with Radiant. JSX
-								stays the optional companion for TSX.
-							</RuiHeadingDescription>
-						</RuiHeading>
+const HomeFooterNavItem = ({ link }: { link: HomeFooterLink }) => (
+	<li>
+		{link.href ? (
+			<a href={link.href} {...(link.external ? { target: '_blank', rel: 'noopener noreferrer' } : {})}>
+				{link.label}
+			</a>
+		) : (
+			<span aria-current="page">{link.label}</span>
+		)}
+	</li>
+);
 
-						<CodeTabs
-							label="Package managers"
-							tabs={[
-								{
-									id: 'npm',
-									label: 'npm',
-									code: 'npm install @ecopages/radiant @ecopages/jsx',
-								},
-								{
-									id: 'pnpm',
-									label: 'pnpm',
-									code: 'pnpm add @ecopages/radiant @ecopages/jsx',
-								},
-								{
-									id: 'bun',
-									label: 'bun',
-									code: 'bun add @ecopages/radiant @ecopages/jsx',
-								},
-							]}
-							copyLabel="Copy install command"
-							defaultSelectedKey="npm"
-						/>
+const HomeFooterColumn = ({ title, links }: HomeFooterColumnData) => (
+	<div class="home-footer__col">
+		<p class="home-footer__label">{title}</p>
+		<ul class="home-footer__list">
+			{links.map((link) => (
+				<HomeFooterNavItem link={link} />
+			))}
+		</ul>
+	</div>
+);
 
-						<div class="home-header__actions">
-							<RuiButton href="/docs/getting-started/introduction">Read the overview</RuiButton>
-							<RuiButton href="/docs/components/radiant-element" variant="outline">
-								Start with RadiantElement
-							</RuiButton>
-						</div>
-					</div>
+const HomeFooterBar = () => (
+	<div class="home-footer__bar">
+		<p>
+			Created by{' '}
+			<a href="https://github.com/andeeplus" target="_blank" rel="noopener noreferrer">
+				andeeplus
+			</a>
+		</p>
+		<p>
+			Built with{' '}
+			<a href="https://github.com/ecopages/ecopages" target="_blank" rel="noopener noreferrer">
+				Ecopages
+			</a>
+			© {new Date().getFullYear()}
+		</p>
+	</div>
+);
 
-					<div class="home-hero__code">
-						<CodeTabs
-							label="Host models"
-							tabs={[
-								{
-									id: 'radiant-element',
-									label: 'radiant-element.tsx',
-									html: `<figure data-rehype-pretty-code-figure class="home-code-block">${counterElementExample}</figure>`,
-									content: counterElementExampleCode,
-								},
-								{
-									id: 'radiant-controller',
-									label: 'radiant-controller.tsx',
-									html: `<figure data-rehype-pretty-code-figure class="home-code-block">${counterControllerExample}</figure>`,
-									content: counterControllerExampleCode,
-								},
-							]}
-							copyLabel="Copy code"
-							defaultSelectedKey="radiant-element"
-						/>
+const HomeFooter = () => (
+	<footer class="home-footer">
+		<nav class="home-footer__nav" aria-label="Ecopages ecosystem">
+			{HOME_FOOTER_COLUMNS.map((column) => (
+				<HomeFooterColumn title={column.title} links={column.links} />
+			))}
+		</nav>
+		<HomeFooterBar />
+	</footer>
+);
 
-						<div class="home-hero__demo">
-							<RadiantCounterDemo value={0} />
-						</div>
-					</div>
+const HomeSidebarSection = ({ label, children }: { label: string; children: JsxRenderable }) => (
+	<div class="home-sidebar__section">
+		<p class="home-sidebar__label">{label}</p>
+		{children}
+	</div>
+);
+
+const HomeSidebar = () => (
+	<aside class="home-sidebar">
+		<HomeSidebarSection label="Repository">
+			<a href="https://github.com/ecopages/radiant" class="home-sidebar__value home-sidebar__link">
+				<GitHubIcon />
+				ecopages/radiant
+			</a>
+		</HomeSidebarSection>
+		<HomeSidebarSection label="License">
+			<p class="home-sidebar__value">
+				<LockIcon />
+				MIT
+			</p>
+		</HomeSidebarSection>
+		<HomeSidebarSection label="For agents">
+			<div class="home-sidebar__tags">
+				{AGENT_LINKS.map((link) => (
+					<RuiButton href={link.href} variant="outline" size="sm" class="font-mono">
+						{link.label}
+					</RuiButton>
+				))}
+			</div>
+		</HomeSidebarSection>
+		<HomeSidebarSection label="Ecosystem">
+			<div class="home-sidebar__tags">
+				{ECOSYSTEM_PACKAGES.map((name) => (
+					<RuiChip class="font-mono">{name}</RuiChip>
+				))}
+			</div>
+		</HomeSidebarSection>
+	</aside>
+);
+
+const HomeHero = () => (
+	<header class="home-header">
+		<div class="home-hero">
+			<div class="home-hero__text">
+				<RuiHeading size="xl" class="home-header__heading">
+					<RuiHeadingEyebrow>Radiant</RuiHeadingEyebrow>
+					<RuiHeadingTitle as="h1">Build reactive hosts with JSX and Signals.</RuiHeadingTitle>
+					<RuiHeadingDescription>
+						Radiant gives you one reactive host model for both custom elements and DOM-attached controllers.
+						Use RadiantElement when the host owns its contract, or RadiantController when the HTML should
+						stay authored outside the class. Signals ships with Radiant. JSX stays the optional companion
+						for TSX.
+					</RuiHeadingDescription>
+				</RuiHeading>
+				<CodeTabs
+					label="Package managers"
+					tabs={INSTALL_TABS}
+					copyLabel="Copy install command"
+					defaultSelectedKey="npm"
+				/>
+				<div class="home-header__actions">
+					<RuiButton href="/docs/getting-started/introduction">Read the overview</RuiButton>
+					<RuiButton href="/docs/components/radiant-element" variant="outline">
+						Start with RadiantElement
+					</RuiButton>
 				</div>
-			</header>
-
-			<main class="home-main">
-				<section>
-					<RuiFeed label="Explore Radiant" class="home-cards">
-						<HomeFeedArticle
-							href="/docs/getting-started/introduction"
-							label="Get Started"
-							title="Learn the model"
-							description="See how RadiantElement and RadiantController share one reactive host surface. Signals comes with Radiant; JSX is the TSX layer."
-							position={1}
-						/>
-						<HomeFeedArticle
-							href="/docs/components/radiant-element"
-							label="Components"
-							title="Choose the right host"
-							description="Use RadiantElement for custom-element hosts. Reach for RadiantController when existing markup should stay authored outside the host class."
-							position={2}
-						/>
-						<HomeFeedArticle
-							href="/docs/decorators/prop"
-							label="Decorators"
-							title="Add intent without boilerplate"
-							description="Typed decorators for public inputs, local state, DOM queries, events, and lifecycle across both host types."
-							position={3}
-						/>
-						<HomeFeedArticle
-							href="/docs/packages/signals-overview"
-							label="Packages"
-							title="Understand the package layers"
-							description="Signals ships with radiant; jsx installs alongside radiant for TSX. Both sit on the shared reactive host model."
-							position={4}
-						/>
-					</RuiFeed>
-				</section>
-
-				<section class="home-path">
-					<RuiHeading as="header" size="sm">
-						<RuiHeadingEyebrow>Suggested path</RuiHeadingEyebrow>
-						<RuiHeadingTitle as="h2">Build confidence step by step</RuiHeadingTitle>
-					</RuiHeading>
-					<ol class="home-path__list">
-						<li>
-							Read the overview, then install `@ecopages/radiant` and `@ecopages/jsx` for the standard
-							setup.
-						</li>
-						<li>
-							Start with RadiantElement when you own the custom-element contract, then learn when
-							RadiantController is a better fit for authored DOM.
-						</li>
-						<li>Learn how signals, JSX bindings, and host decorators fit together.</li>
-						<li>Use the examples to see element-owned and controller-owned flows assembled end to end.</li>
-					</ol>
-
-					<div class="mt-8 grid gap-3">
-						<HomePathCard
-							href="/docs/getting-started/installation"
-							title="Install the ecosystem"
-							description="Install radiant and jsx for the standard setup. Signals comes with radiant automatically."
-						/>
-						<HomePathCard
-							href="/docs/context/context"
-							title="Share state with context"
-							description="Use the same context model across custom-element hosts and DOM-attached controllers."
-						/>
-						<HomePathCard
-							href="/docs/examples/todo-app"
-							title="Study a complete example"
-							description="The todo app shows a render-owning RadiantElement host, child elements, context, and JSX working together."
-						/>
-					</div>
-				</section>
-			</main>
-
-			<aside class="home-sidebar">
-				<div class="home-sidebar__section">
-					<p class="home-sidebar__label">Repository</p>
-					<a href="https://github.com/ecopages/radiant" class="home-sidebar__value home-sidebar__link">
-						<svg
-							xmlns="http://www.w3.org/2000/svg"
-							width="16"
-							height="16"
-							viewBox="0 0 24 24"
-							fill="none"
-							stroke="currentColor"
-							stroke-width="2"
-							stroke-linecap="round"
-							stroke-linejoin="round"
-						>
-							<path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"></path>
-						</svg>
-						ecopages/radiant
-					</a>
+			</div>
+			<div class="home-hero__code">
+				<CodeTabs
+					label="Example"
+					tabs={COUNTER_EXAMPLE_TABS}
+					copyLabel="Copy code"
+					defaultSelectedKey="radiant-counter"
+				/>
+				<div class="home-hero__demo">
+					<RadiantCounterDemo value={0} />
 				</div>
-
-				<div class="home-sidebar__section">
-					<p class="home-sidebar__label">License</p>
-					<p class="home-sidebar__value">
-						<svg
-							xmlns="http://www.w3.org/2000/svg"
-							width="16"
-							height="16"
-							viewBox="0 0 24 24"
-							fill="none"
-							stroke="currentColor"
-							stroke-width="2"
-							stroke-linecap="round"
-							stroke-linejoin="round"
-						>
-							<rect x="3" y="11" width="18" height="11" rx="2" ry="2"></rect>
-							<path d="M7 11V7a5 5 0 0 1 10 0v4"></path>
-						</svg>
-						MIT
-					</p>
-				</div>
-
-				<div class="home-sidebar__section">
-					<p class="home-sidebar__label">For agents</p>
-					<div class="home-sidebar__tags">
-						<RuiButton href="/skill.txt" variant="outline" size="sm" class="font-mono">
-							skill.txt
-						</RuiButton>
-						<RuiButton href="/skill/SKILL.md" variant="outline" size="sm" class="font-mono">
-							SKILL.md
-						</RuiButton>
-						<RuiButton href="/llms.txt" variant="outline" size="sm" class="font-mono">
-							llms.txt
-						</RuiButton>
-					</div>
-				</div>
-
-				<div class="home-sidebar__section">
-					<p class="home-sidebar__label">Ecosystem</p>
-					<div class="home-sidebar__tags">
-						<RuiChip class="font-mono">@ecopages/radiant</RuiChip>
-						<RuiChip class="font-mono">@ecopages/jsx</RuiChip>
-						<RuiChip class="font-mono">@ecopages/signals</RuiChip>
-					</div>
-				</div>
-			</aside>
-
-			<footer class="home-footer">
-				<p>
-					Made with{' '}
-					<a href="https://github.com/ecopages/ecopages" target="_blank" rel="noopener noreferrer">
-						Ecopages
-					</a>
-					© {new Date().getFullYear()}
-				</p>
-			</footer>
+			</div>
 		</div>
-	);
-};
+	</header>
+);
+
+const HomeExplore = () => (
+	<section>
+		<RuiFeed label="Explore Radiant" class="home-cards">
+			{EXPLORE_ARTICLES.map((article, index) => (
+				<HomeFeedArticle
+					href={article.href}
+					label={article.label}
+					title={article.title}
+					description={article.description}
+					position={index + 1}
+					setsize={EXPLORE_ARTICLES.length}
+				/>
+			))}
+		</RuiFeed>
+	</section>
+);
+
+const HomePath = () => (
+	<section class="home-path">
+		<RuiHeading as="header" size="sm">
+			<RuiHeadingEyebrow>Suggested path</RuiHeadingEyebrow>
+			<RuiHeadingTitle as="h2">Build confidence step by step</RuiHeadingTitle>
+		</RuiHeading>
+		<ol class="home-path__list">
+			{PATH_STEPS.map((step) => (
+				<li>{step}</li>
+			))}
+		</ol>
+		<div class="mt-8 grid gap-3">
+			{PATH_CARDS.map((card) => (
+				<HomePathCard href={card.href} title={card.title} description={card.description} />
+			))}
+		</div>
+	</section>
+);
+
+const HomePage = () => (
+	<div class="home-layout not-prose">
+		<HomeHero />
+		<main class="home-main">
+			<HomeExplore />
+			<HomePath />
+		</main>
+		<HomeSidebar />
+		<HomeFooter />
+	</div>
+);
 
 export default eco.page({
 	layout: BaseLayout,

--- a/apps/docs/src/pages/index.tsx
+++ b/apps/docs/src/pages/index.tsx
@@ -80,8 +80,8 @@ const HomePage = () => {
 							<RuiHeadingDescription>
 								Radiant gives you one reactive host model for both custom elements and DOM-attached
 								controllers. Use RadiantElement when the host owns its contract, or RadiantController
-								when the HTML should stay authored outside the class. JSX and Signals stay optional
-								companions.
+								when the HTML should stay authored outside the class. Signals ships with Radiant. JSX
+								stays the optional companion for TSX.
 							</RuiHeadingDescription>
 						</RuiHeading>
 
@@ -151,7 +151,7 @@ const HomePage = () => {
 							href="/docs/getting-started/introduction"
 							label="Get Started"
 							title="Learn the model"
-							description="See how RadiantElement and RadiantController share one reactive host surface, and where JSX and Signals fit."
+							description="See how RadiantElement and RadiantController share one reactive host surface. Signals comes with Radiant; JSX is the TSX layer."
 							position={1}
 						/>
 						<HomeFeedArticle

--- a/apps/radiant-ui/src/content/components/getting-started/introduction.mdx
+++ b/apps/radiant-ui/src/content/components/getting-started/introduction.mdx
@@ -27,8 +27,10 @@ public API, not a generic placeholder.
 ## Install
 
 ```bash
-pnpm add @ecopages/radiant-ui @ecopages/radiant
+pnpm add @ecopages/radiant-ui
 ```
+
+Radiant, JSX, and Signals install as peers. You do not add them separately unless you are authoring hosts outside this library.
 
 Load a theme and the aggregate stylesheet in your app shell. See [Theming](/docs/getting-started/theming) to compose
 colour, spacing, and radius packs, and [Tokens](/docs/getting-started/tokens) for the scales those packs define.

--- a/apps/radiant-ui/src/pages/index.css
+++ b/apps/radiant-ui/src/pages/index.css
@@ -124,7 +124,7 @@
 }
 
 .home-path {
-	@apply mt-6 rounded-sm border border-border bg-background-accent p-6 md:p-8;
+	@apply mt-6;
 }
 
 .home-path__list {

--- a/apps/radiant-ui/src/pages/index.css
+++ b/apps/radiant-ui/src/pages/index.css
@@ -156,22 +156,43 @@
 }
 
 .home-footer {
-	@apply col-span-full border-t border-border pt-6 text-sm text-on-background/70;
+	@apply col-span-full flex flex-col gap-5 border-t border-border pt-6 text-sm text-on-background/70;
+}
 
-	p {
-		@apply flex flex-wrap justify-center gap-x-1;
+.home-footer__nav {
+	@apply grid gap-6 sm:grid-cols-2 lg:grid-cols-4;
+}
+
+.home-footer__label {
+	@apply m-0 text-xs font-semibold uppercase tracking-wide text-on-background/60;
+}
+
+.home-footer__list {
+	@apply m-0 mt-1 flex list-none flex-col p-0;
+}
+
+.home-footer__list a,
+.home-footer__bar a {
+	@apply inline-flex min-h-8 items-center text-sm font-normal text-on-background/80 no-underline underline-offset-4 decoration-border;
+
+	@media (hover: hover) {
+		@apply hover:text-on-background hover:underline hover:decoration-on-background;
 	}
 
-	a {
-		@apply font-medium text-on-background underline decoration-border underline-offset-4 transition-colors;
+	&:focus-visible {
+		@apply rounded-sm outline-2 outline-offset-2 outline-primary;
+	}
+}
 
-		@media (hover: hover) {
-			@apply hover:decoration-on-background;
-		}
+.home-footer__list [aria-current='page'] {
+	@apply inline-flex min-h-8 items-center text-sm font-normal text-on-background;
+}
 
-		&:focus-visible {
-			@apply rounded-sm outline-2 outline-offset-2 outline-primary;
-		}
+.home-footer__bar {
+	@apply flex flex-wrap items-center justify-between gap-x-4 gap-y-1 border-t border-border/60 pt-4;
+
+	p {
+		@apply m-0 flex flex-wrap items-center gap-x-1;
 	}
 }
 

--- a/apps/radiant-ui/src/pages/index.tsx
+++ b/apps/radiant-ui/src/pages/index.tsx
@@ -1,4 +1,5 @@
 import { eco } from '@ecopages/core';
+import type { JsxRenderable } from '@ecopages/jsx';
 import { codeToHtml } from 'shiki';
 import { RuiButton } from '@ecopages/radiant-ui/button';
 import { RuiChip } from '@ecopages/radiant-ui/chip';
@@ -36,20 +37,193 @@ const previewStyles = await codeToHtml(previewStylesExample, {
 const componentCount = componentNavEntries.length;
 const firstActionsHref = firstComponentHref('Actions');
 
+function highlightedCodeFigure(html: string): string {
+	return `<figure data-rehype-pretty-code-figure class="home-code-block">${html}</figure>`;
+}
+
+const INSTALL_TABS = [
+	{ id: 'npm', label: 'npm', code: 'npm install @ecopages/radiant-ui' },
+	{ id: 'pnpm', label: 'pnpm', code: 'pnpm add @ecopages/radiant-ui' },
+	{ id: 'bun', label: 'bun', code: 'bun add @ecopages/radiant-ui' },
+];
+
+const PREVIEW_TABS = [
+	{
+		id: 'preview',
+		label: 'preview.tsx',
+		html: highlightedCodeFigure(previewExample),
+		content: previewExampleCode,
+	},
+	{
+		id: 'styles',
+		label: 'styles.css',
+		html: highlightedCodeFigure(previewStyles),
+		content: previewStylesExample,
+	},
+];
+
+type HomeFeedArticleData = {
+	href: string;
+	label: string;
+	title: string;
+	description: string;
+};
+
+const EXPLORE_ARTICLES: HomeFeedArticleData[] = [
+	{
+		href: '/docs/getting-started/introduction',
+		label: 'Get started',
+		title: 'Learn the model',
+		description:
+			'Import focused modules, compose light-DOM views, and keep the public contract on the custom element.',
+	},
+	{
+		href: '/docs/getting-started/theming',
+		label: 'Theming',
+		title: 'Compose packs, not palettes',
+		description: 'Choose a colour profile, then layer spacing and radius. Components consume semantic roles.',
+	},
+	{
+		href: '/docs/getting-started/tokens',
+		label: 'Tokens',
+		title: 'See what components consume',
+		description: 'Colour roles, spacing, and radius scales with live swatches for every semantic token.',
+	},
+	{
+		href: firstActionsHref,
+		label: 'Components',
+		title: `${componentCount} documented parts`,
+		description: 'Each page pairs usage guidance with a playground that uses the real public API.',
+	},
+];
+
+const PATH_STEPS = [
+	'Read the overview, then install `@ecopages/radiant-ui`. Radiant, JSX, and Signals come along as peers.',
+	'Load a theme and the component stylesheet. Start with Glacier, then compose spacing and radius packs.',
+	'Import a focused module and compose the public JSX helpers in light DOM.',
+	'Use the playgrounds to inspect props, states, and accessibility notes.',
+];
+
+type HomePathCardData = {
+	href: string;
+	title: string;
+	description: string;
+};
+
+const PATH_CARDS: HomePathCardData[] = [
+	{
+		href: '/docs/getting-started/theming',
+		title: 'Compose a theme',
+		description: 'Import the default foundation, then layer the spacing and radius packs the product needs.',
+	},
+	{
+		href: '/docs/getting-started/tokens',
+		title: 'Read the token scales',
+		description: 'Components consume semantic roles and geometry roles, not palette steps.',
+	},
+	{
+		href: firstActionsHref,
+		title: 'Start with a control',
+		description: 'Open a component page and use the playground against the real public API.',
+	},
+];
+
+const AGENT_LINKS = [
+	{ href: '/skill.txt', label: 'skill.txt' },
+	{ href: '/skill/SKILL.md', label: 'SKILL.md' },
+	{ href: '/llms.txt', label: 'llms.txt' },
+];
+
+const ECOSYSTEM_PACKAGES = ['@ecopages/radiant-ui', '@ecopages/radiant', '@ecopages/jsx', '@ecopages/signals'];
+
+type HomeFooterLink = {
+	label: string;
+	href?: string;
+	external?: boolean;
+};
+
+type HomeFooterColumnData = {
+	title: string;
+	links: HomeFooterLink[];
+};
+
+const HOME_FOOTER_COLUMNS: HomeFooterColumnData[] = [
+	{
+		title: 'Ecosystem',
+		links: [
+			{ label: 'Ecopages', href: 'https://ecopages.app', external: true },
+			{ label: 'Radiant', href: 'https://radiant.ecopages.app', external: true },
+			{ label: 'Radiant UI' },
+			{ label: 'Scripts Injector', href: 'https://scripts-injector.ecopages.app', external: true },
+			{ label: 'Logger', href: 'https://github.com/ecopages/logger', external: true },
+		],
+	},
+	{
+		title: 'Guides',
+		links: [
+			{ label: 'Introduction', href: '/docs/getting-started/introduction' },
+			{ label: 'Theming', href: '/docs/getting-started/theming' },
+			{ label: 'Tokens', href: '/docs/getting-started/tokens' },
+		],
+	},
+	{
+		title: 'Library',
+		links: [
+			{ label: 'Actions', href: firstActionsHref },
+			{ label: 'Forms', href: firstComponentHref('Forms') },
+			{ label: 'Layout', href: firstComponentHref('Layout') },
+			{ label: 'Navigation', href: firstComponentHref('Navigation') },
+		],
+	},
+	{
+		title: 'Packages',
+		links: [
+			{ label: '@ecopages/radiant-ui', href: 'https://www.npmjs.com/package/@ecopages/radiant-ui', external: true },
+			{ label: '@ecopages/radiant', href: 'https://www.npmjs.com/package/@ecopages/radiant', external: true },
+			{ label: '@ecopages/jsx', href: 'https://www.npmjs.com/package/@ecopages/jsx', external: true },
+			{ label: '@ecopages/signals', href: 'https://www.npmjs.com/package/@ecopages/signals', external: true },
+		],
+	},
+];
+
+const HomeIcon = ({ children }: { children: JsxRenderable }) => (
+	<svg
+		xmlns="http://www.w3.org/2000/svg"
+		width="16"
+		height="16"
+		viewBox="0 0 24 24"
+		fill="none"
+		stroke="currentColor"
+		stroke-width="2"
+		stroke-linecap="round"
+		stroke-linejoin="round"
+	>
+		{children}
+	</svg>
+);
+
+const GitHubIcon = () => (
+	<HomeIcon>
+		<path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"></path>
+	</HomeIcon>
+);
+
+const LockIcon = () => (
+	<HomeIcon>
+		<rect x="3" y="11" width="18" height="11" rx="2" ry="2"></rect>
+		<path d="M7 11V7a5 5 0 0 1 10 0v4"></path>
+	</HomeIcon>
+);
+
 const HomeFeedArticle = ({
 	href,
 	label,
 	title,
 	description,
 	position,
-}: {
-	href: string;
-	label: string;
-	title: string;
-	description: string;
-	position: number;
-}) => (
-	<RuiFeedArticle posinset={position} setsize={4} tabindex={-1}>
+	setsize,
+}: HomeFeedArticleData & { position: number; setsize: number }) => (
+	<RuiFeedArticle posinset={position} setsize={setsize} tabindex={-1}>
 		<RuiFeedArticleHeader>
 			<RuiHeading size="sm">
 				<RuiHeadingEyebrow>{label}</RuiHeadingEyebrow>
@@ -67,7 +241,7 @@ const HomeFeedArticle = ({
 	</RuiFeedArticle>
 );
 
-const HomePathCard = ({ href, title, description }: { href: string; title: string; description: string }) => (
+const HomePathCard = ({ href, title, description }: HomePathCardData) => (
 	<a
 		href={href}
 		class="flex flex-col gap-1 rounded-sm border border-border bg-background p-4 text-on-background no-underline transition-colors hover:bg-secondary-container/30"
@@ -75,6 +249,98 @@ const HomePathCard = ({ href, title, description }: { href: string; title: strin
 		<p class="text-sm font-semibold">{title}</p>
 		<p class="text-sm text-on-background/70">{description}</p>
 	</a>
+);
+
+const HomeFooterNavItem = ({ link }: { link: HomeFooterLink }) => (
+	<li>
+		{link.href ? (
+			<a href={link.href} {...(link.external ? { target: '_blank', rel: 'noopener noreferrer' } : {})}>
+				{link.label}
+			</a>
+		) : (
+			<span aria-current="page">{link.label}</span>
+		)}
+	</li>
+);
+
+const HomeFooterColumn = ({ title, links }: HomeFooterColumnData) => (
+	<div class="home-footer__col">
+		<p class="home-footer__label">{title}</p>
+		<ul class="home-footer__list">
+			{links.map((link) => (
+				<HomeFooterNavItem link={link} />
+			))}
+		</ul>
+	</div>
+);
+
+const HomeFooterBar = () => (
+	<div class="home-footer__bar">
+		<p>
+			Created by{' '}
+			<a href="https://github.com/andeeplus" target="_blank" rel="noopener noreferrer">
+				andeeplus
+			</a>
+		</p>
+		<p>
+			Built with{' '}
+			<a href="https://github.com/ecopages/ecopages" target="_blank" rel="noopener noreferrer">
+				Ecopages
+			</a>
+			© {new Date().getFullYear()}
+		</p>
+	</div>
+);
+
+const HomeFooter = () => (
+	<footer class="home-footer">
+		<nav class="home-footer__nav" aria-label="Ecopages ecosystem">
+			{HOME_FOOTER_COLUMNS.map((column) => (
+				<HomeFooterColumn title={column.title} links={column.links} />
+			))}
+		</nav>
+		<HomeFooterBar />
+	</footer>
+);
+
+const HomeSidebarSection = ({ label, children }: { label: string; children: JsxRenderable }) => (
+	<div class="home-sidebar__section">
+		<p class="home-sidebar__label">{label}</p>
+		{children}
+	</div>
+);
+
+const HomeSidebar = () => (
+	<aside class="home-sidebar">
+		<HomeSidebarSection label="Repository">
+			<a href="https://github.com/ecopages/radiant" class="home-sidebar__value home-sidebar__link">
+				<GitHubIcon />
+				ecopages/radiant
+			</a>
+		</HomeSidebarSection>
+		<HomeSidebarSection label="License">
+			<p class="home-sidebar__value">
+				<LockIcon />
+				MIT
+			</p>
+		</HomeSidebarSection>
+		<HomeSidebarSection label="For agents">
+			<div class="home-sidebar__tags">
+				{AGENT_LINKS.map((link) => (
+					<RuiButton href={link.href} variant="outline" size="sm" class="font-mono">
+						{link.label}
+					</RuiButton>
+				))}
+			</div>
+		</HomeSidebarSection>
+		<HomeSidebarSection label="Ecosystem">
+			<div class="home-sidebar__tags">
+				{ECOSYSTEM_PACKAGES.map((name) => (
+					<RuiChip class="font-mono">{name}</RuiChip>
+				))}
+			</div>
+		</HomeSidebarSection>
+	</aside>
 );
 
 const HomePreviewCluster = () => (
@@ -87,265 +353,137 @@ const HomePreviewCluster = () => (
 	</div>
 );
 
-const HomePage = () => {
-	return (
-		<div class="home-layout">
-			<header class="home-header">
-				<div class="home-hero">
-					<div class="home-hero__text">
-						<RuiHeading size="xl" class="home-header__heading">
-							<RuiHeadingEyebrow>Radiant UI</RuiHeadingEyebrow>
-							<RuiHeadingTitle as="h1">
-								Accessible light-DOM components for Radiant hosts.
-							</RuiHeadingTitle>
-							<RuiHeadingDescription>
-								Import focused modules, compose views in the document tree, and theme through semantic
-								roles. Components ship accessible defaults; the document tree stays yours.
-							</RuiHeadingDescription>
-						</RuiHeading>
-
-						<CodeTabs
-							label="Package managers"
-							tabs={[
-								{
-									id: 'npm',
-									label: 'npm',
-									code: 'npm install @ecopages/radiant-ui @ecopages/radiant',
-								},
-								{
-									id: 'pnpm',
-									label: 'pnpm',
-									code: 'pnpm add @ecopages/radiant-ui @ecopages/radiant',
-								},
-								{
-									id: 'bun',
-									label: 'bun',
-									code: 'bun add @ecopages/radiant-ui @ecopages/radiant',
-								},
-							]}
-							copyLabel="Copy install command"
-							defaultSelectedKey="npm"
-						/>
-
-						<div class="home-header__actions">
-							<RuiButton href="/docs/getting-started/introduction">Read the overview</RuiButton>
-							<RuiButton href={firstActionsHref} variant="outline">
-								Browse components
-							</RuiButton>
-						</div>
-					</div>
-
-					<div class="home-hero__code">
-						<CodeTabs
-							label="Preview source"
-							tabs={[
-								{
-									id: 'preview',
-									label: 'preview.tsx',
-									html: `<figure data-rehype-pretty-code-figure class="home-code-block">${previewExample}</figure>`,
-									content: previewExampleCode,
-								},
-								{
-									id: 'styles',
-									label: 'styles.css',
-									html: `<figure data-rehype-pretty-code-figure class="home-code-block">${previewStyles}</figure>`,
-									content: previewStylesExample,
-								},
-							]}
-							copyLabel="Copy code"
-							defaultSelectedKey="preview"
-						/>
-
-						<div class="home-hero__demo">
-							<HomePreviewCluster />
-						</div>
-					</div>
+const HomeHero = () => (
+	<header class="home-header">
+		<div class="home-hero">
+			<div class="home-hero__text">
+				<RuiHeading size="xl" class="home-header__heading">
+					<RuiHeadingEyebrow>Radiant UI</RuiHeadingEyebrow>
+					<RuiHeadingTitle as="h1">Accessible light-DOM components for Radiant hosts.</RuiHeadingTitle>
+					<RuiHeadingDescription>
+						Import focused modules, compose views in the document tree, and theme through semantic roles.
+						Components ship accessible defaults; the document tree stays yours.
+					</RuiHeadingDescription>
+				</RuiHeading>
+				<CodeTabs
+					label="Package managers"
+					tabs={INSTALL_TABS}
+					copyLabel="Copy install command"
+					defaultSelectedKey="npm"
+				/>
+				<div class="home-header__actions">
+					<RuiButton href="/docs/getting-started/introduction">Read the overview</RuiButton>
+					<RuiButton href={firstActionsHref} variant="outline">
+						Browse components
+					</RuiButton>
 				</div>
-			</header>
-
-			<main class="home-main">
-				<section>
-					<RuiFeed label="Explore Radiant UI" class="home-cards">
-						<HomeFeedArticle
-							href="/docs/getting-started/introduction"
-							label="Get started"
-							title="Learn the model"
-							description="Import focused modules, compose light-DOM views, and keep the public contract on the custom element."
-							position={1}
-						/>
-						<HomeFeedArticle
-							href="/docs/getting-started/theming"
-							label="Theming"
-							title="Compose packs, not palettes"
-							description="Choose a colour profile, then layer spacing and radius. Components consume semantic roles."
-							position={2}
-						/>
-						<HomeFeedArticle
-							href="/docs/getting-started/tokens"
-							label="Tokens"
-							title="See what components consume"
-							description="Colour roles, spacing, and radius scales with live swatches for every semantic token."
-							position={3}
-						/>
-						<HomeFeedArticle
-							href={firstActionsHref}
-							label="Components"
-							title={`${componentCount} documented parts`}
-							description="Each page pairs usage guidance with a playground that uses the real public API."
-							position={4}
-						/>
-					</RuiFeed>
-				</section>
-
-				<section class="home-theme" aria-labelledby="home-theme-title">
-					<RuiHeading size="sm">
-						<RuiHeadingEyebrow>Theming</RuiHeadingEyebrow>
-						<RuiHeadingTitle id="home-theme-title" as="h2">
-							Remap this page
-						</RuiHeadingTitle>
-						<RuiHeadingDescription>
-							Colour, spacing, and radius are packs. They restyle this document; the hero JSX stays the
-							same.
-						</RuiHeadingDescription>
-					</RuiHeading>
-					<HomeThemePicker />
-				</section>
-
-				<section class="home-specimen" aria-labelledby="home-specimen-title">
-					<RuiHeading size="sm">
-						<RuiHeadingEyebrow>Library</RuiHeadingEyebrow>
-						<RuiHeadingTitle id="home-specimen-title" as="h2">
-							{componentCount} components
-						</RuiHeadingTitle>
-					</RuiHeading>
-					{groupedComponentNavEntries.map((group) => (
-						<div class="home-specimen__group">
-							<p class="home-specimen__category">{group.category}</p>
-							<ul class="home-specimen__list">
-								{group.items.map((item) => (
-									<li>
-										<a href={item.href}>{item.title}</a>
-									</li>
-								))}
-							</ul>
-						</div>
-					))}
-				</section>
-
-				<section class="home-path">
-					<RuiHeading as="header" size="sm">
-						<RuiHeadingEyebrow>Suggested path</RuiHeadingEyebrow>
-						<RuiHeadingTitle as="h2">Build confidence step by step</RuiHeadingTitle>
-					</RuiHeading>
-					<ol class="home-path__list">
-						<li>Read the overview, then install `@ecopages/radiant-ui` and `@ecopages/radiant`.</li>
-						<li>
-							Load a theme and the component stylesheet. Start with Glacier, then compose spacing and
-							radius packs.
-						</li>
-						<li>Import a focused module and compose the public JSX helpers in light DOM.</li>
-						<li>Use the playgrounds to inspect props, states, and accessibility notes.</li>
-					</ol>
-
-					<div class="mt-8 grid gap-3">
-						<HomePathCard
-							href="/docs/getting-started/theming"
-							title="Compose a theme"
-							description="Import the default foundation, then layer the spacing and radius packs the product needs."
-						/>
-						<HomePathCard
-							href="/docs/getting-started/tokens"
-							title="Read the token scales"
-							description="Components consume semantic roles and geometry roles, not palette steps."
-						/>
-						<HomePathCard
-							href={firstActionsHref}
-							title="Start with a control"
-							description="Open a component page and use the playground against the real public API."
-						/>
-					</div>
-				</section>
-			</main>
-
-			<aside class="home-sidebar">
-				<div class="home-sidebar__section">
-					<p class="home-sidebar__label">Repository</p>
-					<a href="https://github.com/ecopages/radiant" class="home-sidebar__value home-sidebar__link">
-						<svg
-							xmlns="http://www.w3.org/2000/svg"
-							width="16"
-							height="16"
-							viewBox="0 0 24 24"
-							fill="none"
-							stroke="currentColor"
-							stroke-width="2"
-							stroke-linecap="round"
-							stroke-linejoin="round"
-						>
-							<path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"></path>
-						</svg>
-						ecopages/radiant
-					</a>
+			</div>
+			<div class="home-hero__code">
+				<CodeTabs
+					label="Preview source"
+					tabs={PREVIEW_TABS}
+					copyLabel="Copy code"
+					defaultSelectedKey="preview"
+				/>
+				<div class="home-hero__demo">
+					<HomePreviewCluster />
 				</div>
-
-				<div class="home-sidebar__section">
-					<p class="home-sidebar__label">License</p>
-					<p class="home-sidebar__value">
-						<svg
-							xmlns="http://www.w3.org/2000/svg"
-							width="16"
-							height="16"
-							viewBox="0 0 24 24"
-							fill="none"
-							stroke="currentColor"
-							stroke-width="2"
-							stroke-linecap="round"
-							stroke-linejoin="round"
-						>
-							<rect x="3" y="11" width="18" height="11" rx="2" ry="2"></rect>
-							<path d="M7 11V7a5 5 0 0 1 10 0v4"></path>
-						</svg>
-						MIT
-					</p>
-				</div>
-
-				<div class="home-sidebar__section">
-					<p class="home-sidebar__label">For agents</p>
-					<div class="home-sidebar__tags">
-						<RuiButton href="/skill.txt" variant="outline" size="sm" class="font-mono">
-							skill.txt
-						</RuiButton>
-						<RuiButton href="/skill/SKILL.md" variant="outline" size="sm" class="font-mono">
-							SKILL.md
-						</RuiButton>
-						<RuiButton href="/llms.txt" variant="outline" size="sm" class="font-mono">
-							llms.txt
-						</RuiButton>
-					</div>
-				</div>
-
-				<div class="home-sidebar__section">
-					<p class="home-sidebar__label">Ecosystem</p>
-					<div class="home-sidebar__tags">
-						<RuiChip class="font-mono">@ecopages/radiant-ui</RuiChip>
-						<RuiChip class="font-mono">@ecopages/radiant</RuiChip>
-						<RuiChip class="font-mono">@ecopages/jsx</RuiChip>
-					</div>
-				</div>
-			</aside>
-
-			<footer class="home-footer">
-				<p>
-					Made with{' '}
-					<a href="https://github.com/ecopages/ecopages" target="_blank" rel="noopener noreferrer">
-						Ecopages
-					</a>
-					© {new Date().getFullYear()}
-				</p>
-			</footer>
+			</div>
 		</div>
-	);
-};
+	</header>
+);
+
+const HomeExplore = () => (
+	<section>
+		<RuiFeed label="Explore Radiant UI" class="home-cards">
+			{EXPLORE_ARTICLES.map((article, index) => (
+				<HomeFeedArticle
+					href={article.href}
+					label={article.label}
+					title={article.title}
+					description={article.description}
+					position={index + 1}
+					setsize={EXPLORE_ARTICLES.length}
+				/>
+			))}
+		</RuiFeed>
+	</section>
+);
+
+const HomeTheme = () => (
+	<section class="home-theme" aria-labelledby="home-theme-title">
+		<RuiHeading size="sm">
+			<RuiHeadingEyebrow>Theming</RuiHeadingEyebrow>
+			<RuiHeadingTitle id="home-theme-title" as="h2">
+				Remap this page
+			</RuiHeadingTitle>
+			<RuiHeadingDescription>
+				Colour, spacing, and radius are packs. They restyle this document; the hero JSX stays the same.
+			</RuiHeadingDescription>
+		</RuiHeading>
+		<HomeThemePicker />
+	</section>
+);
+
+const HomeSpecimenGroup = ({ category, items }: { category: string; items: { href: string; title: string }[] }) => (
+	<div class="home-specimen__group">
+		<p class="home-specimen__category">{category}</p>
+		<ul class="home-specimen__list">
+			{items.map((item) => (
+				<li>
+					<a href={item.href}>{item.title}</a>
+				</li>
+			))}
+		</ul>
+	</div>
+);
+
+const HomeSpecimen = () => (
+	<section class="home-specimen" aria-labelledby="home-specimen-title">
+		<RuiHeading size="sm">
+			<RuiHeadingEyebrow>Library</RuiHeadingEyebrow>
+			<RuiHeadingTitle id="home-specimen-title" as="h2">
+				{componentCount} components
+			</RuiHeadingTitle>
+		</RuiHeading>
+		{groupedComponentNavEntries.map((group) => (
+			<HomeSpecimenGroup category={group.category} items={group.items} />
+		))}
+	</section>
+);
+
+const HomePath = () => (
+	<section class="home-path">
+		<RuiHeading as="header" size="sm">
+			<RuiHeadingEyebrow>Suggested path</RuiHeadingEyebrow>
+			<RuiHeadingTitle as="h2">Build confidence step by step</RuiHeadingTitle>
+		</RuiHeading>
+		<ol class="home-path__list">
+			{PATH_STEPS.map((step) => (
+				<li>{step}</li>
+			))}
+		</ol>
+		<div class="mt-8 grid gap-3">
+			{PATH_CARDS.map((card) => (
+				<HomePathCard href={card.href} title={card.title} description={card.description} />
+			))}
+		</div>
+	</section>
+);
+
+const HomePage = () => (
+	<div class="home-layout">
+		<HomeHero />
+		<main class="home-main">
+			<HomeExplore />
+			<HomeTheme />
+			<HomeSpecimen />
+			<HomePath />
+		</main>
+		<HomeSidebar />
+		<HomeFooter />
+	</div>
+);
 
 export default eco.page({
 	layout: BaseLayout,

--- a/apps/radiant-ui/src/public/skill/SKILL.md
+++ b/apps/radiant-ui/src/public/skill/SKILL.md
@@ -24,8 +24,10 @@ For exhaustive generated docs, use [/llms.txt](/llms.txt). For `RadiantElement` 
 ## Install and load styles
 
 ```bash
-pnpm add @ecopages/radiant-ui @ecopages/radiant
+pnpm add @ecopages/radiant-ui
 ```
+
+Radiant, JSX, and Signals install as peers.
 
 Load a theme and the aggregate stylesheet before registering elements. Import focused modules; do not pull the root entry unless the app needs every custom element.
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,29 +48,29 @@ importers:
     apps/docs:
         devDependencies:
             '@ecopages/browser-router':
-                specifier: 0.2.0-beta.43
-                version: 0.2.0-beta.43(@ecopages/core@0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(typescript@7.0.2))
+                specifier: 0.2.0-rc.0
+                version: 0.2.0-rc.0(@ecopages/core@0.2.0-rc.0(@ecopages/dev-toolbar@0.2.0-rc.0)(typescript@7.0.2))
             '@ecopages/content-processor':
-                specifier: 0.2.0-beta.43
-                version: 0.2.0-beta.43(@ecopages/core@0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(typescript@7.0.2))(supports-color@7.2.0)(typescript@7.0.2)
+                specifier: 0.2.0-rc.0
+                version: 0.2.0-rc.0(@ecopages/core@0.2.0-rc.0(@ecopages/dev-toolbar@0.2.0-rc.0)(typescript@7.0.2))(supports-color@7.2.0)(typescript@7.0.2)
             '@ecopages/core':
-                specifier: 0.2.0-beta.43
-                version: 0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(typescript@7.0.2)
+                specifier: 0.2.0-rc.0
+                version: 0.2.0-rc.0(@ecopages/dev-toolbar@0.2.0-rc.0)(typescript@7.0.2)
             '@ecopages/dev-toolbar':
-                specifier: 0.2.0-beta.43
-                version: 0.2.0-beta.43
+                specifier: 0.2.0-rc.0
+                version: 0.2.0-rc.0
             '@ecopages/ecopages-jsx':
-                specifier: 0.2.0-beta.43
-                version: 0.2.0-beta.43(@ecopages/core@0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(typescript@7.0.2))(@ecopages/jsx@packages+jsx+dist)(@ecopages/radiant@packages+radiant+dist)(supports-color@7.2.0)(typescript@7.0.2)
+                specifier: 0.2.0-rc.0
+                version: 0.2.0-rc.0(@ecopages/core@0.2.0-rc.0(@ecopages/dev-toolbar@0.2.0-rc.0)(typescript@7.0.2))(@ecopages/jsx@packages+jsx+dist)(@ecopages/radiant@packages+radiant+dist)(supports-color@7.2.0)(typescript@7.0.2)
             '@ecopages/file-system':
-                specifier: 0.2.0-beta.43
-                version: 0.2.0-beta.43
+                specifier: 0.2.0-rc.0
+                version: 0.2.0-rc.0
             '@ecopages/jsx':
                 specifier: workspace:*
                 version: link:../../packages/jsx/dist
             '@ecopages/postcss-processor':
-                specifier: 0.2.0-beta.43
-                version: 0.2.0-beta.43(@ecopages/core@0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(typescript@7.0.2))(@tailwindcss/postcss@4.3.3)(tailwindcss@4.3.3)(typescript@7.0.2)
+                specifier: 0.2.0-rc.0
+                version: 0.2.0-rc.0(@ecopages/core@0.2.0-rc.0(@ecopages/dev-toolbar@0.2.0-rc.0)(typescript@7.0.2))(@tailwindcss/postcss@4.3.3)(tailwindcss@4.3.3)(typescript@7.0.2)
             '@ecopages/radiant':
                 specifier: workspace:*
                 version: link:../../packages/radiant/dist
@@ -96,8 +96,8 @@ importers:
                 specifier: ^24.13.2
                 version: 24.13.3
             ecopages:
-                specifier: 0.2.0-beta.43
-                version: 0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(bun-types@1.3.14)(typescript@7.0.2)
+                specifier: 0.2.0-rc.0
+                version: 0.2.0-rc.0(@ecopages/dev-toolbar@0.2.0-rc.0)(bun-types@1.3.14)(typescript@7.0.2)
             remark-gfm:
                 specifier: ^4.0.1
                 version: 4.0.1(supports-color@7.2.0)
@@ -126,26 +126,26 @@ importers:
     apps/radiant-ui:
         devDependencies:
             '@ecopages/browser-router':
-                specifier: 0.2.0-beta.43
-                version: 0.2.0-beta.43(@ecopages/core@0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(typescript@7.0.2))
+                specifier: 0.2.0-rc.0
+                version: 0.2.0-rc.0(@ecopages/core@0.2.0-rc.0(@ecopages/dev-toolbar@0.2.0-rc.0)(typescript@7.0.2))
             '@ecopages/content-processor':
-                specifier: 0.2.0-beta.43
-                version: 0.2.0-beta.43(@ecopages/core@0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(typescript@7.0.2))(supports-color@7.2.0)(typescript@7.0.2)
+                specifier: 0.2.0-rc.0
+                version: 0.2.0-rc.0(@ecopages/core@0.2.0-rc.0(@ecopages/dev-toolbar@0.2.0-rc.0)(typescript@7.0.2))(supports-color@7.2.0)(typescript@7.0.2)
             '@ecopages/core':
-                specifier: 0.2.0-beta.43
-                version: 0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(typescript@7.0.2)
+                specifier: 0.2.0-rc.0
+                version: 0.2.0-rc.0(@ecopages/dev-toolbar@0.2.0-rc.0)(typescript@7.0.2)
             '@ecopages/ecopages-jsx':
-                specifier: 0.2.0-beta.43
-                version: 0.2.0-beta.43(@ecopages/core@0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(typescript@7.0.2))(@ecopages/jsx@packages+jsx+dist)(@ecopages/radiant@packages+radiant+dist)(supports-color@7.2.0)(typescript@7.0.2)
+                specifier: 0.2.0-rc.0
+                version: 0.2.0-rc.0(@ecopages/core@0.2.0-rc.0(@ecopages/dev-toolbar@0.2.0-rc.0)(typescript@7.0.2))(@ecopages/jsx@packages+jsx+dist)(@ecopages/radiant@packages+radiant+dist)(supports-color@7.2.0)(typescript@7.0.2)
             '@ecopages/file-system':
-                specifier: 0.2.0-beta.43
-                version: 0.2.0-beta.43
+                specifier: 0.2.0-rc.0
+                version: 0.2.0-rc.0
             '@ecopages/jsx':
                 specifier: workspace:*
                 version: link:../../packages/jsx/dist
             '@ecopages/postcss-processor':
-                specifier: 0.2.0-beta.43
-                version: 0.2.0-beta.43(@ecopages/core@0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(typescript@7.0.2))(@tailwindcss/postcss@4.3.3)(tailwindcss@4.3.3)(typescript@7.0.2)
+                specifier: 0.2.0-rc.0
+                version: 0.2.0-rc.0(@ecopages/core@0.2.0-rc.0(@ecopages/dev-toolbar@0.2.0-rc.0)(typescript@7.0.2))(@tailwindcss/postcss@4.3.3)(tailwindcss@4.3.3)(typescript@7.0.2)
             '@ecopages/radiant':
                 specifier: workspace:*
                 version: link:../../packages/radiant/dist
@@ -159,8 +159,8 @@ importers:
                 specifier: ^24.13.2
                 version: 24.13.3
             ecopages:
-                specifier: 0.2.0-beta.43
-                version: 0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(bun-types@1.3.14)(typescript@7.0.2)
+                specifier: 0.2.0-rc.0
+                version: 0.2.0-rc.0(@ecopages/dev-toolbar@0.2.0-rc.0)(bun-types@1.3.14)(typescript@7.0.2)
             happy-dom:
                 specifier: ^20.0.0
                 version: 20.11.2
@@ -232,8 +232,8 @@ importers:
     packages/radiant:
         dependencies:
             '@ecopages/signals':
-                specifier: '>=0.3.0-beta.8'
-                version: 0.3.0-beta.8
+                specifier: '>=0.3.0-rc.0'
+                version: 0.3.0-rc.0
         devDependencies:
             '@babel/core':
                 specifier: ^7.28.0
@@ -310,7 +310,7 @@ importers:
                 version: 7.29.7(@babel/core@7.29.7(supports-color@7.2.0))
             '@chromatic-com/storybook':
                 specifier: ^5.2.1
-                version: 5.3.0(storybook@10.5.7(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))
+                version: 5.3.0(storybook@10.5.8(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))
             '@ecopages/jsx':
                 specifier: workspace:*
                 version: link:../jsx/dist
@@ -331,13 +331,13 @@ importers:
                 version: 0.2.3(@babel/core@7.29.7(supports-color@7.2.0))(@babel/runtime@7.29.7)(rolldown@1.2.4)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
             '@storybook/addon-a11y':
                 specifier: ^10.5.2
-                version: 10.5.7(storybook@10.5.7(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))
+                version: 10.5.8(storybook@10.5.8(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))
             '@storybook/addon-docs':
                 specifier: ^10.5.2
-                version: 10.5.7(@types/react@19.2.18)(esbuild@0.28.2)(rollup@4.62.4)(storybook@10.5.7(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+                version: 10.5.8(@types/react@19.2.18)(esbuild@0.28.2)(rollup@4.62.4)(storybook@10.5.8(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
             '@storybook/addon-vitest':
                 specifier: ^10.5.2
-                version: 10.5.7(@vitest/browser-playwright@4.1.10)(@vitest/browser@4.1.10)(@vitest/runner@4.1.10)(react@19.2.8)(storybook@10.5.7(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))(vitest@4.1.10)
+                version: 10.5.8(@vitest/browser-playwright@4.1.10)(@vitest/browser@4.1.10)(@vitest/runner@4.1.10)(react@19.2.8)(storybook@10.5.8(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))(vitest@4.1.10)
             '@tailwindcss/postcss':
                 specifier: ^4.3.3
                 version: 4.3.3
@@ -376,7 +376,7 @@ importers:
                 version: 19.2.8(react@19.2.8)
             storybook:
                 specifier: ^10.5.2
-                version: 10.5.7(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8)
+                version: 10.5.8(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8)
             tailwindcss:
                 specifier: ^4.1.11
                 version: 4.3.3
@@ -421,17 +421,17 @@ importers:
     packages/storybook-radiant-vite:
         dependencies:
             '@ecopages/radiant':
-                specifier: '>=0.3.0-beta.8'
-                version: 0.3.0-beta.8(@ecopages/jsx@packages+jsx+dist)
+                specifier: '>=0.3.0-rc.0'
+                version: 0.3.0-rc.0(@ecopages/jsx@packages+jsx+dist)
             '@ecopages/signals':
-                specifier: '>=0.3.0-beta.8'
-                version: 0.3.0-beta.8
+                specifier: '>=0.3.0-rc.0'
+                version: 0.3.0-rc.0
             '@ecopages/vite-plugin-radiant':
                 specifier: workspace:*
                 version: link:../vite-plugin-radiant
             '@storybook/builder-vite':
                 specifier: ^10.5.2
-                version: 10.5.7(esbuild@0.28.2)(rollup@4.62.4)(storybook@10.5.7(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+                version: 10.5.8(esbuild@0.28.2)(rollup@4.62.4)(storybook@10.5.8(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
             '@storybook/global':
                 specifier: ^5.0.0
                 version: 5.0.0
@@ -440,7 +440,7 @@ importers:
                 version: 0.28.2
             storybook:
                 specifier: ^10.5.2
-                version: 10.5.7(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8)
+                version: 10.5.8(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8)
             ts-dedent:
                 specifier: ^2.2.0
                 version: 2.3.0
@@ -1026,62 +1026,62 @@ packages:
                 integrity: sha512-3PxTH8itZzltK0U9jTwVVnjLXvnDYuq3m+QXsHkENxWiPRh4WaoLcs1SQjqgZ55kS+QyirpH5BVwzP2gMVG6EQ==,
             }
 
-    '@ecopages/browser-router@0.2.0-beta.43':
+    '@ecopages/browser-router@0.2.0-rc.0':
         resolution:
             {
-                integrity: sha512-2gBmDUvqP82Oaec7o5/c/jIscbCdYMnjdCZvhDLZnqTb2DN/ahyDnSPeh5bsT+BK2a3xoBP5M3OTXZE4I7R2oA==,
+                integrity: sha512-wB7URvBSD2Gc1waEg09icD00sdnKAKEEdT0/kDWqT0vR737yDNred0CPx5+/GDthUCQ42Bj4wJAIj3VfqxX4Nw==,
             }
         peerDependencies:
-            '@ecopages/core': 0.2.0-beta.43
+            '@ecopages/core': 0.2.0-rc.0
 
-    '@ecopages/content-processor@0.2.0-beta.43':
+    '@ecopages/content-processor@0.2.0-rc.0':
         resolution:
             {
-                integrity: sha512-19Sn9iesmma+nMCMdrEG+QX0UOSy4X6UZi7CGzpvV1KjqKRQGypW95bBfYFgTobT3bRjw/nKrN8oBzW4npm9ew==,
+                integrity: sha512-wF4rpwzLiOjyNK9qIInV2kQ+ALpcCemfQ39Lh0rJVqeT9seBjgrL7eGY1VHDoRMIV2n7k5WSjyHR30R+Njxisg==,
             }
         peerDependencies:
-            '@ecopages/core': 0.2.0-beta.43
+            '@ecopages/core': 0.2.0-rc.0
 
-    '@ecopages/core@0.2.0-beta.43':
+    '@ecopages/core@0.2.0-rc.0':
         resolution:
             {
-                integrity: sha512-BvBxKugEVZ4EtfpwIJmbOjdsfuuYO/1NGT0aONoELSLUdCqotVTfymqoSMPV8vRW91jY61A3RGiKQPskx8XB6g==,
+                integrity: sha512-C94dpIcDo7foXBNO1MNsrtceYszI34FiZe3bXZpUQf/4r5Ha5t0+MD/Dy6Xd6Nb9/cwB24jMrmdUCIuPKWF0Hw==,
             }
         peerDependencies:
-            '@ecopages/dev-toolbar': 0.2.0-beta.43
+            '@ecopages/dev-toolbar': 0.2.0-rc.0
         peerDependenciesMeta:
             '@ecopages/dev-toolbar':
                 optional: true
 
-    '@ecopages/dev-toolbar@0.2.0-beta.43':
+    '@ecopages/dev-toolbar@0.2.0-rc.0':
         resolution:
             {
-                integrity: sha512-q7T4NGRlBs/mih7jRUW76gNdeBfSorIh23DHYTblrtjdYEUGRleHA0dLyiWne6GMjwifzUqLsvsoCnA4fq9v/w==,
+                integrity: sha512-vyd90NF5OrgISmFvbDrJJkNlMsmfvX4BhcQhQU7QZcMbwLmvEHYoZcxoekz/btkG3c6q7iXBmwiNnRQa9tHnVA==,
             }
 
-    '@ecopages/ecopages-jsx@0.2.0-beta.43':
+    '@ecopages/ecopages-jsx@0.2.0-rc.0':
         resolution:
             {
-                integrity: sha512-HOy4Tm3H7ZZIc4L42duCgBkw9RQ5F49MHstbvA5JMjQ9GW72jRxthovKHy2kG0fOXvVxCu97SUjGEUB16JbhoA==,
+                integrity: sha512-wAPXcUcTybAjAmSb2Cnm1D848b/2Z85Nhc7sIAciOtfnhYUfK9wAftCtG+GyRX4yJLyMFZTxEIkGYEAT9cs3Bw==,
             }
         peerDependencies:
-            '@ecopages/core': 0.2.0-beta.43
-            '@ecopages/jsx': 0.3.0-beta.6
-            '@ecopages/radiant': 0.3.0-beta.6
+            '@ecopages/core': 0.2.0-rc.0
+            '@ecopages/jsx': 0.3.0-rc.0
+            '@ecopages/radiant': 0.3.0-rc.0
 
-    '@ecopages/file-system@0.2.0-beta.43':
+    '@ecopages/file-system@0.2.0-rc.0':
         resolution:
             {
-                integrity: sha512-SMFrJhYUyohrDe2Dpa7fT15G7PtsNrPzKYRIMgvQwWNAn+fT+PUcJ/tolmu49OZzjH4zj7yexbVOx23HiRpwqQ==,
+                integrity: sha512-U+ElqAP5j1dg7pJ1B23qHWmmsJn12GhGmzFDTKSfc/XsXligP+PjJ9UZT3w1PHd/hZKEu6kEcUkM21BbsUSFkg==,
             }
 
-    '@ecopages/jsx@0.3.0-beta.6':
+    '@ecopages/jsx@0.3.0-rc.0':
         resolution:
             {
-                integrity: sha512-0899gAdflauLTRWX0ul5kxJUEaALOKl4JGL9Dq42xncfWVSkEVdNTl6JIl5jx/EpXInYWn4JOflhYWv+/R6OUQ==,
+                integrity: sha512-m1whJscd9hgdIu9cwiuIV4HSlxwTC4MQ1C4Qv4tW8FUjA88ZBfVW3jkvlj55jl6dlzXmadDyBUiE2UfDrsTwoA==,
             }
         peerDependencies:
-            '@ecopages/signals': '>=0.3.0-beta.6'
+            '@ecopages/signals': '>=0.3.0-rc.0'
 
     '@ecopages/logger@0.2.3':
         resolution:
@@ -1091,22 +1091,22 @@ packages:
         peerDependencies:
             typescript: ^5.0.0
 
-    '@ecopages/mdx@0.2.0-beta.43':
+    '@ecopages/mdx@0.2.0-rc.0':
         resolution:
             {
-                integrity: sha512-0KAalriXkrnsTV7/YKAK9mXJ503iH4CFaG/ZTbbrTwfc52nsPp42R54wVZonP4XtuhjUbMOe0Dw8bAAyYllgQA==,
+                integrity: sha512-ols89h+kKeV9miZ+TF+ZOlV30jJagEG4Ydhw462f6TfFqvBTEEr8pyrTQD64XdXITQV4vi7J3kV9sOC90XjQkA==,
             }
         peerDependencies:
-            '@ecopages/core': 0.2.0-beta.43
+            '@ecopages/core': 0.2.0-rc.0
             '@mdx-js/mdx': ^3.1.0
 
-    '@ecopages/postcss-processor@0.2.0-beta.43':
+    '@ecopages/postcss-processor@0.2.0-rc.0':
         resolution:
             {
-                integrity: sha512-Ng1omlA+3LtEPVOzkrNw6R2ETGLwTCxdPxybGLzS5gc3Et0fYd35I7TC14Eey29309QdmGQ1qA581rbTeIfl6g==,
+                integrity: sha512-MmOooYKtL0XheGN5urR/L57PQeYNfjGndceeQmROuYguzXkE1gvK3ibS+EQ1cFf+RtIunOKsVFEV588j2Tqmbw==,
             }
         peerDependencies:
-            '@ecopages/core': 0.2.0-beta.43
+            '@ecopages/core': 0.2.0-rc.0
             '@tailwindcss/postcss': '>=4'
             tailwindcss: '>=3'
         peerDependenciesMeta:
@@ -1115,21 +1115,13 @@ packages:
             tailwindcss:
                 optional: true
 
-    '@ecopages/radiant@0.3.0-beta.6':
+    '@ecopages/radiant@0.3.0-rc.0':
         resolution:
             {
-                integrity: sha512-pXBAjkZioF8pQhBcwTpLB4AbsPRmuH228n5m4yHHK/XEVp0u69f4eEsF5RgJ5t6nFiw3h5pWmF0t4llnLHVcpg==,
+                integrity: sha512-qU40YZHEW+vZxquDt0U+6eQik5H6rRS5xbJyW6r7kGmSaBRl6+XtNrKsaTA71rjO2QlFx5ZBtPGEMB5R9C7tvw==,
             }
         peerDependencies:
-            '@ecopages/jsx': '>=0.3.0-beta.6'
-
-    '@ecopages/radiant@0.3.0-beta.8':
-        resolution:
-            {
-                integrity: sha512-jaFs82UUMqSybIkGL3HT2sp+ZaXj4cbIMRdE1Xee72n91xziEOn8wEsXLIPNgdB9lji1lY4NuJG+IVP2NSd8uQ==,
-            }
-        peerDependencies:
-            '@ecopages/jsx': '>=0.3.0-beta.8'
+            '@ecopages/jsx': '>=0.3.0-rc.0'
 
     '@ecopages/scripts-injector@0.1.5':
         resolution:
@@ -1139,16 +1131,10 @@ packages:
         peerDependencies:
             typescript: ^5.0.0
 
-    '@ecopages/signals@0.3.0-beta.6':
+    '@ecopages/signals@0.3.0-rc.0':
         resolution:
             {
-                integrity: sha512-VjF9D5kiTSQGx3k3Dqe5pmvkjb8uI6Fo7+3Zw4ed9jTPEa4cnk/COhm5JGOTQnXvqg3i1zOQNVMOi+WeiMs1ng==,
-            }
-
-    '@ecopages/signals@0.3.0-beta.8':
-        resolution:
-            {
-                integrity: sha512-fZSFmzNeoCWQGKLB32VnovwtojPH9YwSId44eyK2ynXDnGRqtxoQIG12TWBScUM520VvoX3efFqp9riWyXv6tg==,
+                integrity: sha512-Lh0KyMeJIAoUrYG4saNiWH8qDiR1xOA2o/wa97ZJRzwIHQEDTmgdTIUS3R9XpSt6aHvJvOuVsWZIzem0VtkHcQ==,
             }
 
     '@emnapi/core@1.11.2':
@@ -2968,36 +2954,36 @@ packages:
                 integrity: sha512-MS6PCYiRNJ32c69+3NPyL+bu7LpiFDvMcBXnlhQnF8CKMG0R/xRVCCo422NPkQ0+Cox3xKpk5Lc1LfWFS4b3cw==,
             }
 
-    '@storybook/addon-a11y@10.5.7':
+    '@storybook/addon-a11y@10.5.8':
         resolution:
             {
-                integrity: sha512-I30rsNz6aA3xg3811MEry40uJDHP3l5SOkfqtmNkp7y4NdqTDdKhmbhhDAZQX1WWEk6GeMBGr3AJ3TCz7r7JmQ==,
+                integrity: sha512-yunl+sKa29NaUC3I4yjESwk6ED8waEgmmvIJzNAJvdhb7thFzZYYEld68RzKmOVcGBkD3snK5eZ/Xf0l4VWliQ==,
             }
         peerDependencies:
-            storybook: ^10.5.7
+            storybook: ^10.5.8
 
-    '@storybook/addon-docs@10.5.7':
+    '@storybook/addon-docs@10.5.8':
         resolution:
             {
-                integrity: sha512-KNARJfjICaizinsR3INMEiipZm1ObYo+xw+E26gteu50Bcy2dIZUtk5uHY5XdtardU3AXX6yRXoBZ2HCY3lbHA==,
+                integrity: sha512-NlHiMKW/UvW/uL8HXFDCEVwoH3qZeGYZ/qlWax4d7H471b/T54MBq2KcB4ZrdA785FfIH3numAJdBb5jwn00Mg==,
             }
         peerDependencies:
             '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-            storybook: ^10.5.7
+            storybook: ^10.5.8
         peerDependenciesMeta:
             '@types/react':
                 optional: true
 
-    '@storybook/addon-vitest@10.5.7':
+    '@storybook/addon-vitest@10.5.8':
         resolution:
             {
-                integrity: sha512-7NK7Kzazc2vb2h8nGlH15QlUn5J6/LV0xF70VziAK0bxu3r1JupLCoBvckX39vHzFXiAZljXZtt1Wq/OidBxow==,
+                integrity: sha512-/2K6JXncyHEM8v7UfOeR0KGd7s46Q2XlfaBJUnBoGsEG6JF46la8sh43b+kIOG7JGPUqlyfA6uOMewUmG6S17w==,
             }
         peerDependencies:
             '@vitest/browser': ^3.0.0 || ^4.0.0
             '@vitest/browser-playwright': ^4.0.0
             '@vitest/runner': ^3.0.0 || ^4.0.0
-            storybook: ^10.5.7
+            storybook: ^10.5.8
             vitest: ^3.0.0 || ^4.0.0
         peerDependenciesMeta:
             '@vitest/browser':
@@ -3009,24 +2995,24 @@ packages:
             vitest:
                 optional: true
 
-    '@storybook/builder-vite@10.5.7':
+    '@storybook/builder-vite@10.5.8':
         resolution:
             {
-                integrity: sha512-fShF/aQaITqcJuMCLr42BGNUAbhDi4IboqvlbZqXAwgrrTslnZEUnY8GcEcvpZmjl11VwlmazhMJdH50fIgBPg==,
+                integrity: sha512-UeRnn7yT55WmBlHNOQzLrvN7vsHEvVgIukhKDO+4cMbGXN87wZkbxhx6NstpuXRH8OxGqwKS0SZNVp+SC1ftLQ==,
             }
         peerDependencies:
-            storybook: ^10.5.7
+            storybook: ^10.5.8
             vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
-    '@storybook/csf-plugin@10.5.7':
+    '@storybook/csf-plugin@10.5.8':
         resolution:
             {
-                integrity: sha512-IaX8FlM0H36HNFhJ2+4L9bCldqfvHGqcLg841SJNyK/DhfMlM7JsvY/GDH2ZFuWrUf8FSOx96GRRnHq6XfRKag==,
+                integrity: sha512-/FHiMyOWWEXfwK/lM0WxmkP9GLzbSJJuzGtfeuNWSOVDnvAMbjavitxfHb5wSbWKIQo0XYC1EJ2Y7x91XNYP4w==,
             }
         peerDependencies:
             esbuild: '*'
             rollup: '*'
-            storybook: ^10.5.7
+            storybook: ^10.5.8
             vite: '*'
             webpack: '*'
         peerDependenciesMeta:
@@ -3053,17 +3039,17 @@ packages:
         peerDependencies:
             react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-    '@storybook/react-dom-shim@10.5.7':
+    '@storybook/react-dom-shim@10.5.8':
         resolution:
             {
-                integrity: sha512-lxOkyh+wu/MiBXvYQHjZfD+DRKOa4bHBzbuGuiHXnHXmdOcTRdcrQTsoeN2FPtfugmmOG66cZUEgDwNX+k5eRA==,
+                integrity: sha512-N8D13/Xny+V3kfe1KBgsAHS0nKWXLLdgOOXS9poKdYzVwVCN+CGEGBxWX0zMMtdCptqa6/57em9coPlZMoO+bg==,
             }
         peerDependencies:
             '@types/react': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
             '@types/react-dom': ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
             react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
             react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-            storybook: ^10.5.7
+            storybook: ^10.5.8
         peerDependenciesMeta:
             '@types/react':
                 optional: true
@@ -3818,10 +3804,10 @@ packages:
                 integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==,
             }
 
-    baseline-browser-mapping@2.11.13:
+    baseline-browser-mapping@2.11.14:
         resolution:
             {
-                integrity: sha512-k9HNuUVMlqVjQ9UHzfPjIqiDbWw7WqT1AoT7GL8VwvF3r0ZfArtgiSPAlmupyNquNgOJHTuH4CKYf8ttMTWBTQ==,
+                integrity: sha512-JyJ954WzuIR8/FFzX0o5krdSTrBAkcCSRfWSleRsIHSWV+cZe2FI1PKggVkFke1hBldRs+LRxUczzE9iPmgZww==,
             }
         engines: { node: '>=6.0.0' }
         hasBin: true
@@ -4353,10 +4339,10 @@ packages:
             }
         engines: { node: '>=10' }
 
-    ecopages@0.2.0-beta.43:
+    ecopages@0.2.0-rc.0:
         resolution:
             {
-                integrity: sha512-pnjefjdb6Vs1QMniwfJpoy75bRuktUXmOKLIW38LTLowr0TxBDGSg27tezi7Wrgy62FIENf8/q17OIa7SPs4HA==,
+                integrity: sha512-HSt5WSzM/5d21xOkMUqVvWprj7aEUIjrzpoq0uP0qsCYEfpzinxmbGrzmh5xKy8t33Qi/FJXvln77RgNEOh2LQ==,
             }
         engines: { node: '>=24.0.0' }
         hasBin: true
@@ -4680,13 +4666,6 @@ packages:
                 integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==,
             }
         engines: { node: '>=6.9.0' }
-
-    ghtml@4.0.2:
-        resolution:
-            {
-                integrity: sha512-ymJljsiXUc6hrq2407EnkyCQ8dk5NVEvpAbB4fhnZ+oqP0u9Aq/YWsNkDh+Ew5lBz2uGqyLfzCBdE8J8g4NNgg==,
-            }
-        engines: { node: '>=18' }
 
     giget@2.0.0:
         resolution:
@@ -6882,10 +6861,10 @@ packages:
                 integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==,
             }
 
-    storybook@10.5.7:
+    storybook@10.5.8:
         resolution:
             {
-                integrity: sha512-oiKvWIwIoOhFP1i6dASYyMXwPHKEtVZMshqSB7EvIVYjWRh0l9H7gHEt1z4Gh2rLGFMekWdsm4s94rvwpR7gkg==,
+                integrity: sha512-rR4oFMSiWBSqI0lvsJPtcQUPj8+hzj3TkLu+Mw61Wo6YxPSb5FsLSHai0jZnuaIdKIlmu25KCfwlSQl4e1uvnA==,
             }
         hasBin: true
         peerDependencies:
@@ -7967,12 +7946,12 @@ snapshots:
             human-id: 4.2.0
             prettier: 2.8.8
 
-    '@chromatic-com/storybook@5.3.0(storybook@10.5.7(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))':
+    '@chromatic-com/storybook@5.3.0(storybook@10.5.8(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))':
         dependencies:
             '@neoconfetti/react': 1.0.0
             chromatic: 18.2.0
             jsonfile: 6.2.1
-            storybook: 10.5.7(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8)
+            storybook: 10.5.8(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8)
             strip-ansi: 7.2.0
         transitivePeerDependencies:
             - '@chromatic-com/cypress'
@@ -7993,15 +7972,15 @@ snapshots:
 
     '@colordx/core@5.5.0': {}
 
-    '@ecopages/browser-router@0.2.0-beta.43(@ecopages/core@0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(typescript@7.0.2))':
+    '@ecopages/browser-router@0.2.0-rc.0(@ecopages/core@0.2.0-rc.0(@ecopages/dev-toolbar@0.2.0-rc.0)(typescript@7.0.2))':
         dependencies:
-            '@ecopages/core': 0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(typescript@7.0.2)
+            '@ecopages/core': 0.2.0-rc.0(@ecopages/dev-toolbar@0.2.0-rc.0)(typescript@7.0.2)
             morphdom: 2.7.8
 
-    '@ecopages/content-processor@0.2.0-beta.43(@ecopages/core@0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(typescript@7.0.2))(supports-color@7.2.0)(typescript@7.0.2)':
+    '@ecopages/content-processor@0.2.0-rc.0(@ecopages/core@0.2.0-rc.0(@ecopages/dev-toolbar@0.2.0-rc.0)(typescript@7.0.2))(supports-color@7.2.0)(typescript@7.0.2)':
         dependencies:
-            '@ecopages/core': 0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(typescript@7.0.2)
-            '@ecopages/file-system': 0.2.0-beta.43
+            '@ecopages/core': 0.2.0-rc.0(@ecopages/dev-toolbar@0.2.0-rc.0)(typescript@7.0.2)
+            '@ecopages/file-system': 0.2.0-rc.0
             '@ecopages/logger': 0.2.3(typescript@7.0.2)
             remark-frontmatter: 5.0.0(supports-color@7.2.0)
             unified: 11.0.5
@@ -8011,9 +7990,9 @@ snapshots:
             - supports-color
             - typescript
 
-    '@ecopages/core@0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(typescript@7.0.2)':
+    '@ecopages/core@0.2.0-rc.0(@ecopages/dev-toolbar@0.2.0-rc.0)(typescript@7.0.2)':
         dependencies:
-            '@ecopages/file-system': 0.2.0-beta.43
+            '@ecopages/file-system': 0.2.0-rc.0
             '@ecopages/logger': 0.2.3(typescript@7.0.2)
             '@ecopages/scripts-injector': 0.1.5(typescript@7.0.2)
             '@oxc-project/runtime': 0.141.0
@@ -8021,30 +8000,29 @@ snapshots:
             '@standard-schema/utils': 0.3.0
             '@worker-tools/html-rewriter': 0.1.0-pre.19
             chokidar: 5.0.0
-            ghtml: 4.0.2
             oxc-parser: 0.141.0
             oxc-resolver: 11.24.2
             rolldown: 1.2.4
             ws: 8.21.3
         optionalDependencies:
-            '@ecopages/dev-toolbar': 0.2.0-beta.43
+            '@ecopages/dev-toolbar': 0.2.0-rc.0
         transitivePeerDependencies:
             - bufferutil
             - typescript
             - utf-8-validate
 
-    '@ecopages/dev-toolbar@0.2.0-beta.43':
+    '@ecopages/dev-toolbar@0.2.0-rc.0':
         dependencies:
-            '@ecopages/jsx': 0.3.0-beta.6(@ecopages/signals@0.3.0-beta.6)
-            '@ecopages/radiant': 0.3.0-beta.6(@ecopages/jsx@0.3.0-beta.6(@ecopages/signals@0.3.0-beta.6))
-            '@ecopages/signals': 0.3.0-beta.6
+            '@ecopages/jsx': 0.3.0-rc.0(@ecopages/signals@0.3.0-rc.0)
+            '@ecopages/radiant': 0.3.0-rc.0(@ecopages/jsx@0.3.0-rc.0(@ecopages/signals@0.3.0-rc.0))
+            '@ecopages/signals': 0.3.0-rc.0
             axe-core: 4.13.0
 
-    '@ecopages/ecopages-jsx@0.2.0-beta.43(@ecopages/core@0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(typescript@7.0.2))(@ecopages/jsx@packages+jsx+dist)(@ecopages/radiant@packages+radiant+dist)(supports-color@7.2.0)(typescript@7.0.2)':
+    '@ecopages/ecopages-jsx@0.2.0-rc.0(@ecopages/core@0.2.0-rc.0(@ecopages/dev-toolbar@0.2.0-rc.0)(typescript@7.0.2))(@ecopages/jsx@packages+jsx+dist)(@ecopages/radiant@packages+radiant+dist)(supports-color@7.2.0)(typescript@7.0.2)':
         dependencies:
-            '@ecopages/core': 0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(typescript@7.0.2)
+            '@ecopages/core': 0.2.0-rc.0(@ecopages/dev-toolbar@0.2.0-rc.0)(typescript@7.0.2)
             '@ecopages/jsx': link:packages/jsx/dist
-            '@ecopages/mdx': 0.2.0-beta.43(@ecopages/core@0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(typescript@7.0.2))(@mdx-js/mdx@3.1.1(supports-color@7.2.0))(typescript@7.0.2)
+            '@ecopages/mdx': 0.2.0-rc.0(@ecopages/core@0.2.0-rc.0(@ecopages/dev-toolbar@0.2.0-rc.0)(typescript@7.0.2))(@mdx-js/mdx@3.1.1(supports-color@7.2.0))(typescript@7.0.2)
             '@ecopages/radiant': link:packages/radiant/dist
             '@mdx-js/mdx': 3.1.1(supports-color@7.2.0)
             vfile: 6.0.3
@@ -8052,19 +8030,19 @@ snapshots:
             - supports-color
             - typescript
 
-    '@ecopages/file-system@0.2.0-beta.43': {}
+    '@ecopages/file-system@0.2.0-rc.0': {}
 
-    '@ecopages/jsx@0.3.0-beta.6(@ecopages/signals@0.3.0-beta.6)':
+    '@ecopages/jsx@0.3.0-rc.0(@ecopages/signals@0.3.0-rc.0)':
         dependencies:
-            '@ecopages/signals': 0.3.0-beta.6
+            '@ecopages/signals': 0.3.0-rc.0
 
     '@ecopages/logger@0.2.3(typescript@7.0.2)':
         dependencies:
             typescript: 7.0.2
 
-    '@ecopages/mdx@0.2.0-beta.43(@ecopages/core@0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(typescript@7.0.2))(@mdx-js/mdx@3.1.1(supports-color@7.2.0))(typescript@7.0.2)':
+    '@ecopages/mdx@0.2.0-rc.0(@ecopages/core@0.2.0-rc.0(@ecopages/dev-toolbar@0.2.0-rc.0)(typescript@7.0.2))(@mdx-js/mdx@3.1.1(supports-color@7.2.0))(typescript@7.0.2)':
         dependencies:
-            '@ecopages/core': 0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(typescript@7.0.2)
+            '@ecopages/core': 0.2.0-rc.0(@ecopages/dev-toolbar@0.2.0-rc.0)(typescript@7.0.2)
             '@ecopages/logger': 0.2.3(typescript@7.0.2)
             '@mdx-js/mdx': 3.1.1(supports-color@7.2.0)
             source-map: 0.8.0
@@ -8072,10 +8050,10 @@ snapshots:
         transitivePeerDependencies:
             - typescript
 
-    '@ecopages/postcss-processor@0.2.0-beta.43(@ecopages/core@0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(typescript@7.0.2))(@tailwindcss/postcss@4.3.3)(tailwindcss@4.3.3)(typescript@7.0.2)':
+    '@ecopages/postcss-processor@0.2.0-rc.0(@ecopages/core@0.2.0-rc.0(@ecopages/dev-toolbar@0.2.0-rc.0)(typescript@7.0.2))(@tailwindcss/postcss@4.3.3)(tailwindcss@4.3.3)(typescript@7.0.2)':
         dependencies:
-            '@ecopages/core': 0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(typescript@7.0.2)
-            '@ecopages/file-system': 0.2.0-beta.43
+            '@ecopages/core': 0.2.0-rc.0(@ecopages/dev-toolbar@0.2.0-rc.0)(typescript@7.0.2)
+            '@ecopages/file-system': 0.2.0-rc.0
             '@ecopages/logger': 0.2.3(typescript@7.0.2)
             autoprefixer: 10.5.4(postcss@8.5.26)
             browserslist: 4.28.8
@@ -8089,11 +8067,11 @@ snapshots:
         transitivePeerDependencies:
             - typescript
 
-    '@ecopages/radiant@0.3.0-beta.6(@ecopages/jsx@0.3.0-beta.6(@ecopages/signals@0.3.0-beta.6))':
+    '@ecopages/radiant@0.3.0-rc.0(@ecopages/jsx@0.3.0-rc.0(@ecopages/signals@0.3.0-rc.0))':
         dependencies:
-            '@ecopages/jsx': 0.3.0-beta.6(@ecopages/signals@0.3.0-beta.6)
+            '@ecopages/jsx': 0.3.0-rc.0(@ecopages/signals@0.3.0-rc.0)
 
-    '@ecopages/radiant@0.3.0-beta.8(@ecopages/jsx@packages+jsx+dist)':
+    '@ecopages/radiant@0.3.0-rc.0(@ecopages/jsx@packages+jsx+dist)':
         dependencies:
             '@ecopages/jsx': link:packages/jsx/dist
 
@@ -8101,9 +8079,7 @@ snapshots:
         dependencies:
             typescript: 7.0.2
 
-    '@ecopages/signals@0.3.0-beta.6': {}
-
-    '@ecopages/signals@0.3.0-beta.8': {}
+    '@ecopages/signals@0.3.0-rc.0': {}
 
     '@emnapi/core@1.11.2':
         dependencies:
@@ -8842,21 +8818,21 @@ snapshots:
 
     '@stardazed/zlib@1.0.1': {}
 
-    '@storybook/addon-a11y@10.5.7(storybook@10.5.7(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))':
+    '@storybook/addon-a11y@10.5.8(storybook@10.5.8(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))':
         dependencies:
             '@storybook/global': 5.0.0
             axe-core: 4.13.0
-            storybook: 10.5.7(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8)
+            storybook: 10.5.8(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8)
 
-    '@storybook/addon-docs@10.5.7(@types/react@19.2.18)(esbuild@0.28.2)(rollup@4.62.4)(storybook@10.5.7(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))':
+    '@storybook/addon-docs@10.5.8(@types/react@19.2.18)(esbuild@0.28.2)(rollup@4.62.4)(storybook@10.5.8(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))':
         dependencies:
             '@mdx-js/react': 3.1.1(@types/react@19.2.18)(react@19.2.8)
-            '@storybook/csf-plugin': 10.5.7(esbuild@0.28.2)(rollup@4.62.4)(storybook@10.5.7(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+            '@storybook/csf-plugin': 10.5.8(esbuild@0.28.2)(rollup@4.62.4)(storybook@10.5.8(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
             '@storybook/icons': 2.1.0(react@19.2.8)
-            '@storybook/react-dom-shim': 10.5.7(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(storybook@10.5.7(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))
+            '@storybook/react-dom-shim': 10.5.8(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(storybook@10.5.8(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))
             react: 19.2.8
             react-dom: 19.2.8(react@19.2.8)
-            storybook: 10.5.7(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8)
+            storybook: 10.5.8(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8)
             ts-dedent: 2.3.0
         optionalDependencies:
             '@types/react': 19.2.18
@@ -8867,11 +8843,11 @@ snapshots:
             - vite
             - webpack
 
-    '@storybook/addon-vitest@10.5.7(@vitest/browser-playwright@4.1.10)(@vitest/browser@4.1.10)(@vitest/runner@4.1.10)(react@19.2.8)(storybook@10.5.7(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))(vitest@4.1.10)':
+    '@storybook/addon-vitest@10.5.8(@vitest/browser-playwright@4.1.10)(@vitest/browser@4.1.10)(@vitest/runner@4.1.10)(react@19.2.8)(storybook@10.5.8(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))(vitest@4.1.10)':
         dependencies:
             '@storybook/global': 5.0.0
             '@storybook/icons': 2.1.0(react@19.2.8)
-            storybook: 10.5.7(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8)
+            storybook: 10.5.8(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8)
         optionalDependencies:
             '@vitest/browser': 4.1.10(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))(vitest@4.1.10)
             '@vitest/browser-playwright': 4.1.10(playwright@1.62.1)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))(vitest@4.1.10)
@@ -8880,10 +8856,10 @@ snapshots:
         transitivePeerDependencies:
             - react
 
-    '@storybook/builder-vite@10.5.7(esbuild@0.28.2)(rollup@4.62.4)(storybook@10.5.7(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))':
+    '@storybook/builder-vite@10.5.8(esbuild@0.28.2)(rollup@4.62.4)(storybook@10.5.8(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))':
         dependencies:
-            '@storybook/csf-plugin': 10.5.7(esbuild@0.28.2)(rollup@4.62.4)(storybook@10.5.7(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
-            storybook: 10.5.7(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8)
+            '@storybook/csf-plugin': 10.5.8(esbuild@0.28.2)(rollup@4.62.4)(storybook@10.5.8(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+            storybook: 10.5.8(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8)
             ts-dedent: 2.3.0
             vite: 8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
         transitivePeerDependencies:
@@ -8891,9 +8867,9 @@ snapshots:
             - rollup
             - webpack
 
-    '@storybook/csf-plugin@10.5.7(esbuild@0.28.2)(rollup@4.62.4)(storybook@10.5.7(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))':
+    '@storybook/csf-plugin@10.5.8(esbuild@0.28.2)(rollup@4.62.4)(storybook@10.5.8(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))':
         dependencies:
-            storybook: 10.5.7(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8)
+            storybook: 10.5.8(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8)
             unplugin: 2.3.11
         optionalDependencies:
             esbuild: 0.28.2
@@ -8906,11 +8882,11 @@ snapshots:
         dependencies:
             react: 19.2.8
 
-    '@storybook/react-dom-shim@10.5.7(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(storybook@10.5.7(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))':
+    '@storybook/react-dom-shim@10.5.8(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(storybook@10.5.8(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))':
         dependencies:
             react: 19.2.8
             react-dom: 19.2.8(react@19.2.8)
-            storybook: 10.5.7(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8)
+            storybook: 10.5.8(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8)
         optionalDependencies:
             '@types/react': 19.2.18
 
@@ -9339,7 +9315,7 @@ snapshots:
 
     bail@2.0.2: {}
 
-    baseline-browser-mapping@2.11.13: {}
+    baseline-browser-mapping@2.11.14: {}
 
     better-commits@1.24.0(typescript@7.0.2):
         dependencies:
@@ -9367,7 +9343,7 @@ snapshots:
 
     browserslist@4.28.8:
         dependencies:
-            baseline-browser-mapping: 2.11.13
+            baseline-browser-mapping: 2.11.14
             caniuse-lite: 1.0.30001809
             electron-to-chromium: 1.5.405
             node-releases: 2.0.53
@@ -9629,9 +9605,9 @@ snapshots:
 
     dotenv@8.6.0: {}
 
-    ecopages@0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(bun-types@1.3.14)(typescript@7.0.2):
+    ecopages@0.2.0-rc.0(@ecopages/dev-toolbar@0.2.0-rc.0)(bun-types@1.3.14)(typescript@7.0.2):
         dependencies:
-            '@ecopages/core': 0.2.0-beta.43(@ecopages/dev-toolbar@0.2.0-beta.43)(typescript@7.0.2)
+            '@ecopages/core': 0.2.0-rc.0(@ecopages/dev-toolbar@0.2.0-rc.0)(typescript@7.0.2)
             '@ecopages/logger': 0.2.3(typescript@7.0.2)
             bun-types: 1.3.14
             giget: 2.0.0
@@ -9860,8 +9836,6 @@ snapshots:
     function-bind@1.1.2: {}
 
     gensync@1.0.0-beta.2: {}
-
-    ghtml@4.0.2: {}
 
     giget@2.0.0:
         dependencies:
@@ -11520,7 +11494,7 @@ snapshots:
 
     std-env@4.2.0: {}
 
-    storybook@10.5.7(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8):
+    storybook@10.5.8(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8):
         dependencies:
             '@storybook/global': 5.0.0
             '@storybook/icons': 2.1.0(react@19.2.8)


### PR DESCRIPTION
## Summary
- Treat Signals as Radiant's default reactivity layer in CONTEXT, install, and homepage copy; JSX stays the TSX companion.
- Add a UI site link in the docs header and docs layout nav.
- Balance the docs homepage hero columns and drop the bordered home-path card on both sites.

## Test plan
- [x] Docs homepage and installation copy describe Signals as default and JSX as optional
- [x] Docs header and docs-layout nav link to https://radiant-ui.ecopages.app
- [x] Docs homepage hero layout holds at large breakpoints
- [x] Home path sections on docs and radiant-ui no longer use the bordered card chrome