### PR TITLE
feat(radiant-ui): add RuiForm onSubmit and native submission

### DIFF
--- a/.changeset/form-native-submission.md
+++ b/.changeset/form-native-submission.md
@@ -1,0 +1,5 @@
+---
+'@ecopages/radiant-ui': minor
+---
+
+Add `RuiForm` `onSubmit`, `action`, and `method` support, plus form-context error state. `onSubmit` receives validated values; without it, forms with an action or method submit natively after validation.

--- a/apps/radiant-ui/src/content/components/form.mdx
+++ b/apps/radiant-ui/src/content/components/form.mdx
@@ -30,7 +30,7 @@ export const config = {
 
 ## Usage
 
-Wrap fields in `RuiForm` and handle `on:submit` with validated values. Choose `mode` to control when validation runs.
+Wrap fields in `RuiForm` and handle validated values with `onSubmit`. Choose `mode` to control when validation runs.
 
 ```tsx
 import { RuiForm } from '@ecopages/radiant-ui/form';
@@ -39,7 +39,7 @@ import { RuiLabel } from '@ecopages/radiant-ui/label';
 import { RuiInput } from '@ecopages/radiant-ui/input';
 import { RuiButton } from '@ecopages/radiant-ui/button';
 
-<RuiForm mode="onSubmit" on:submit={handleSubmit}>
+<RuiForm mode="onSubmit" onSubmit={handleSubmit}>
   <RuiField name="name" rules={{ required: 'Name is required' }}>
     <RuiLabel>Full name</RuiLabel>
     <RuiInput />
@@ -47,6 +47,8 @@ import { RuiButton } from '@ecopages/radiant-ui/button';
   <RuiButton type="submit">Create account</RuiButton>
 </RuiForm>
 ```
+
+Load `@ecopages/radiant-ui/styles.css` once in your app to style the form and every composed control. When bundling styles per component, import `@ecopages/radiant-ui/form/styles.css` plus the stylesheet for every component used inside the form, such as `field/styles.css`, `textarea/styles.css`, or `number-field/styles.css`.
 
 ## Validation timing
 
@@ -81,6 +83,8 @@ The form itself carries no color roles; fields, labels, and controls inside keep
 | `mode` | `onSubmit` · `onBlur` · `onChange` · `onTouched` · `all` | `onSubmit` | When validation runs. |
 | `revalidate-mode` | `onSubmit` · `onBlur` · `onChange` · `onTouched` · `all` | `onChange` | When fields re-validate after a failed submit. |
 | `data-default-values` | `string` | | JSON-serialized default values for SSR / JSX attribute channel. |
+| `action` | `string` | | Native form destination when `onSubmit` is not provided. |
+| `method` | `string` | | Native form HTTP method when `onSubmit` is not provided. |
 
 ### Props
 
@@ -88,6 +92,11 @@ The form itself carries no color roles; fields, labels, and controls inside keep
 | --- | --- | --- |
 | `defaultValues` | `Partial<FieldValues>` | Initial values; fields read their state from the form store. |
 | `resolver` | `Resolver<T>` | Custom validation resolver (e.g. from `createRulesResolver`). |
+| `onSubmit` | `(values: T) => void \| Promise<void>` | Receives validated values. When omitted, an `action` or `method` submits the native form after validation passes. |
+
+### Context
+
+`formContext` exposes the current `errors` map to custom consumers. `RuiField` reads the matching field state and applies it to its control as `aria-invalid`; use `fieldContext` for a control's local `error` and `invalid` values.
 
 ### Events
 

--- a/packages/radiant-ui/src/components/ui/alert/alert.css
+++ b/packages/radiant-ui/src/components/ui/alert/alert.css
@@ -6,7 +6,7 @@ rui-alert {
 
 @layer components {
 	.rui-alert {
-		@apply relative rounded-container text-sm shadow-sm;
+		@apply relative block rounded-container text-sm shadow-sm;
 	}
 
 	.rui-alert--inline {

--- a/packages/radiant-ui/src/components/ui/form/form-context.ts
+++ b/packages/radiant-ui/src/components/ui/form/form-context.ts
@@ -1,5 +1,5 @@
 import { createContext } from '@ecopages/radiant/context';
-import type { FieldRegistration, RegisterOptions } from './types';
+import type { FieldError, FieldRegistration, RegisterOptions } from './types';
 
 /** UI slice for one field, computed by `<rui-form>` from the store. */
 export type FormFieldPresentation = {
@@ -23,6 +23,8 @@ export type FormContextValue = {
 	revision: number;
 	/** Per-field messages and invalid flags; only the form writes this map. */
 	fields: Record<string, FormFieldPresentation>;
+	/** Current validation errors keyed by field name, including errors not yet displayed by the validation mode. */
+	errors: Partial<Record<string, FieldError>>;
 	/** Registration and validation triggers; fields call these instead of touching the store. */
 	actions: FormContextActions;
 };

--- a/packages/radiant-ui/src/components/ui/form/form-field.test.tsx
+++ b/packages/radiant-ui/src/components/ui/form/form-field.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { createRoot } from '@ecopages/jsx';
 import { RuiButton } from '../button/button';
 import { RuiField, RuiFieldDescription, RuiFieldError } from '../field';
@@ -37,6 +37,71 @@ describe('RuiField view', () => {
 });
 
 describe('rui-field projected content discovery', () => {
+	it('calls RuiForm onSubmit with validated values', async () => {
+		const host = document.createElement('div');
+		document.body.append(host);
+		const root = createRoot(host);
+		const submitted: Array<Record<string, unknown>> = [];
+		root.render(
+			<RuiForm
+				defaultValues={{ email: 'hello@example.com' }}
+				onSubmit={(values) => {
+					submitted.push(values);
+				}}
+			>
+				<RuiField name="email">
+					<RuiLabel>Email</RuiLabel>
+					<RuiInput type="email" />
+				</RuiField>
+				<RuiButton type="submit">Save</RuiButton>
+			</RuiForm>,
+		);
+
+		await customElements.whenDefined('rui-form');
+		await flushRender();
+		await new Promise((resolve) => setTimeout(resolve, 0));
+
+		const save = host.querySelector('button') as HTMLButtonElement;
+		save.click();
+		await new Promise((resolve) => setTimeout(resolve, 0));
+
+		expect(submitted).toEqual([{ email: 'hello@example.com' }]);
+		host.remove();
+	});
+
+	it('submits the native form after validation when action or method is provided', async () => {
+		const host = document.createElement('div');
+		document.body.append(host);
+		const root = createRoot(host);
+		root.render(
+			<RuiForm defaultValues={{ email: 'hello@example.com' }} action="/accounts" method="post">
+				<RuiField name="email">
+					<RuiLabel>Email</RuiLabel>
+					<RuiInput type="email" />
+				</RuiField>
+				<RuiButton type="submit">Save</RuiButton>
+			</RuiForm>,
+		);
+
+		await customElements.whenDefined('rui-form');
+		await flushRender();
+		await new Promise((resolve) => setTimeout(resolve, 0));
+
+		const form = host.querySelector('rui-form') as RuiFormElement;
+		const nativeForm = form.getRef<HTMLFormElement>('form')!;
+		const submit = vi.fn();
+		nativeForm.submit = submit;
+
+		const save = host.querySelector('button') as HTMLButtonElement;
+		save.click();
+		await new Promise((resolve) => setTimeout(resolve, 0));
+
+		expect(nativeForm.action).toContain('/accounts');
+		expect(nativeForm.method).toBe('post');
+		expect(submit).toHaveBeenCalledOnce();
+		host.remove();
+	});
+
 	it('finds control and error nodes after Radiant slot projection', async () => {
 		const form = document.createElement('rui-form') as RuiFormElement;
 		const field = document.createElement('rui-field') as RuiFieldElement;
@@ -115,6 +180,7 @@ describe('rui-field projected content discovery', () => {
 		const ctx = (form as unknown as { formProvider: { getContext(): FormContextValue } }).formProvider.getContext();
 		expect(ctx.fields.email?.error).toBe('Email is required');
 		expect(ctx.fields.email?.invalid).toBe(true);
+		expect(ctx.errors.email?.message).toBe('Email is required');
 
 		const control = findFieldControl(field);
 		expect(control?.getAttribute('aria-invalid')).toBe('true');

--- a/packages/radiant-ui/src/components/ui/form/form.script.tsx
+++ b/packages/radiant-ui/src/components/ui/form/form.script.tsx
@@ -19,6 +19,12 @@ export type RuiFormProps<T extends FieldValues = FieldValues> = {
 	resolver?: Resolver<T>;
 	mode?: ValidationMode;
 	reValidateMode?: ValidationMode;
+	/** Receives validated values instead of performing a native form navigation. */
+	onSubmit?: (values: T) => void | Promise<void>;
+	/** Native form destination, used when `onSubmit` is not provided. */
+	action?: string;
+	/** Native form HTTP method, used when `onSubmit` is not provided. */
+	method?: HTMLFormElement['method'];
 };
 
 export type RuiFormSubmitDetail<T extends FieldValues = FieldValues> = {
@@ -53,6 +59,8 @@ const initialFormActions: FormContextActions = {
  *   fields re-validate after a failed submit. Reflects to markup. Default: `onChange`.
  * @attr {string} data-default-values - JSON-serialized default values for SSR / JSX
  *   attribute channel. Default: `undefined`.
+ * @attr {string} action - Native form destination when `onSubmit` is not provided.
+ * @attr {string} method - Native form HTTP method when `onSubmit` is not provided.
  *
  * @fires rui-submit - Emitted when validation passes; `detail.values` holds field values.
  * @fires rui-invalid - Emitted when validation fails on submit; `detail.errors` maps
@@ -72,6 +80,7 @@ export class RuiForm extends RadiantElement {
 			ready: false,
 			revision: 0,
 			fields: {},
+			errors: {},
 			actions: initialFormActions,
 		},
 	})
@@ -89,6 +98,9 @@ export class RuiForm extends RadiantElement {
 	@prop({ type: String, reflect: true, defaultValue: 'onSubmit' }) mode: ValidationMode;
 	@prop({ type: String, reflect: true, attribute: 'revalidate-mode', defaultValue: 'onChange' })
 	reValidateMode: ValidationMode;
+	@prop({ type: String, reflect: true }) action?: string;
+	@prop({ type: String, reflect: true }) method?: HTMLFormElement['method'];
+	onSubmit?: (values: FieldValues) => void | Promise<void>;
 
 	private store: FormStore | undefined;
 	private unsubscribeStore?: () => void;
@@ -159,12 +171,26 @@ export class RuiForm extends RadiantElement {
 	private runFormSubmit(): void {
 		const store = this.ensureStore();
 		void store.handleSubmit(
-			(values) => {
+			async (values) => {
 				this.submitEvent.emit({ values });
+				if (typeof this.onSubmit === 'function') {
+					await this.onSubmit(values);
+					return;
+				}
+				if (this.hasNativeSubmission()) {
+					this.queryNativeForm()?.submit();
+				}
 			},
 			(errors) => {
 				this.invalidEvent.emit({ errors });
 			},
+		);
+	}
+
+	private hasNativeSubmission(): boolean {
+		return (
+			typeof this.onSubmit !== 'function' &&
+			(this.getAttribute('action') !== null || this.getAttribute('method') !== null)
 		);
 	}
 
@@ -248,6 +274,7 @@ export class RuiForm extends RadiantElement {
 			ready: true,
 			revision,
 			fields: this.buildFieldPresentations(store),
+			errors: { ...store.errors },
 			actions: this.formActions,
 		} satisfies FormContextValue;
 		this.lastPublishedContext = nextContext;
@@ -294,7 +321,7 @@ export class RuiForm extends RadiantElement {
 
 	override render() {
 		return (
-			<form class="rui-form" data-ref="form" noValidate>
+			<form class="rui-form" data-ref="form" noValidate action={this.action} method={this.method}>
 				<slot></slot>
 			</form>
 		);

--- a/packages/radiant-ui/src/components/ui/form/form.stories.tsx
+++ b/packages/radiant-ui/src/components/ui/form/form.stories.tsx
@@ -1,6 +1,12 @@
 import type { Meta, StoryObj } from '@ecopages/storybook-radiant-vite';
 import { expect, userEvent, waitFor, within } from 'storybook/test';
+import type { JsxCustomElementAttributes } from '@ecopages/jsx';
+import { consumeContext, onContextUpdate } from '@ecopages/radiant/context';
+import type { ContextProvider } from '@ecopages/radiant/context';
+import { customElement } from '@ecopages/radiant';
 import { RuiAutocomplete, RuiAutocompleteCollection, RuiAutocompleteEmpty } from '../autocomplete';
+import { RuiAlertDescription, RuiAlertTitle } from '../alert';
+import { RuiAlert as RuiAlertElement, type RuiAlertProps } from '../alert/alert.script';
 import { RuiButton } from '../button/button';
 import { RuiCheckbox } from '../checkbox';
 import { RuiCombobox } from '../combobox';
@@ -28,13 +34,41 @@ import { RuiTagGroup, RuiTagList } from '../tag-group';
 import { RuiTextarea } from '../textarea';
 import { findFieldControl, findFieldError, isNativeTextControl } from './control-protocol';
 import { RuiForm as RuiFormElement } from './form.script';
+import { formContext, type FormContextValue } from './form-context';
 import '../field/field.script';
 import './form.script';
+
+declare module '@ecopages/jsx/jsx-runtime' {
+	interface JsxCustomIntrinsicElements {
+		'rui-form-validation-alert': JsxCustomElementAttributes<RuiFormValidationAlert, RuiAlertProps>;
+	}
+}
+
+/** Story-only alert that demonstrates consuming a parent form's aggregate validation errors. */
+@customElement('rui-form-validation-alert')
+class RuiFormValidationAlert extends RuiAlertElement {
+	@consumeContext(formContext)
+	private formContextProvider?: ContextProvider<typeof formContext>;
+
+	override connectedCallback(): void {
+		super.connectedCallback();
+		this.syncVisibility(this.formContextProvider?.getContext());
+	}
+
+	@onContextUpdate({ context: formContext, requestUpdate: false })
+	onFormContextChanged(context: FormContextValue): void {
+		this.syncVisibility(context);
+	}
+
+	private syncVisibility(context: FormContextValue | undefined): void {
+		this.hidden = Object.keys(context?.errors ?? {}).length === 0;
+	}
+}
 
 const meta = {
 	title: 'Components/Form',
 	component: RuiForm,
-	parameters: { radiant: { element: RuiFormElement, cssImports: ['./form.css'] } },
+	parameters: { radiant: { element: RuiFormElement, cssImports: ['../../../styles/styles.css'] } },
 } satisfies Meta<typeof RuiForm>;
 
 export default meta;
@@ -152,6 +186,50 @@ export const Validation: Story = {
 			await userEvent.click(canvas.getByRole('button', { name: 'Save' }));
 			await waitFor(() => {
 				expect(getFieldErrorMessage(canvasElement, 'bio')).toBeNull();
+			});
+		});
+	},
+};
+
+export const FormErrorSummary: Story = {
+	render: () => (
+		<RuiForm defaultValues={{ email: '', bio: '' }} mode="onSubmit" reValidateMode="onChange">
+			<rui-form-validation-alert variant="error" layout="banner" hidden>
+				<div class="rui-alert rui-alert--error rui-alert--banner" role="alert">
+					<RuiAlertTitle>There are issues with this form</RuiAlertTitle>
+					<RuiAlertDescription>
+						The form cannot be submitted. Review the highlighted fields before trying again.
+					</RuiAlertDescription>
+				</div>
+			</rui-form-validation-alert>
+
+			<RuiField name="email" rules={{ required: 'Email is required' }}>
+				<RuiLabel>Email</RuiLabel>
+				<RuiInput type="email" placeholder="you@example.com" />
+				<RuiFieldError />
+			</RuiField>
+
+			<RuiField name="bio" rules={{ minLength: { value: 10, message: 'Enter at least 10 characters' } }}>
+				<RuiLabel>Bio</RuiLabel>
+				<RuiTextarea rows={3} placeholder="Tell us about yourself" />
+				<RuiFieldError />
+			</RuiField>
+
+			<RuiButton type="submit">Save</RuiButton>
+		</RuiForm>
+	),
+	play: async ({ canvasElement, step }) => {
+		const canvas = within(canvasElement);
+		await step('invalid submission reveals the form error summary', async () => {
+			await userEvent.click(canvas.getByRole('button', { name: 'Save' }));
+			await expect(canvas.findByText('There are issues with this form')).resolves.toBeVisible();
+		});
+
+		await step('resolving every error hides the summary', async () => {
+			setNativeInputValue(getTextControl(canvasElement, 0), 'hello@example.com');
+			setNativeInputValue(getTextControl(canvasElement, 1), 'A complete biography');
+			await waitFor(() => {
+				expect(canvas.getByText('There are issues with this form')).not.toBeVisible();
 			});
 		});
 	},

--- a/packages/radiant-ui/src/components/ui/form/form.stories.tsx
+++ b/packages/radiant-ui/src/components/ui/form/form.stories.tsx
@@ -194,13 +194,17 @@ export const Validation: Story = {
 export const FormErrorSummary: Story = {
 	render: () => (
 		<RuiForm defaultValues={{ email: '', bio: '' }} mode="onSubmit" reValidateMode="onChange">
-			<rui-form-validation-alert variant="error" layout="banner" hidden>
-				<div class="rui-alert rui-alert--error rui-alert--banner" role="alert">
-					<RuiAlertTitle>There are issues with this form</RuiAlertTitle>
-					<RuiAlertDescription>
-						The form cannot be submitted. Review the highlighted fields before trying again.
-					</RuiAlertDescription>
-				</div>
+			<rui-form-validation-alert
+				class="rui-alert rui-alert--error rui-alert--banner"
+				variant="error"
+				layout="banner"
+				role="alert"
+				hidden
+			>
+				<RuiAlertTitle>There are issues with this form</RuiAlertTitle>
+				<RuiAlertDescription>
+					The form cannot be submitted. Review the highlighted fields before trying again.
+				</RuiAlertDescription>
 			</rui-form-validation-alert>
 
 			<RuiField name="email" rules={{ required: 'Email is required' }}>

--- a/packages/radiant-ui/src/components/ui/form/form.tsx
+++ b/packages/radiant-ui/src/components/ui/form/form.tsx
@@ -8,15 +8,21 @@ export function RuiForm({
 	defaultValuesData,
 	resolver,
 	reValidateMode,
+	onSubmit,
+	action,
+	method,
 	...props
 }: JsxCustomElementAttributes<RuiFormElement, RuiFormProps>) {
 	return (
 		<rui-form
 			{...props}
+			action={action}
+			method={method}
 			reValidateMode={reValidateMode}
 			attr:revalidate-mode={reValidateMode}
 			prop:defaultValues={defaultValues}
 			prop:resolver={resolver}
+			prop:onSubmit={onSubmit}
 			data={{
 				defaultValues:
 					defaultValuesData ?? (defaultValues !== undefined ? JSON.stringify(defaultValues) : undefined),


### PR DESCRIPTION
## Summary

- Add `onSubmit`, `action`, and `method` to `RuiForm`: validated values flow to `onSubmit`, or the native form submits after validation when `action` or `method` is set without `onSubmit`.
- Expose aggregate validation `errors` on `formContext` so custom consumers (e.g. form-level error summaries) can react to invalid submit attempts.
- Update form docs, tests, and a Storybook `FormErrorSummary` story demonstrating context-driven error UI.

## Test plan

- [x] `pnpm --filter @ecopages/radiant-ui test:lib` (form-field tests cover `onSubmit` and native submission)
- [x] Storybook: **Components/Form → FormErrorSummary** — invalid submit shows summary; fixing fields hides it
- [x] Docs: form component page reflects `onSubmit` / `action` / `method` props