### PR TITLE
fix(ci): use npm OIDC trusted publishing in Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,6 @@ jobs:
               uses: actions/setup-node@v4
               with:
                   node-version: '24'
-                  registry-url: 'https://registry.npmjs.org'
                   cache: 'pnpm'
 
             - name: Install Dependencies
@@ -39,6 +38,9 @@ jobs:
 
             - name: Build Libraries
               run: pnpm run build:all
+
+            - name: Configure npm for OIDC trusted publishing
+              run: npm config delete //registry.npmjs.org/:_authToken --location=user || true
 
             - name: Create Release Pull Request or Publish
               id: changesets


### PR DESCRIPTION
## Summary

- Remove `registry-url` from `setup-node` so npm uses OIDC trusted publishing instead of an empty `NODE_AUTH_TOKEN`.
- Clear any stray `//registry.npmjs.org/:_authToken` from the runner npm config before `changeset publish`.

## Test plan

- [ ] Merge and re-run **Release** workflow on `release/v0.3.0` (workflow_dispatch)
- [ ] Confirm `@ecopages/radiant-ui@0.1.0-rc.1` publishes to the `rc` dist-tag