### PR TITLE
feat(radiant): add onConnected hook

### DIFF
--- a/.changeset/radiant-on-connected.md
+++ b/.changeset/radiant-on-connected.md
@@ -1,0 +1,10 @@
+---
+'@ecopages/radiant': minor
+---
+
+Add `protected onConnected()` on `RadiantElement` for post-catch-up connect work. Override it instead of `connectedCallback` + `queueMicrotask(sync)` so authored attributes and the initial hydrate/update are visible; it runs on every connection.
+
+**@ecopages/radiant**
+
+- `onConnected()` fires after first-connect attribute catch-up and, when `render()` is overridden, after the initial hydrate/update. Rebuild work torn down in `disconnectedCallback` here; guard once-only bootstrapping with an explicit flag.
+- This is not `registerConnectedCallback()`, which still runs synchronously at the start of `connectedCallback`.

--- a/apps/docs/src/content/docs/components/radiant-element.mdx
+++ b/apps/docs/src/content/docs/components/radiant-element.mdx
@@ -142,6 +142,32 @@ Full host HTML (`<my-element>...</my-element>`) is produced by the server pipeli
 
 This means the correct question is not "element or component?" anymore. The question is whether the host should keep authored DOM or own a JSX view.
 
+## Connect-time sync
+
+Override `protected onConnected()` for work that must wait until authored attributes are visible and (when the host owns `render()`) the initial hydrate/update has committed.
+
+Do not queue a `queueMicrotask` from `connectedCallback` for that. `onConnected` is invoked at that same point, on every connection — not once per instance. Rebuild controllers, observers, and listeners here if `disconnectedCallback` tears them down. Guard once-only bootstrapping with an explicit flag.
+
+Keep synchronous setup (event listeners, `MutationObserver`) in `connectedCallback`. Keep behavioral deferrals such as focus moves as explicit microtasks at their trigger sites.
+
+`onConnected` is not `registerConnectedCallback()`. Those reactive-host callbacks run synchronously at the start of `connectedCallback`, before attribute catch-up.
+
+```typescript
+import { RadiantElement, customElement, prop } from '@ecopages/radiant';
+
+@customElement('status-chip')
+class StatusChip extends RadiantElement {
+  @prop({ type: String, defaultValue: '' }) label!: string;
+
+  protected override onConnected(): void {
+    const labelText = this.querySelector('[data-ref="label"]');
+    if (labelText) {
+      labelText.textContent = this.label;
+    }
+  }
+}
+```
+
 ## Bindings And Reactive Reads
 
 `RadiantElement` exposes three ways to wire reactive values into JSX:
@@ -215,6 +241,8 @@ Use these when you build host adapters, tests, or custom decorators. Prefer `@st
 - Use `RadiantElement` when you want a custom element host, whether the host is imperative or JSX-owned.
 - Override `render()` when the host itself should own a JSX view.
 - Skip `render()` when the host should enhance authored light DOM instead.
+- Override `onConnected()` for post-catch-up connect work; keep listeners in `connectedCallback`.
+- In JSX-authored composite libraries, keep parent-owned children in the view shell; do not re-project them through `<slot>` (see [Slots — JSX-authored composites](/docs/components/slots#jsx-authored-composites)).
 - Use [RadiantController](/docs/components/radiant-controller) when the DOM is authored elsewhere and a custom element wrapper would be unnecessary.
 
 ## See Also

--- a/packages/radiant/README.md
+++ b/packages/radiant/README.md
@@ -34,6 +34,7 @@ Application code does not need to import JSX helpers or Signals primitives direc
 - `@onUpdated(...)` is the bridge from reactive member changes to `update()` or `requestUpdate()` when the rendered structure needs to be recomputed.
 - `this.bindings.key`, `this.$.key`, and `this.bind('key')` expose stable JSX bindings for reactive members.
 - If `render()` is omitted, the base implementation behaves like `<slot />`, so authored light-DOM children pass through unchanged.
+- `onConnected()` runs after every connection, once attribute catch-up and (when `render()` is overridden) the initial hydrate/update have finished. Use it instead of `connectedCallback` + `queueMicrotask(sync)`. It is not `registerConnectedCallback()`, which runs synchronously before catch-up.
 - Literal `<slot>` tags project authored light-DOM content, and `getSlotElement(...)`, `getSlotElements(...)`, or `@querySlot(...)` let component logic read the assigned elements.
 
 The key distinction is this:

--- a/packages/radiant/src/core/radiant-element.ts
+++ b/packages/radiant/src/core/radiant-element.ts
@@ -332,31 +332,48 @@ export class RadiantElement<Bindings extends object = {}>
 				this.reactivePropertyState.completeInitialSync();
 			}
 
-			if (!this.shouldRunRenderLifecycle()) {
-				return;
-			}
+			if (this.shouldRunRenderLifecycle()) {
+				const renderRuntime = this.getOrCreateRenderRuntime();
+				renderRuntime.observeSlotProjection();
 
-			const renderRuntime = this.getOrCreateRenderRuntime();
-			renderRuntime.observeSlotProjection();
+				if (this.needsInitialHydration(renderRuntime)) {
+					this.renderScheduler.clearPending();
+					this.hydrate();
 
-			if (this.needsInitialHydration(renderRuntime)) {
-				this.renderScheduler.clearPending();
-				this.hydrate();
-
-				if (this.renderScheduler.pending) {
+					if (this.renderScheduler.pending) {
+						this.update();
+					}
+				} else if (this.isReconnectWithLiveProjection(renderRuntime)) {
+					// Already-mounted reconnects keep their live light DOM (see
+					// `isReconnectWithLiveProjection`); no update is scheduled.
+				} else {
 					this.update();
 				}
-
-				return;
 			}
 
-			if (this.isReconnectWithLiveProjection(renderRuntime)) {
-				return;
-			}
-
-			this.update();
+			this.onConnected();
 		});
 	}
+
+	/**
+	 * Lifecycle hook invoked after every host connection, once attribute catch-up,
+	 * initial property sync, and (when applicable) the initial hydrate/update have
+	 * completed.
+	 *
+	 * @remarks
+	 * This replaces the former `connectedCallback` + `queueMicrotask(sync)`
+	 * boilerplate: it runs at exactly the point that boilerplate targeted, so
+	 * authored attributes are visible and view-owned light-DOM children are
+	 * queryable via `data-ref`. It fires on every connection, not once per
+	 * instance — hosts that tear down in `disconnectedCallback` (controllers,
+	 * observers, listeners, timers) must rebuild here to survive reconnects.
+	 * Once-only bootstrapping should guard itself explicitly.
+	 *
+	 * This is not `ReactiveHost.registerConnectedCallback()`. Those callbacks
+	 * run synchronously from `connectHost()` at the start of `connectedCallback`,
+	 * before attribute catch-up. Override this hook for post-sync work.
+	 */
+	protected onConnected(): void {}
 
 	/**
 	 * @remarks A host can disconnect and reconnect while keeping the same instance (e.g. SPA

--- a/packages/radiant/test/core/radiant-element.browser.test.ts
+++ b/packages/radiant/test/core/radiant-element.browser.test.ts
@@ -3,6 +3,8 @@ import { jsx } from '@ecopages/jsx';
 import { beforeEach, describe, expect, test } from 'vitest';
 import { installRadiantHydrator, uninstallRadiantHydrator } from '../../src/client/hydrator';
 import { RadiantElement } from '../../src/core/radiant-element';
+import { customElement } from '../../src/decorators/custom-element';
+import { prop } from '../../src/decorators/prop';
 
 class MyRadiantElement extends RadiantElement {
 	static observedAttributes = ['number', 'string'];
@@ -301,5 +303,87 @@ describe('RadiantElement', () => {
 
 		el.items = [...el.items, 'another item'];
 		expect(updateCount).toBe(1);
+	});
+});
+
+describe('onConnected', () => {
+	beforeEach(() => {
+		document.body.innerHTML = '';
+	});
+
+	@customElement('on-connected-attr-host')
+	class OnConnectedAttrHost extends RadiantElement {
+		@prop({ type: String, defaultValue: '' }) label: string;
+		connectedCount = 0;
+		seenLabel = '';
+
+		protected override onConnected(): void {
+			this.connectedCount += 1;
+			this.seenLabel = this.label;
+		}
+	}
+
+	@customElement('on-connected-render-host')
+	class OnConnectedRenderHost extends RadiantElement {
+		connectedCount = 0;
+		hasRef = false;
+
+		override render() {
+			return jsx('div', { 'data-ref': 'root' });
+		}
+
+		protected override onConnected(): void {
+			this.connectedCount += 1;
+			this.hasRef = this.querySelector('[data-ref="root"]') != null;
+		}
+	}
+
+	test('runs after first-connect attribute catch-up on a host with no render override', async () => {
+		const element = document.createElement('on-connected-attr-host') as OnConnectedAttrHost;
+		element.setAttribute('label', 'authored');
+		document.body.appendChild(element);
+
+		expect(element.connectedCount).toBe(0);
+		expect(element.seenLabel).toBe('');
+
+		await Promise.resolve();
+
+		expect(element.connectedCount).toBe(1);
+		expect(element.seenLabel).toBe('authored');
+	});
+
+	test('runs after the initial render commit so refs exist', async () => {
+		const element = document.createElement('on-connected-render-host') as OnConnectedRenderHost;
+		document.body.appendChild(element);
+
+		await Promise.resolve();
+
+		expect(element.connectedCount).toBe(1);
+		expect(element.hasRef).toBe(true);
+	});
+
+	test('runs again when the same instance reconnects', async () => {
+		const element = document.createElement('on-connected-attr-host') as OnConnectedAttrHost;
+		element.setAttribute('label', 'authored');
+		document.body.appendChild(element);
+		await Promise.resolve();
+		expect(element.connectedCount).toBe(1);
+
+		element.remove();
+		document.body.appendChild(element);
+		await Promise.resolve();
+
+		expect(element.connectedCount).toBe(2);
+		expect(element.seenLabel).toBe('authored');
+	});
+
+	test('does not run if the host disconnects before the connect microtask', async () => {
+		const element = document.createElement('on-connected-attr-host') as OnConnectedAttrHost;
+		document.body.appendChild(element);
+		element.remove();
+
+		await Promise.resolve();
+
+		expect(element.connectedCount).toBe(0);
 	});
 });


### PR DESCRIPTION
Add protected onConnected() on RadiantElement for post-catch-up connect
work, with browser tests and docs.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>