### PR TITLE
refactor(radiant-ui): shared preview timing and popover visibility

### DIFF
--- a/packages/radiant-ui/src/components/ui/shared/popover-controller.ts
+++ b/packages/radiant-ui/src/components/ui/shared/popover-controller.ts
@@ -68,7 +68,7 @@ export class PopoverController {
 		const open = this.config.getOpen();
 		if (!open) {
 			this.teardown();
-			floating.hidden = true;
+			floating.toggleAttribute('hidden', true);
 			return;
 		}
 
@@ -77,7 +77,7 @@ export class PopoverController {
 			return;
 		}
 
-		floating.hidden = false;
+		floating.toggleAttribute('hidden', false);
 
 		const usePortal = this.config.portal !== false;
 		if (usePortal) {

--- a/packages/radiant-ui/src/components/ui/shared/popover.css
+++ b/packages/radiant-ui/src/components/ui/shared/popover.css
@@ -1,5 +1,4 @@
 @reference '../../../styles/radiant-ui.css';
-@import './floating.css';
 
 @layer components {
 	.rui-popover {

--- a/packages/radiant-ui/src/components/ui/shared/preview-timing.test.ts
+++ b/packages/radiant-ui/src/components/ui/shared/preview-timing.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+	notePreviewClosed,
+	notePreviewOpened,
+	resetPreviewTimingForTests,
+	resolvePreviewOpenDelay,
+} from './preview-timing';
+
+describe('preview-timing', () => {
+	afterEach(() => {
+		resetPreviewTimingForTests();
+	});
+
+	it('uses the requested delay when no preview was shown recently', () => {
+		expect(resolvePreviewOpenDelay(600, 1_000)).toBe(600);
+	});
+
+	it('opens immediately while another preview is open', () => {
+		notePreviewOpened();
+		expect(resolvePreviewOpenDelay(600, 1_000)).toBe(0);
+	});
+
+	it('opens immediately during the post-close cooldown window', () => {
+		notePreviewOpened();
+		notePreviewClosed(1_000, 300);
+		expect(resolvePreviewOpenDelay(600, 1_200)).toBe(0);
+	});
+
+	it('restores warmup after the cooldown window elapses', () => {
+		notePreviewOpened();
+		notePreviewClosed(1_000, 300);
+		expect(resolvePreviewOpenDelay(600, 1_301)).toBe(600);
+	});
+});

--- a/packages/radiant-ui/src/components/ui/shared/preview-timing.ts
+++ b/packages/radiant-ui/src/components/ui/shared/preview-timing.ts
@@ -1,0 +1,37 @@
+const DEFAULT_COOLDOWN_MS = 300;
+
+let openCount = 0;
+let fastPathUntil = 0;
+
+/** @remarks Test-only reset for preview timing state. */
+export function resetPreviewTimingForTests(): void {
+	openCount = 0;
+	fastPathUntil = 0;
+}
+
+export function notePreviewOpened(): void {
+	openCount += 1;
+}
+
+export function notePreviewClosed(now = Date.now(), cooldownMs = DEFAULT_COOLDOWN_MS): void {
+	openCount = Math.max(0, openCount - 1);
+	if (openCount === 0) {
+		fastPathUntil = now + cooldownMs;
+	}
+}
+
+/**
+ * Resolves the effective open delay for a preview trigger.
+ *
+ * @remarks Once any preview is open, or while still inside the post-close cooldown
+ * window, subsequent previews open immediately.
+ */
+export function resolvePreviewOpenDelay(requestedDelay: number, now = Date.now()): number {
+	if (openCount > 0) {
+		return 0;
+	}
+	if (now < fastPathUntil) {
+		return 0;
+	}
+	return requestedDelay;
+}

--- a/packages/radiant-ui/src/styles/primitives.css
+++ b/packages/radiant-ui/src/styles/primitives.css
@@ -1,0 +1,10 @@
+/**
+ * Shared structural styles used by composed component views.
+ *
+ * Generated aggregate entries import this once. Selective consumers include it
+ * when listed by `style-dependencies`.
+ */
+@import '../lib/icons/icons.css';
+@import '../components/ui/shared/control-toggle.css';
+@import '../components/ui/shared/floating.css';
+@import '../components/ui/shared/popover.css';


### PR DESCRIPTION
Add preview-timing helpers and toggleAttribute-based PopoverController
visibility for view-owned popup surfaces.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>