### PR TITLE
refactor(radiant-ui): view-owned light DOM for form controls

### DIFF
--- a/packages/radiant-ui/src/components/ui/checkbox/checkbox.script.tsx
+++ b/packages/radiant-ui/src/components/ui/checkbox/checkbox.script.tsx
@@ -1,4 +1,4 @@
-import { RadiantElement, customElement, event, onEvent, prop } from '@ecopages/radiant';
+import { RadiantElement, bound, customElement, event, onEvent, onUpdated, prop, query } from '@ecopages/radiant';
 import type { EventEmitter } from '@ecopages/radiant/tools/event-emitter';
 
 export type RuiCheckboxProps = {
@@ -23,13 +23,13 @@ export type RuiCheckboxChangeDetail = {
 	indeterminate: boolean;
 };
 
-type RuiCheckboxBindings = {
-	checked: boolean;
-	indeterminate: boolean;
-	disabled: boolean;
-	value: string;
-	name: string;
-};
+/**
+ * Default submitted value for a checkbox.
+ *
+ * @remarks Must match the host `@prop` default: the SSR view seeds the inner
+ * `<input>` with it so form submission works before hydration.
+ */
+export const CHECKBOX_DEFAULT_VALUE = 'on';
 
 /**
  * `<rui-checkbox>` — a dual-state or tri-state checkbox.
@@ -44,7 +44,6 @@ type RuiCheckboxBindings = {
  * - `Space`: toggle checked state
  *
  * @element rui-checkbox
- * @slot - Visible label for the checkbox.
  * @fires rui-change - Emitted after the checked/indeterminate state changes.
  * @cssclass rui-checkbox - Label row: box + visible label.
  * @cssclass rui-checkbox__input - Native input (visually hidden, receives focus).
@@ -52,20 +51,46 @@ type RuiCheckboxBindings = {
  * @cssclass rui-checkbox__label - Light-DOM label text.
  */
 @customElement('rui-checkbox')
-export class RuiCheckbox extends RadiantElement<RuiCheckboxBindings> {
+export class RuiCheckbox extends RadiantElement {
 	@prop({ type: Boolean, reflect: true, defaultValue: false }) checked: boolean;
 	@prop({ type: Boolean, reflect: true, defaultValue: false }) indeterminate: boolean;
 	@prop({ type: Boolean, reflect: true, defaultValue: false }) disabled: boolean;
-	@prop({ type: String, defaultValue: 'on' }) value: string;
+	@prop({ type: String, defaultValue: CHECKBOX_DEFAULT_VALUE }) value: string;
 	@prop({ type: String, defaultValue: '' }) name: string;
+
+	@query({ ref: 'input' }) inputTarget: HTMLInputElement;
 
 	@event({ name: 'rui-change', bubbles: true, composed: true })
 	changeEvent: EventEmitter<RuiCheckboxChangeDetail>;
 
-	private readonly nameAttr = this.$.name.map((name) => name || undefined);
-	private readonly resolvedAriaChecked = this.$.indeterminate.map((indeterminate) =>
-		indeterminate ? 'mixed' : undefined,
-	);
+	protected override onConnected(): void {
+		this.syncInputState();
+	}
+
+	@bound
+	@onUpdated(['checked', 'indeterminate', 'disabled', 'value', 'name'])
+	syncInputState(): void {
+		const input = this.inputTarget;
+		if (!input) {
+			return;
+		}
+
+		input.checked = this.checked;
+		input.indeterminate = this.indeterminate;
+		input.disabled = this.disabled;
+		input.value = this.value;
+		if (this.name) {
+			input.name = this.name;
+		} else {
+			input.removeAttribute('name');
+		}
+
+		if (this.indeterminate) {
+			input.setAttribute('aria-checked', 'mixed');
+		} else {
+			input.removeAttribute('aria-checked');
+		}
+	}
 
 	@onEvent({ ref: 'input', type: 'change' })
 	onInputChange(event: Event): void {
@@ -73,29 +98,5 @@ export class RuiCheckbox extends RadiantElement<RuiCheckboxBindings> {
 		this.checked = input.checked;
 		input.indeterminate = this.indeterminate;
 		this.changeEvent.emit({ checked: this.checked, indeterminate: this.indeterminate });
-	}
-
-	override render() {
-		return (
-			<label class="rui-checkbox">
-				<input
-					type="checkbox"
-					data-ref="input"
-					data-rui-control
-					data-rui-control-type="boolean"
-					class="rui-checkbox__input"
-					prop:checked={this.$.checked}
-					disabled={this.$.disabled}
-					prop:value={this.$.value}
-					name={this.nameAttr}
-					prop:indeterminate={this.$.indeterminate}
-					aria-checked={this.resolvedAriaChecked}
-				/>
-				<span class="rui-checkbox__control" aria-hidden="true"></span>
-				<span class="rui-checkbox__label">
-					<slot></slot>
-				</span>
-			</label>
-		);
 	}
 }

--- a/packages/radiant-ui/src/components/ui/checkbox/checkbox.tsx
+++ b/packages/radiant-ui/src/components/ui/checkbox/checkbox.tsx
@@ -1,7 +1,41 @@
 import type { JsxCustomElementAttributes } from '@ecopages/jsx';
-import type { RuiCheckbox as RuiCheckboxElement, RuiCheckboxProps } from './checkbox.script';
+import { CHECKBOX_DEFAULT_VALUE, type RuiCheckbox as RuiCheckboxElement, type RuiCheckboxProps } from './checkbox.script';
 import './checkbox.script';
 
-export function RuiCheckbox({ children, ...props }: JsxCustomElementAttributes<RuiCheckboxElement, RuiCheckboxProps>) {
-	return <rui-checkbox {...props}>{children}</rui-checkbox>;
+export function RuiCheckbox({
+	children,
+	checked,
+	disabled,
+	indeterminate,
+	name,
+	value = CHECKBOX_DEFAULT_VALUE,
+	...props
+}: JsxCustomElementAttributes<RuiCheckboxElement, RuiCheckboxProps>) {
+	return (
+		<rui-checkbox
+			{...props}
+			checked={checked}
+			disabled={disabled}
+			indeterminate={indeterminate}
+			name={name}
+			value={value}
+		>
+			<label class="rui-checkbox">
+				<input
+					type="checkbox"
+					data-ref="input"
+					data-rui-control
+					data-rui-control-type="boolean"
+					class="rui-checkbox__input"
+					checked={checked}
+					disabled={disabled}
+					value={value}
+					name={name || undefined}
+					aria-checked={indeterminate ? 'mixed' : undefined}
+				/>
+				<span class="rui-checkbox__control" aria-hidden="true"></span>
+				<span class="rui-checkbox__label">{children}</span>
+			</label>
+		</rui-checkbox>
+	);
 }

--- a/packages/radiant-ui/src/components/ui/field/field.script.tsx
+++ b/packages/radiant-ui/src/components/ui/field/field.script.tsx
@@ -14,7 +14,7 @@ import {
 	findFieldError,
 	findFieldErrorElements,
 	findFieldLabel,
-	getAriaControlTarget,
+	getAriaControlTargets,
 	isNativeTextControl,
 	readControlValue,
 	RUI_FIELD_DEFAULT_VALUE_ATTR,
@@ -51,7 +51,7 @@ export type RuiFieldProps = {
 };
 
 /**
- * `<rui-field>` — connector between slotted controls and an ancestor `<rui-form>`.
+ * `<rui-field>` — connector between composed controls and an ancestor `<rui-form>`.
  *
  * Registers with the form via {@link formContext} actions, forwards control events,
  * and applies presentation (errors, ARIA) from the form-published `fields` map.
@@ -72,8 +72,6 @@ export type RuiFieldProps = {
  * @attr {string} data-default-value - JSON-serialized default value for SSR hydration.
  *   Default: `undefined`.
  *
- * @slot - Field content: label, control, description, error.
- *
  * @remarks
  * The composed surface is `.rui-field` (column). Error / description presentation
  * lives on `RuiFieldError` / `RuiFieldDescription` helpers (`@cssclass` there).
@@ -85,7 +83,7 @@ export type RuiFieldProps = {
  * apply ARIA + error text to light-DOM nodes after mount — a JSX wrapper has no
  * lifecycle hook for that.
  *
- * @cssclass rui-field - Root column; wires the slotted control, label, description,
+ * @cssclass rui-field - Root column; wires the composed control, label, description,
  *   and error into the form-published presentation.
  */
 @customElement('rui-field')
@@ -137,12 +135,8 @@ export class RuiField extends RadiantElement {
 		registerSsrPreparationCallback(this, () => this.fieldProvider.setContext({ rules: this.readFieldRules() }));
 	}
 
-	override connectedCallback(): void {
-		super.connectedCallback();
+	protected override onConnected(): void {
 		this.connectToForm();
-		queueMicrotask(() => {
-			this.connectToForm();
-		});
 	}
 
 	override disconnectedCallback(): void {
@@ -295,7 +289,7 @@ export class RuiField extends RadiantElement {
 
 	@onEvent({
 		selector:
-			'[data-rui-control], rui-combobox, rui-date-field, rui-date-range-picker, rui-select, rui-tag-group, rui-checkbox, rui-switch, rui-radio-group, rui-slider, rui-number-field, rui-listbox',
+			'[data-rui-control], rui-combobox, rui-date-field, rui-date-range-picker, rui-select, rui-tag-group, rui-checkbox, rui-switch, rui-radio-group, rui-slider, rui-knob, rui-number-field, rui-listbox',
 		type: 'rui-change',
 	})
 	onControlChange(): void {
@@ -329,7 +323,7 @@ export class RuiField extends RadiantElement {
 		}
 	}
 
-	@onEvent({ selector: '[data-rui-control]', type: 'focusout' })
+	@onEvent({ selector: '[data-rui-control], rui-knob, rui-slider', type: 'focusout' })
 	onControlFocusOut(): void {
 		const fieldName = this.resolveFieldName();
 		if (fieldName) {
@@ -339,7 +333,8 @@ export class RuiField extends RadiantElement {
 
 	private syncField(formCtx?: FormContextValue): void {
 		const controlHost = findFieldControl(this);
-		const ariaTarget = controlHost ? getAriaControlTarget(controlHost) : null;
+		const ariaTargets = controlHost ? getAriaControlTargets(controlHost) : [];
+		const ariaTarget = ariaTargets[0] ?? null;
 		const controlId = ariaTarget?.id || `rui-field-control-${this.uid}`;
 		const descriptionId = `rui-field-desc-${this.uid}`;
 		const errorId = `rui-field-error-${this.uid}`;
@@ -350,42 +345,42 @@ export class RuiField extends RadiantElement {
 		const fieldName = this.resolveFieldName();
 		wireFieldControlName(controlHost, ariaTarget, fieldName);
 
-		if (ariaTarget) {
-			if (!ariaTarget.id) {
-				ariaTarget.id = controlId;
+		const describedBy: string[] = [];
+		const description = findFieldDescription(this);
+		if (description) {
+			description.id = descriptionId;
+			describedBy.push(descriptionId);
+		}
+		const errorEl = findFieldError(this);
+		if (errorEl) {
+			errorEl.id = errorId;
+			if (errorMessage) {
+				describedBy.push(errorId);
 			}
-			ariaTarget.setAttribute(RUI_FIELD_MANAGED_ATTR, '');
-			ariaTarget.setAttribute('aria-invalid', invalid ? 'true' : 'false');
-			if (this.isRequired()) {
-				ariaTarget.setAttribute('aria-required', 'true');
-			} else {
-				ariaTarget.removeAttribute('aria-required');
-			}
+		}
 
-			const describedBy: string[] = [];
-			const description = findFieldDescription(this);
-			if (description) {
-				description.id = descriptionId;
-				describedBy.push(descriptionId);
+		for (const [index, target] of ariaTargets.entries()) {
+			if (!target.id) {
+				target.id = index === 0 ? controlId : `${controlId}-${index}`;
 			}
-			const errorEl = findFieldError(this);
-			if (errorEl) {
-				errorEl.id = errorId;
-				if (errorMessage) {
-					describedBy.push(errorId);
-				}
+			target.setAttribute(RUI_FIELD_MANAGED_ATTR, '');
+			target.setAttribute('aria-invalid', invalid ? 'true' : 'false');
+			if (this.isRequired()) {
+				target.setAttribute('aria-required', 'true');
+			} else {
+				target.removeAttribute('aria-required');
 			}
 
 			if (describedBy.length > 0) {
-				ariaTarget.setAttribute('aria-describedby', describedBy.join(' '));
+				target.setAttribute('aria-describedby', describedBy.join(' '));
 			} else {
-				ariaTarget.removeAttribute('aria-describedby');
+				target.removeAttribute('aria-describedby');
 			}
 
 			if (this.disabled) {
-				ariaTarget.setAttribute('aria-disabled', 'true');
-				if (isNativeTextControl(ariaTarget)) {
-					ariaTarget.disabled = true;
+				target.setAttribute('aria-disabled', 'true');
+				if (isNativeTextControl(target)) {
+					target.disabled = true;
 				}
 			}
 		}
@@ -428,13 +423,5 @@ export class RuiField extends RadiantElement {
 		}
 
 		this.fieldProvider.setContext(nextFieldContext);
-	}
-
-	override render() {
-		return (
-			<div class="rui-field">
-				<slot></slot>
-			</div>
-		);
 	}
 }

--- a/packages/radiant-ui/src/components/ui/field/field.tsx
+++ b/packages/radiant-ui/src/components/ui/field/field.tsx
@@ -26,7 +26,7 @@ export function RuiField({
 					defaultValueData ?? (defaultValue !== undefined ? JSON.stringify(defaultValue) : undefined),
 			}}
 		>
-			{children}
+			<div class="rui-field">{children}</div>
 		</rui-field>
 	);
 }

--- a/packages/radiant-ui/src/components/ui/form/control-protocol.ts
+++ b/packages/radiant-ui/src/components/ui/form/control-protocol.ts
@@ -16,6 +16,7 @@ const HOST_CONTROL_TAGS = new Set([
 	'rui-switch',
 	'rui-radio-group',
 	'rui-slider',
+	'rui-knob',
 	'rui-number-field',
 	'rui-listbox',
 ]);
@@ -93,6 +94,47 @@ const booleanValueAdapter: ControlValueAdapter = {
 	},
 };
 
+function readNumberProperty(host: HTMLElement, property: string, attribute: string): number | '' {
+	const value = Reflect.get(host, property);
+	if (typeof value === 'number' && Number.isFinite(value)) {
+		return value;
+	}
+	const raw = host.getAttribute(attribute);
+	return raw == null || raw === '' ? '' : Number(raw);
+}
+
+function isRangeSlider(host: HTMLElement): boolean {
+	const variant = Reflect.get(host, 'variant');
+	return variant === 'range' || host.getAttribute('variant') === 'range';
+}
+
+const sliderValueAdapter: ControlValueAdapter = {
+	read: (host) => {
+		if (isRangeSlider(host)) {
+			return [readNumberProperty(host, 'rangeMin', 'range-min'), readNumberProperty(host, 'rangeMax', 'range-max')];
+		}
+		return numberValueAdapter.read(host);
+	},
+	write: (host, value) => {
+		if (Array.isArray(value) && value.length >= 2) {
+			host.setAttribute('variant', 'range');
+			if ('variant' in host) {
+				Reflect.set(host, 'variant', 'range');
+			}
+			host.setAttribute('range-min', String(value[0]));
+			host.setAttribute('range-max', String(value[1]));
+			if ('rangeMin' in host) {
+				Reflect.set(host, 'rangeMin', value[0]);
+			}
+			if ('rangeMax' in host) {
+				Reflect.set(host, 'rangeMax', value[1]);
+			}
+			return;
+		}
+		numberValueAdapter.write(host, value);
+	},
+};
+
 const CONTROL_VALUE_ADAPTERS = new Map<string, ControlValueAdapter>([
 	['rui-checkbox', booleanValueAdapter],
 	['rui-switch', booleanValueAdapter],
@@ -103,7 +145,8 @@ const CONTROL_VALUE_ADAPTERS = new Map<string, ControlValueAdapter>([
 	['rui-radio-group', stringValueAdapter],
 	['rui-listbox', stringValueAdapter],
 	['rui-tag-group', stringValueAdapter],
-	['rui-slider', numberValueAdapter],
+	['rui-slider', sliderValueAdapter],
+	['rui-knob', numberValueAdapter],
 	['rui-number-field', numberValueAdapter],
 ]);
 
@@ -388,6 +431,10 @@ export function getAriaControlTarget(control: HTMLElement): HTMLElement {
 		return control;
 	}
 
+	if (control.localName === 'rui-slider') {
+		return control.querySelector<HTMLElement>('[data-thumb]:not([hidden])') ?? control;
+	}
+
 	const marked = control.querySelector<HTMLElement>(`[${RUI_CONTROL_ATTR}]`);
 	if (marked) {
 		return marked;
@@ -417,8 +464,8 @@ export function getAriaControlTarget(control: HTMLElement): HTMLElement {
 		return control.querySelector<HTMLElement>('[data-number-field-input], input') ?? control;
 	}
 
-	if (control.localName === 'rui-slider') {
-		return control.querySelector<HTMLElement>('input[type="range"]') ?? control;
+	if (control.localName === 'rui-knob') {
+		return control.querySelector<HTMLElement>('[data-knob-control]') ?? control;
 	}
 
 	if (control.localName === 'rui-checkbox' || control.localName === 'rui-switch') {
@@ -437,3 +484,13 @@ export function getAriaControlTarget(control: HTMLElement): HTMLElement {
 
 	return control;
 }
+
+/** Focusable surfaces that Field should wire `aria-invalid` / `aria-describedby` onto. */
+export function getAriaControlTargets(control: HTMLElement): HTMLElement[] {
+	if (control.localName === 'rui-slider') {
+		const thumbs = Array.from(control.querySelectorAll<HTMLElement>('[data-thumb]:not([hidden])'));
+		return thumbs.length > 0 ? thumbs : [control];
+	}
+	return [getAriaControlTarget(control)];
+}
+

--- a/packages/radiant-ui/src/components/ui/form/form-field.test.tsx
+++ b/packages/radiant-ui/src/components/ui/form/form-field.test.tsx
@@ -36,7 +36,7 @@ describe('RuiField view', () => {
 	});
 });
 
-describe('rui-field projected content discovery', () => {
+	describe('rui-field composed content discovery', () => {
 	it('calls RuiForm onSubmit with validated values', async () => {
 		const host = document.createElement('div');
 		document.body.append(host);
@@ -146,6 +146,10 @@ describe('rui-field projected content discovery', () => {
 
 	it('shows validation message after invalid submit', async () => {
 		const form = document.createElement('rui-form') as RuiFormElement;
+		const nativeForm = document.createElement('form');
+		nativeForm.className = 'rui-form';
+		nativeForm.setAttribute('data-ref', 'form');
+		nativeForm.noValidate = true;
 		const field = document.createElement('rui-field') as RuiFieldElement;
 		field.name = 'email';
 		field.rules = { required: 'Email is required' };
@@ -155,7 +159,8 @@ describe('rui-field projected content discovery', () => {
 			<p class="rui-field__error" data-rui-field-error role="alert" hidden></p>
 		`;
 
-		form.append(field);
+		nativeForm.append(field);
+		form.append(nativeForm);
 		document.body.append(form);
 
 		await customElements.whenDefined('rui-form');
@@ -163,15 +168,14 @@ describe('rui-field projected content discovery', () => {
 		await flushRender();
 		await new Promise<void>((resolve) => queueMicrotask(() => queueMicrotask(resolve)));
 
-		const nativeForm = form.getRef<HTMLFormElement>('form');
-		expect(nativeForm).not.toBeNull();
+		expect(form.getRef<HTMLFormElement>('form')).toBe(nativeForm);
 
 		let invalid = false;
 		form.addEventListener('rui-invalid', () => {
 			invalid = true;
 		});
 
-		nativeForm!.requestSubmit();
+		nativeForm.requestSubmit();
 		await flushRender();
 		await new Promise((resolve) => setTimeout(resolve, 0));
 

--- a/packages/radiant-ui/src/components/ui/form/form.script.tsx
+++ b/packages/radiant-ui/src/components/ui/form/form.script.tsx
@@ -144,14 +144,17 @@ export class RuiForm extends RadiantElement {
 		super.connectedCallback();
 		this.ensureStore();
 		this.publishFormContext({ force: true });
-		queueMicrotask(() => this.wireOrphanSubmitButtons());
+	}
+
+	protected override onConnected(): void {
+		this.wireOrphanSubmitButtons();
 	}
 
 	private queryNativeForm(): HTMLFormElement | null {
 		return this.getRef<HTMLFormElement>('form') ?? this.querySelector('form.rui-form');
 	}
 
-	/** Link submit buttons left on the host (outside the inner `<form>`) after slot projection. */
+	/** Link submit buttons left on the host outside the composed native `<form>`. */
 	private wireOrphanSubmitButtons(): void {
 		const formEl = this.queryNativeForm();
 		if (!formEl) {
@@ -317,13 +320,5 @@ export class RuiForm extends RadiantElement {
 	@onEvent({ ref: 'form', type: 'reset' })
 	onNativeReset(): void {
 		this.store?.reset();
-	}
-
-	override render() {
-		return (
-			<form class="rui-form" data-ref="form" noValidate action={this.action} method={this.method}>
-				<slot></slot>
-			</form>
-		);
 	}
 }

--- a/packages/radiant-ui/src/components/ui/form/form.tsx
+++ b/packages/radiant-ui/src/components/ui/form/form.tsx
@@ -28,7 +28,9 @@ export function RuiForm({
 					defaultValuesData ?? (defaultValues !== undefined ? JSON.stringify(defaultValues) : undefined),
 			}}
 		>
-			{children}
+			<form class="rui-form" data-ref="form" noValidate action={action} method={method}>
+				{children}
+			</form>
 		</rui-form>
 	);
 }

--- a/packages/radiant-ui/src/components/ui/number-field/number-field.script.tsx
+++ b/packages/radiant-ui/src/components/ui/number-field/number-field.script.tsx
@@ -77,18 +77,8 @@ type RuiNumberFieldBindings = {
  * @attr {string} decrement-aria-label - Accessible name for the decrement stepper. Default: `Decrement`.
  * @attr {boolean} wheel-disabled - Disables scroll-wheel value changes. Default: `false`.
  *
- * @slot group - Input + stepper row (`RuiNumberFieldGroup`).
- * @slot input - Text input (`RuiNumberFieldInput`).
- * @slot decrement - Decrement button (`RuiNumberFieldDecrementButton`).
- * @slot increment - Increment button (`RuiNumberFieldIncrementButton`).
- *
  * @fires rui-change - Emitted when a value is committed (blur, stepper, or keyboard);
  *   `detail.value` holds the new number.
- *
- * @remarks
- * Slot content authored by the view helpers carries the BEM classes (`@cssclass` on
- * the exports). The default `render()` provides matching fallback markup so the
- * element renders identically when used standalone.
  *
  * @cssclass rui-number-field - Root field wrapper.
  */
@@ -122,7 +112,6 @@ export class RuiNumberField extends RadiantElement<RuiNumberFieldBindings> {
 	private initialized = false;
 
 	private readonly uid = Math.random().toString(36).slice(2, 9);
-	private readonly nameAttr = this.$.name.map((name) => name || undefined);
 
 	private get resolvedLocale(): string | string[] | undefined {
 		return resolveLocale(this.locale);
@@ -215,12 +204,17 @@ export class RuiNumberField extends RadiantElement<RuiNumberFieldBindings> {
 	}
 
 	private syncSlottedSteppers(): void {
+		const incrementLabel = this.incrementAriaLabel || 'Increment';
+		const decrementLabel = this.decrementAriaLabel || 'Decrement';
+
 		for (const button of this.querySelectorAll<HTMLButtonElement>('[data-number-field-action="decrement"]')) {
 			button.disabled = this.decreaseDisabled;
+			button.setAttribute('aria-label', decrementLabel);
 		}
 
 		for (const button of this.querySelectorAll<HTMLButtonElement>('[data-number-field-action="increment"]')) {
 			button.disabled = this.increaseDisabled;
+			button.setAttribute('aria-label', incrementLabel);
 		}
 	}
 
@@ -279,9 +273,8 @@ export class RuiNumberField extends RadiantElement<RuiNumberFieldBindings> {
 		this.updateStepperState();
 	}
 
-	override connectedCallback(): void {
-		super.connectedCallback();
-		queueMicrotask(() => this.initialize());
+	protected override onConnected(): void {
+		this.initialize();
 	}
 
 	@onUpdated([
@@ -401,58 +394,5 @@ export class RuiNumberField extends RadiantElement<RuiNumberFieldBindings> {
 		} else if (event.deltaY > 0) {
 			this.decrement(event);
 		}
-	}
-
-	override render() {
-		const incrementLabel = this.incrementAriaLabel || 'Increment';
-		const decrementLabel = this.decrementAriaLabel || 'Decrement';
-
-		return (
-			<div class="rui-number-field">
-				<slot name="group">
-					<div class="rui-number-field__group" data-number-field-group>
-						<slot name="input">
-							<input
-								type="text"
-								data-number-field-input
-								data-rui-control
-								data-rui-control-type="number"
-								class="rui-number-field__input"
-								disabled={this.$.disabled}
-								readOnly={this.$.readOnly}
-								name={this.nameAttr}
-							/>
-							<input type="hidden" data-number-field-value />
-						</slot>
-						<div class="rui-number-field__steppers">
-							<slot name="decrement">
-								<button
-									type="button"
-									class="rui-number-field__stepper"
-									data-number-field-action="decrement"
-									aria-label={decrementLabel}
-									disabled={this.$.decreaseDisabled}
-									tabIndex={-1}
-								>
-									−
-								</button>
-							</slot>
-							<slot name="increment">
-								<button
-									type="button"
-									class="rui-number-field__stepper"
-									data-number-field-action="increment"
-									aria-label={incrementLabel}
-									disabled={this.$.increaseDisabled}
-									tabIndex={-1}
-								>
-									+
-								</button>
-							</slot>
-						</div>
-					</div>
-				</slot>
-			</div>
-		);
 	}
 }

--- a/packages/radiant-ui/src/components/ui/number-field/number-field.tsx
+++ b/packages/radiant-ui/src/components/ui/number-field/number-field.tsx
@@ -11,14 +11,9 @@ export type RuiNumberFieldGroupProps = JsxElementProps<HTMLDivElement>;
  *
  * @cssclass rui-number-field__group - Control-height bordered row wrapping input and steppers.
  */
-export function RuiNumberFieldGroup({
-	children,
-	slot = 'group',
-	class: className,
-	...props
-}: RuiNumberFieldGroupProps) {
+export function RuiNumberFieldGroup({ children, class: className, ...props }: RuiNumberFieldGroupProps) {
 	return (
-		<div {...props} slot={slot} data-number-field-group class={cx('rui-number-field__group', className)}>
+		<div {...props} data-number-field-group class={cx('rui-number-field__group', className)}>
 			{children}
 		</div>
 	);
@@ -31,12 +26,11 @@ export type RuiNumberFieldInputProps = JsxElementProps<HTMLInputElement> & {
 };
 
 /**
- * Text input in the `input` slot. Formatting is handled by `<rui-number-field>`.
+ * Text input for the number field. Formatting is handled by `<rui-number-field>`.
  *
  * @cssclass rui-number-field__input - Borderless text input inside the group.
  */
 export function RuiNumberFieldInput({
-	slot = 'input',
 	class: className,
 	disabled,
 	readOnly,
@@ -46,7 +40,6 @@ export function RuiNumberFieldInput({
 		<input
 			{...props}
 			type="text"
-			slot={slot}
 			data-number-field-input
 			data-rui-control
 			data-rui-control-type="number"
@@ -64,27 +57,25 @@ export type RuiNumberFieldSteppersProps = JsxElementProps<HTMLDivElement>;
  *
  * @cssclass rui-number-field__steppers - Trailing stepper column with a border divider.
  */
-export function RuiNumberFieldSteppers({ children, slot, class: className, ...props }: RuiNumberFieldSteppersProps) {
+export function RuiNumberFieldSteppers({ children, class: className, ...props }: RuiNumberFieldSteppersProps) {
 	return (
-		<div {...props} slot={slot} class={cx('rui-number-field__steppers', className)}>
+		<div {...props} class={cx('rui-number-field__steppers', className)}>
 			{children}
 		</div>
 	);
 }
 
 export type RuiNumberFieldStepperButtonProps = JsxElementProps<HTMLButtonElement> & {
-	slot?: 'increment' | 'decrement';
 	disabled?: boolean;
 };
 
 /**
- * Increment stepper in the `increment` slot.
+ * Increment stepper button.
  *
  * @cssclass rui-number-field__stepper - Icon button cell in the steppers column.
  */
 export function RuiNumberFieldIncrementButton({
 	children,
-	slot = 'increment',
 	class: className,
 	aria,
 	disabled,
@@ -95,7 +86,6 @@ export function RuiNumberFieldIncrementButton({
 			{...props}
 			aria={withDefaultAriaLabel(aria, 'Increment')}
 			type="button"
-			slot={slot}
 			data-number-field-action="increment"
 			class={cx('rui-number-field__stepper', className)}
 			disabled={disabled}
@@ -107,13 +97,12 @@ export function RuiNumberFieldIncrementButton({
 }
 
 /**
- * Decrement stepper in the `decrement` slot.
+ * Decrement stepper button.
  *
  * @cssclass rui-number-field__stepper - Icon button cell in the steppers column.
  */
 export function RuiNumberFieldDecrementButton({
 	children,
-	slot = 'decrement',
 	class: className,
 	aria,
 	disabled,
@@ -124,7 +113,6 @@ export function RuiNumberFieldDecrementButton({
 			{...props}
 			aria={withDefaultAriaLabel(aria, 'Decrement')}
 			type="button"
-			slot={slot}
 			data-number-field-action="decrement"
 			class={cx('rui-number-field__stepper', className)}
 			disabled={disabled}
@@ -132,6 +120,19 @@ export function RuiNumberFieldDecrementButton({
 		>
 			{children ?? '−'}
 		</button>
+	);
+}
+
+function NumberFieldDefaultGroup() {
+	return (
+		<RuiNumberFieldGroup>
+			<RuiNumberFieldInput />
+			<input type="hidden" data-number-field-value />
+			<RuiNumberFieldSteppers>
+				<RuiNumberFieldDecrementButton />
+				<RuiNumberFieldIncrementButton />
+			</RuiNumberFieldSteppers>
+		</RuiNumberFieldGroup>
 	);
 }
 
@@ -150,12 +151,18 @@ export function RuiNumberFieldDecrementButton({
  * </RuiNumberField>
  * ```
  *
- * Or use standalone; default slots render input and stepper buttons.
+ * When `children` is omitted, the view renders the default input and stepper row.
  * Pair with `RuiLabel` / `RuiField` for labeling and validation.
  */
 export function RuiNumberField({
 	children,
 	...props
 }: JsxCustomElementAttributes<RuiNumberFieldElement, RuiNumberFieldProps>) {
-	return <rui-number-field {...props}>{children}</rui-number-field>;
+	return (
+		<rui-number-field {...props}>
+			<div class="rui-number-field" data-ref="root">
+				{children ?? <NumberFieldDefaultGroup />}
+			</div>
+		</rui-number-field>
+	);
 }

--- a/packages/radiant-ui/src/components/ui/switch/switch.script.tsx
+++ b/packages/radiant-ui/src/components/ui/switch/switch.script.tsx
@@ -1,4 +1,4 @@
-import { RadiantElement, customElement, event, onEvent, prop } from '@ecopages/radiant';
+import { RadiantElement, bound, customElement, event, onEvent, onUpdated, prop, query } from '@ecopages/radiant';
 import type { EventEmitter } from '@ecopages/radiant/tools/event-emitter';
 
 export type RuiSwitchProps = {
@@ -12,12 +12,6 @@ export type RuiSwitchProps = {
 
 export type RuiSwitchChangeDetail = {
 	checked: boolean;
-};
-
-type RuiSwitchBindings = {
-	checked: boolean;
-	disabled: boolean;
-	name: string;
 };
 
 /**
@@ -40,7 +34,6 @@ type RuiSwitchBindings = {
  * - `Space`: toggle the switch
  *
  * @element rui-switch
- * @slot - Visible label for the switch. Must not change with state.
  * @fires rui-change - Emitted after the checked state changes; `detail.checked` holds the new state.
  * @cssclass rui-switch - Label row: track + thumb + visible label.
  * @cssclass rui-switch__input - Native `role="switch"` input (visually hidden).
@@ -49,44 +42,41 @@ type RuiSwitchBindings = {
  * @cssclass rui-switch__label - Light-DOM label text.
  */
 @customElement('rui-switch')
-export class RuiSwitch extends RadiantElement<RuiSwitchBindings> {
+export class RuiSwitch extends RadiantElement {
 	@prop({ type: Boolean, reflect: true, defaultValue: false }) checked: boolean;
 	@prop({ type: Boolean, reflect: true, defaultValue: false }) disabled: boolean;
 	@prop({ type: String, defaultValue: '' }) name: string;
 
+	@query({ ref: 'input' }) inputTarget: HTMLInputElement;
+
 	@event({ name: 'rui-change', bubbles: true, composed: true })
 	changeEvent: EventEmitter<RuiSwitchChangeDetail>;
 
-	private readonly nameAttr = this.$.name.map((name) => name || undefined);
+	protected override onConnected(): void {
+		this.syncInputState();
+	}
+
+	@bound
+	@onUpdated(['checked', 'disabled', 'name'])
+	syncInputState(): void {
+		const input = this.inputTarget;
+		if (!input) {
+			return;
+		}
+
+		input.checked = this.checked;
+		input.disabled = this.disabled;
+		if (this.name) {
+			input.name = this.name;
+		} else {
+			input.removeAttribute('name');
+		}
+	}
 
 	@onEvent({ ref: 'input', type: 'change' })
 	onInputChange(event: Event): void {
 		const input = event.target as HTMLInputElement;
 		this.checked = input.checked;
 		this.changeEvent.emit({ checked: this.checked });
-	}
-
-	override render() {
-		return (
-			<label class="rui-switch">
-				<input
-					type="checkbox"
-					role="switch"
-					data-ref="input"
-					data-rui-control
-					data-rui-control-type="boolean"
-					class="rui-switch__input"
-					prop:checked={this.$.checked}
-					disabled={this.$.disabled}
-					name={this.nameAttr}
-				/>
-				<span class="rui-switch__track" aria-hidden="true">
-					<span class="rui-switch__thumb"></span>
-				</span>
-				<span class="rui-switch__label">
-					<slot></slot>
-				</span>
-			</label>
-		);
 	}
 }

--- a/packages/radiant-ui/src/components/ui/switch/switch.ssr.test.tsx
+++ b/packages/radiant-ui/src/components/ui/switch/switch.ssr.test.tsx
@@ -1,17 +1,14 @@
 import { describe, expect, it } from 'vitest';
 import { renderToString } from '@ecopages/jsx/server';
-import '@ecopages/radiant/server/install-ssr-runtime';
-import { renderRadiantElementHostToString } from '@ecopages/radiant/server/radiant-element-ssr';
-import { RuiSwitch as RuiSwitchView } from './switch';
-import { RuiSwitch } from './switch.script';
+import { RuiSwitch } from './switch';
 
 describe('RuiSwitch SSR', () => {
 	it('renders track, thumb, and label markup before hydration', () => {
-		const element = document.createElement('rui-switch') as RuiSwitch;
-		element.checked = false;
-		element.innerHTML = 'Email notifications';
-
-		const html = renderRadiantElementHostToString(element, { mode: 'hydrate' });
+		const html = renderToString(
+			<RuiSwitch checked={false} disabled={false}>
+				Email notifications
+			</RuiSwitch>,
+		);
 
 		expect(html).toContain('rui-switch__track');
 		expect(html).toContain('rui-switch__thumb');
@@ -19,24 +16,28 @@ describe('RuiSwitch SSR', () => {
 		expect(html).toContain('Email notifications');
 	});
 
-	it('reflects checked state in SSR markup', () => {
-		const element = document.createElement('rui-switch') as RuiSwitch;
-		element.checked = true;
+	it('renders checked state on the host and native control', () => {
+		const html = renderToString(
+			<RuiSwitch checked disabled name="notifications">
+				Notifications
+			</RuiSwitch>,
+		);
 
-		const html = renderRadiantElementHostToString(element, { mode: 'hydrate' });
-
-		expect(html).toContain('checked');
+		expect(html).toMatch(/<rui-switch[^>]*checked/);
+		expect(html).toMatch(/<input[^>]*checked/);
+		expect(html).toMatch(/<input[^>]*disabled/);
+		expect(html).toMatch(/<input[^>]*name="notifications"/);
 	});
 
-	it('view passes label text as children without duplicating chrome', () => {
+	it('renders a single chrome shell for the view composition', () => {
 		const html = renderToString(
-			<RuiSwitchView checked={false} disabled={false}>
+			<RuiSwitch checked={false} disabled={false}>
 				Disabled
-			</RuiSwitchView>,
+			</RuiSwitch>,
 		);
 
 		expect(html).toContain('rui-switch');
 		expect(html).toContain('Disabled');
-		expect(html.match(/rui-switch__track/g)?.length ?? 0).toBeLessThanOrEqual(1);
+		expect(html.match(/rui-switch__track/g)?.length ?? 0).toBe(1);
 	});
 });

--- a/packages/radiant-ui/src/components/ui/switch/switch.stories.tsx
+++ b/packages/radiant-ui/src/components/ui/switch/switch.stories.tsx
@@ -7,7 +7,7 @@ import { RuiSwitch as RuiSwitchElement } from './switch.script';
 const meta = {
 	title: 'Components/Switch',
 	component: RuiSwitch,
-	parameters: { radiant: { element: RuiSwitchElement, cssImports: ['./switch.css'] } },
+	parameters: { radiant: { element: RuiSwitchElement, cssImports: ['./switch.css', '../field/field.css'] } },
 	args: {
 		checked: false,
 		disabled: false,

--- a/packages/radiant-ui/src/components/ui/switch/switch.tsx
+++ b/packages/radiant-ui/src/components/ui/switch/switch.tsx
@@ -2,14 +2,32 @@ import type { JsxCustomElementAttributes } from '@ecopages/jsx';
 import type { RuiSwitch as RuiSwitchElement, RuiSwitchProps } from './switch.script';
 import './switch.script';
 
-/**
- * Switch view — label text as light-DOM children; chrome comes from the host `render()`.
- *
- * @remarks
- * Do not SSR a full `.rui-switch` shell as children. The host projects authored
- * children into `.rui-switch__label` via `<slot>`; a pre-rendered shell would
- * paint a second track after hydration.
- */
-export function RuiSwitch({ children, ...props }: JsxCustomElementAttributes<RuiSwitchElement, RuiSwitchProps>) {
-	return <rui-switch {...props}>{children}</rui-switch>;
+export function RuiSwitch({
+	children,
+	checked,
+	disabled,
+	name,
+	...props
+}: JsxCustomElementAttributes<RuiSwitchElement, RuiSwitchProps>) {
+	return (
+		<rui-switch {...props} checked={checked} disabled={disabled} name={name}>
+			<label class="rui-switch">
+				<input
+					type="checkbox"
+					role="switch"
+					data-ref="input"
+					data-rui-control
+					data-rui-control-type="boolean"
+					class="rui-switch__input"
+					checked={checked}
+					disabled={disabled}
+					name={name || undefined}
+				/>
+				<span class="rui-switch__track" aria-hidden="true">
+					<span class="rui-switch__thumb"></span>
+				</span>
+				<span class="rui-switch__label">{children}</span>
+			</label>
+		</rui-switch>
+	);
 }


### PR DESCRIPTION
Migrate form, field, checkbox, switch, and number-field to view-owned
shells with onConnected sync.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>