### PR TITLE
refactor(radiant-ui): view-owned light DOM for collections

### DIFF
--- a/packages/radiant-ui/src/components/ui/grid/grid.script.tsx
+++ b/packages/radiant-ui/src/components/ui/grid/grid.script.tsx
@@ -24,9 +24,6 @@ type RuiGridBindings = {
  *
  * @attr {string} label - Accessible name announced when focus enters the grid.
  *
- * @slot - Grid cells authored as `role="row"` / `role="gridcell"` children. Use
- *   the `RuiGrid` view to author rows and cells with BEM classes.
- *
  * @cssclass rui-grid - Root surface (`role="grid"`).
  *
  * @remarks
@@ -37,14 +34,9 @@ type RuiGridBindings = {
 export class RuiGrid extends RadiantElement<RuiGridBindings> {
 	@prop({ type: String, defaultValue: '' }) label: string;
 
-	private readonly resolvedAriaLabel = this.$.label.map((label) => label || undefined);
-
-	override connectedCallback(): void {
-		super.connectedCallback();
-		queueMicrotask(() => {
-			const cells = Array.from(this.querySelectorAll<HTMLElement>('[role="gridcell"]'));
-			applyRovingTabindex(cells, 0);
-		});
+	protected override onConnected(): void {
+		const cells = Array.from(this.querySelectorAll<HTMLElement>('[role="gridcell"]'));
+		applyRovingTabindex(cells, 0);
 	}
 
 	private getRows(): HTMLElement[] {
@@ -95,13 +87,5 @@ export class RuiGrid extends RadiantElement<RuiGridBindings> {
 		const allCells = Array.from(this.querySelectorAll<HTMLElement>('[role="gridcell"]'));
 		applyRovingTabindex(allCells, allCells.indexOf(target));
 		target.focus();
-	}
-
-	override render() {
-		return (
-			<div class="rui-grid" role="grid" aria-label={this.resolvedAriaLabel}>
-				<slot></slot>
-			</div>
-		);
 	}
 }

--- a/packages/radiant-ui/src/components/ui/grid/grid.tsx
+++ b/packages/radiant-ui/src/components/ui/grid/grid.tsx
@@ -13,19 +13,28 @@ import './grid.script';
  */
 export function RuiGrid({
 	rows,
+	label,
+	children,
 	...props
-}: JsxCustomElementAttributes<RuiGridElement, RuiGridProps & { rows: JsxRenderable[][] }>) {
+}: JsxCustomElementAttributes<RuiGridElement, RuiGridProps & { rows?: JsxRenderable[][] }>) {
+	const content =
+		rows != null
+			? rows.map((row) => (
+					<div class="rui-grid__row" role="row">
+						{row.map((cell) => (
+							<div class="rui-grid__cell" role="gridcell" tabindex={-1}>
+								{cell}
+							</div>
+						))}
+					</div>
+				))
+			: children;
+
 	return (
-		<rui-grid {...props}>
-			{rows.map((row) => (
-				<div class="rui-grid__row" role="row">
-					{row.map((cell) => (
-						<div class="rui-grid__cell" role="gridcell" tabindex={-1}>
-							{cell}
-						</div>
-					))}
-				</div>
-			))}
+		<rui-grid {...props} label={label}>
+			<div class="rui-grid" data-ref="root" role="grid" aria-label={label || undefined}>
+				{content}
+			</div>
 		</rui-grid>
 	);
 }

--- a/packages/radiant-ui/src/components/ui/listbox/listbox.script.tsx
+++ b/packages/radiant-ui/src/components/ui/listbox/listbox.script.tsx
@@ -18,15 +18,12 @@ export type RuiListboxProps = {
 
 export type RuiListboxChangeDetail = { value: string };
 
-type RuiListboxBindings = {
-	label: string;
-	disabled: boolean;
-};
-
 /**
  * `<rui-listbox>` — a list of options where one may be selected.
  *
  * Implements the APG Listbox pattern with roving tabindex on `[role="option"]`.
+ * The view-owned `.rui-listbox` shell carries presentation; this host coordinates
+ * selection and keyboard interaction only.
  *
  * @see https://www.w3.org/WAI/ARIA/apg/patterns/listbox/
  *
@@ -38,15 +35,13 @@ type RuiListboxBindings = {
  * @attr {boolean} embedded - Parent-owned listbox: border chrome omitted, selection handled by the parent. Default: `false`.
  * @attr {boolean} bordered - Override the border (`true` standalone, `false` embedded). Default: follows `embedded`.
  *
- * @slot - Option elements (`RuiListboxOption`), each with `role="option"`.
- *
  * @fires rui-change - Emitted when an option is selected; detail carries `value`.
  *
  * @cssclass rui-listbox - Scrollable option list surface (`role="listbox"`).
  * @cssclass rui-listbox--bordered - Bordered standalone listbox.
  */
 @customElement('rui-listbox')
-export class RuiListbox extends RadiantElement<RuiListboxBindings> {
+export class RuiListbox extends RadiantElement {
 	@prop({ type: String, reflect: true, defaultValue: '' }) value: string;
 	@prop({ type: String, defaultValue: '' }) label: string;
 	@prop({ type: Boolean, reflect: true, defaultValue: false }) disabled: boolean;
@@ -56,21 +51,13 @@ export class RuiListbox extends RadiantElement<RuiListboxBindings> {
 	@event({ name: 'rui-change', bubbles: true, composed: true })
 	changeEvent: EventEmitter<RuiListboxChangeDetail>;
 
-	private readonly resolvedAriaLabel = this.$.label.map((label) => label || undefined);
-	private readonly resolvedAriaDisabled = this.$.disabled.map((disabled) => (disabled ? 'true' : undefined));
-
-	override connectedCallback(): void {
-		super.connectedCallback();
-		queueMicrotask(() => {
-			this.sync();
-			this.syncPresentation();
-		});
+	protected override onConnected(): void {
+		this.sync();
 	}
 
-	@onUpdated(['value', 'disabled', 'embedded', 'bordered'])
+	@onUpdated(['value', 'disabled', 'embedded'])
 	onPropsUpdated(): void {
 		this.sync();
-		this.syncPresentation();
 	}
 
 	private getOptions(): HTMLElement[] {
@@ -129,39 +116,5 @@ export class RuiListbox extends RadiantElement<RuiListboxBindings> {
 
 		event.preventDefault();
 		this.select(result.item);
-	}
-
-	private isBordered(): boolean {
-		if (this.bordered != null) {
-			return this.bordered;
-		}
-
-		return !this.embedded;
-	}
-
-	private syncPresentation(): void {
-		const root = this.querySelector<HTMLElement>('.rui-listbox');
-		if (!root) {
-			return;
-		}
-
-		root.classList.toggle('rui-listbox--bordered', this.isBordered());
-	}
-
-	override render() {
-		const bordered = this.isBordered();
-
-		return (
-			<div
-				class={`rui-listbox${bordered ? ' rui-listbox--bordered' : ''}`}
-				role="listbox"
-				data-rui-control
-				data-rui-control-type="text"
-				aria-label={this.resolvedAriaLabel}
-				aria-disabled={this.resolvedAriaDisabled}
-			>
-				<slot></slot>
-			</div>
-		);
 	}
 }

--- a/packages/radiant-ui/src/components/ui/listbox/listbox.tsx
+++ b/packages/radiant-ui/src/components/ui/listbox/listbox.tsx
@@ -39,26 +39,70 @@ export function RuiListboxOption({
 
 export type RuiListboxOptionData = { value: string; label: JsxRenderable; disabled?: boolean };
 
+function listboxIsBordered(embedded?: boolean, bordered?: boolean): boolean {
+	if (bordered != null) {
+		return bordered;
+	}
+
+	return !embedded;
+}
+
+type ListboxShellProps = {
+	bordered: boolean;
+	children: JsxRenderable;
+	disabled?: boolean;
+	label?: string;
+};
+
+function ListboxShell({ bordered, children, disabled, label }: ListboxShellProps) {
+	return (
+		<div
+			class={cx('rui-listbox', bordered && 'rui-listbox--bordered')}
+			role="listbox"
+			data-rui-control
+			data-rui-control-type="text"
+			aria-label={label || undefined}
+			aria-disabled={disabled ? 'true' : undefined}
+		>
+			{children}
+		</div>
+	);
+}
+
 export function RuiListbox({
 	options,
 	children,
+	embedded,
+	bordered,
+	label,
+	disabled,
 	...props
 }: JsxCustomElementAttributes<RuiListboxElement, RuiListboxProps & { options?: RuiListboxOptionData[] }>) {
+	const isBordered = listboxIsBordered(embedded, bordered);
+
 	if (options != null) {
 		return (
-			<rui-listbox {...props}>
-				{options.map((option) => (
-					<RuiListboxOption
-						value={option.value}
-						label={typeof option.label === 'string' ? option.label : undefined}
-						disabled={option.disabled}
-					>
-						{option.label}
-					</RuiListboxOption>
-				))}
+			<rui-listbox {...props} embedded={embedded} bordered={bordered} label={label} disabled={disabled}>
+				<ListboxShell bordered={isBordered} disabled={disabled} label={label}>
+					{options.map((option) => (
+						<RuiListboxOption
+							value={option.value}
+							label={typeof option.label === 'string' ? option.label : undefined}
+							disabled={option.disabled}
+						>
+							{option.label}
+						</RuiListboxOption>
+					))}
+				</ListboxShell>
 			</rui-listbox>
 		);
 	}
 
-	return <rui-listbox {...props}>{children}</rui-listbox>;
+	return (
+		<rui-listbox {...props} embedded={embedded} bordered={bordered} label={label} disabled={disabled}>
+			<ListboxShell bordered={isBordered} disabled={disabled} label={label}>
+				{children}
+			</ListboxShell>
+		</rui-listbox>
+	);
 }

--- a/packages/radiant-ui/src/components/ui/tag-group/tag-group.script.tsx
+++ b/packages/radiant-ui/src/components/ui/tag-group/tag-group.script.tsx
@@ -31,7 +31,6 @@ export type RuiTagGroupRemoveDetail = { value: string };
  * @attr {boolean} disabled - Disable selection and removal. Default: `false`.
  * @attr {('single'|'multiple')} selection-mode - Allow one or many selected tags. Default: `multiple`.
  * @attr {boolean} embedded - Disables selection when the parent component owns the selected values. Default: `false`.
- * @slot - Tag content. Compose `RuiTagList` / `RuiTag` / `RuiTagRemove`, or set items via `setItems()`.
  * @fires rui-change - Emitted when the selected `value` changes; `detail.value` is the comma-separated value.
  * @fires rui-remove - Emitted when a tag is removed; `detail.value` is the removed tag's value.
  * @cssclass rui-tag-group - Root wrapper around the tag list.
@@ -74,16 +73,8 @@ export class RuiTagGroup extends RadiantElement {
 		if (managed) {
 			return managed;
 		}
-		const rendered = this.querySelector<HTMLElement>('[data-tag-list]');
-		if (rendered) {
-			return rendered;
-		}
 
-		return (
-			this.getSlotElements<HTMLElement>().find(
-				(element) => element.matches('[data-tag-list]') || element.querySelector('[data-tag-list]'),
-			) ?? null
-		);
+		return this.querySelector<HTMLElement>('[data-tag-list]');
 	}
 
 	private getTags(): HTMLElement[] {
@@ -194,13 +185,13 @@ export class RuiTagGroup extends RadiantElement {
 		this.syncTags();
 	}
 
-	override connectedCallback(): void {
-		super.connectedCallback();
-		queueMicrotask(() => this.initialize());
+	protected override onConnected(): void {
+		this.initialize();
 	}
 
 	@onUpdated(['value', 'label', 'disabled', 'selectionMode', 'embedded', 'managedItems'])
 	onPropsUpdated(): void {
+		this.syncManagedList();
 		this.syncList();
 		this.syncTags();
 	}
@@ -214,6 +205,60 @@ export class RuiTagGroup extends RadiantElement {
 	setItems(items: RuiTagGroupItem[]): void {
 		this.managedItems = items;
 		this.value = serializeMultiValue(items.map((item) => item.value));
+	}
+
+	/**
+	 * Imperative twin of the view's `RuiTag` / `RuiTagRemove` markup for
+	 * CE-managed items (same `data-*` hooks, classes, and remove glyph).
+	 */
+	private createManagedTag(item: RuiTagGroupItem): HTMLElement {
+		const tag = document.createElement('span');
+		tag.setAttribute('data-tag', '');
+		tag.setAttribute('data-value', item.value);
+		tag.setAttribute('data-label', item.label);
+		tag.className = 'rui-tag';
+		tag.textContent = item.label;
+
+		const remove = document.createElement('button');
+		remove.type = 'button';
+		remove.setAttribute('data-tag-remove', '');
+		remove.className = 'rui-tag__remove';
+		remove.setAttribute('aria-label', `Remove ${item.label}`);
+
+		const icon = document.createElement('span');
+		icon.setAttribute('aria-hidden', 'true');
+		icon.textContent = '×';
+		remove.append(icon);
+		tag.append(remove);
+
+		return tag;
+	}
+
+	private syncManagedList(): void {
+		const root = this.querySelector<HTMLElement>('[data-ref="root"]');
+		if (!root) {
+			return;
+		}
+
+		let managed = root.querySelector<HTMLElement>('[data-rui-managed-list]');
+		if (this.managedItems.length === 0) {
+			managed?.remove();
+			return;
+		}
+
+		if (!managed) {
+			managed = document.createElement('div');
+			managed.setAttribute('data-tag-list', '');
+			managed.setAttribute('data-rui-managed-list', '');
+			managed.className = 'rui-tag-group__list';
+			root.appendChild(managed);
+		}
+
+		managed.replaceChildren(...this.managedItems.map((item) => this.createManagedTag(item)));
+
+		this.ensureTagIds();
+		this.syncList();
+		this.syncTags();
 	}
 
 	@onEvent({ selector: '[data-tag]', type: 'click' })
@@ -273,30 +318,5 @@ export class RuiTagGroup extends RadiantElement {
 		if (result.handled) {
 			event.preventDefault();
 		}
-	}
-
-	override render() {
-		return (
-			<div class="rui-tag-group" data-ref="root">
-				<slot></slot>
-				{this.managedItems.length > 0 ? (
-					<div data-tag-list data-rui-managed-list class="rui-tag-group__list">
-						{this.managedItems.map((item) => (
-							<span data-tag data-value={item.value} data-label={item.label} class="rui-tag">
-								{item.label}
-								<button
-									type="button"
-									data-tag-remove
-									class="rui-tag__remove"
-									aria-label={`Remove ${item.label}`}
-								>
-									<span aria-hidden="true">×</span>
-								</button>
-							</span>
-						))}
-					</div>
-				) : null}
-			</div>
-		);
 	}
 }

--- a/packages/radiant-ui/src/components/ui/tag-group/tag-group.tsx
+++ b/packages/radiant-ui/src/components/ui/tag-group/tag-group.tsx
@@ -29,6 +29,9 @@ export type RuiTagProps = JsxElementProps<HTMLSpanElement> & {
  * A single tag with optional remove button.
  *
  * @cssclass rui-tag - Tag chip; selected state via `[aria-selected='true']`.
+ *
+ * @remarks Tags built imperatively for CE-managed items mirror this markup in
+ * `RuiTagGroup.createManagedTag` (`tag-group.script.tsx`) — edit both together.
  */
 export function RuiTag({ value, label, children, class: className, disabled, ...props }: RuiTagProps) {
 	return (
@@ -69,6 +72,14 @@ export function RuiTagRemove({ children, class: className, aria, ...props }: Rui
 
 export type RuiTagData = { value: string; label: JsxRenderable; disabled?: boolean };
 
+function TagGroupShell({ children }: { children: JsxRenderable }) {
+	return (
+		<div class="rui-tag-group" data-ref="root">
+			{children}
+		</div>
+	);
+}
+
 export function RuiTagGroup({
 	tags,
 	children,
@@ -82,20 +93,26 @@ export function RuiTagGroup({
 	if (tags != null) {
 		return (
 			<rui-tag-group {...props}>
-				<RuiTagList>
-					{tags.map((tag) => (
-						<RuiTag
-							value={tag.value}
-							label={typeof tag.label === 'string' ? tag.label : undefined}
-							disabled={tag.disabled}
-						>
-							{tag.label}
-						</RuiTag>
-					))}
-				</RuiTagList>
+				<TagGroupShell>
+					<RuiTagList>
+						{tags.map((tag) => (
+							<RuiTag
+								value={tag.value}
+								label={typeof tag.label === 'string' ? tag.label : undefined}
+								disabled={tag.disabled}
+							>
+								{tag.label}
+							</RuiTag>
+						))}
+					</RuiTagList>
+				</TagGroupShell>
 			</rui-tag-group>
 		);
 	}
 
-	return <rui-tag-group {...props}>{children}</rui-tag-group>;
+	return (
+		<rui-tag-group {...props}>
+			<TagGroupShell>{children}</TagGroupShell>
+		</rui-tag-group>
+	);
 }

--- a/packages/radiant-ui/src/components/ui/tree/tree.script.tsx
+++ b/packages/radiant-ui/src/components/ui/tree/tree.script.tsx
@@ -31,9 +31,6 @@ type RuiTreeBindings = {
  * @attr {string} label - Accessible name for the tree.
  * @attr {string} value - Selected item's `data-value` / id. Default: `''`.
  *
- * @slot - Tree items authored as `role="treeitem"` markup. Use the `RuiTree`
- *   view (`nodes`) or author light-DOM items directly.
- *
  * @fires rui-change - Emitted with `{ value }` when a tree item is selected.
  *
  * @cssclass rui-tree - Root list (`role="tree"`).
@@ -50,8 +47,6 @@ export class RuiTree extends RadiantElement<RuiTreeBindings> {
 
 	@event({ name: 'rui-change', bubbles: true, composed: true })
 	changeEvent: EventEmitter<RuiTreeChangeDetail>;
-
-	private readonly resolvedAriaLabel = this.$.label.map((label) => label || undefined);
 
 	private getVisibleItems(): HTMLElement[] {
 		return Array.from(this.querySelectorAll<HTMLElement>('[role="treeitem"]')).filter((item) => {
@@ -120,12 +115,9 @@ export class RuiTree extends RadiantElement<RuiTreeBindings> {
 		}
 	}
 
-	override connectedCallback(): void {
-		super.connectedCallback();
-		queueMicrotask(() => {
-			this.syncExpanded();
-			this.syncSelection();
-		});
+	protected override onConnected(): void {
+		this.syncExpanded();
+		this.syncSelection();
 	}
 
 	@onUpdated('value')
@@ -231,13 +223,5 @@ export class RuiTree extends RadiantElement<RuiTreeBindings> {
 			default:
 				break;
 		}
-	}
-
-	override render() {
-		return (
-			<ul class="rui-tree" role="tree" aria-label={this.resolvedAriaLabel} aria-multiselectable="false">
-				<slot></slot>
-			</ul>
-		);
 	}
 }

--- a/packages/radiant-ui/src/components/ui/tree/tree.tsx
+++ b/packages/radiant-ui/src/components/ui/tree/tree.tsx
@@ -26,7 +26,7 @@ const TreeNodes = ({ nodes }: { nodes: RuiTreeNode[] }) => (
 						>
 							{node.label}
 						</button>
-						<ul role="group" hidden={!(node.expanded ?? false)}>
+						<ul role="group">
 							<TreeNodes nodes={node.children} />
 						</ul>
 					</>
@@ -58,11 +58,23 @@ const TreeNodes = ({ nodes }: { nodes: RuiTreeNode[] }) => (
  */
 export function RuiTree({
 	nodes,
+	label,
+	children,
 	...props
-}: JsxCustomElementAttributes<RuiTreeElement, RuiTreeProps & { nodes: RuiTreeNode[] }>) {
+}: JsxCustomElementAttributes<RuiTreeElement, RuiTreeProps & { nodes?: RuiTreeNode[] }>) {
+	const content = nodes != null ? <TreeNodes nodes={nodes} /> : children;
+
 	return (
-		<rui-tree {...props}>
-			<TreeNodes nodes={nodes} />
+		<rui-tree {...props} label={label}>
+			<ul
+				class="rui-tree"
+				data-ref="root"
+				role="tree"
+				aria-label={label || undefined}
+				aria-multiselectable="false"
+			>
+				{content}
+			</ul>
 		</rui-tree>
 	);
 }

--- a/packages/radiant-ui/src/components/ui/treegrid/treegrid.script.tsx
+++ b/packages/radiant-ui/src/components/ui/treegrid/treegrid.script.tsx
@@ -35,9 +35,6 @@ type RuiTreegridBindings = {
  * @attr {string} label - Accessible name for the treegrid.
  * @attr {string} value - Selected row's `data-row-id`. Default: `''`.
  *
- * @slot - Rows and groups authored as `role="row"` / `role="rowgroup"` markup.
- *   Use the `RuiTreegrid` view (`columns`, `rows`) or author light-DOM rows directly.
- *
  * @fires rui-change - Emitted with `{ rowId, columnIndex }` when a cell activates.
  *
  * @cssclass rui-treegrid - Root surface (`role="treegrid"`).
@@ -54,8 +51,6 @@ export class RuiTreegrid extends RadiantElement<RuiTreegridBindings> {
 
 	@event({ name: 'rui-change', bubbles: true, composed: true })
 	changeEvent: EventEmitter<RuiTreegridChangeDetail>;
-
-	private readonly resolvedAriaLabel = this.$.label.map((label) => label || undefined);
 
 	private getDataRows(): HTMLElement[] {
 		return Array.from(this.querySelectorAll<HTMLElement>('[role="row"][data-row-id]'));
@@ -130,12 +125,9 @@ export class RuiTreegrid extends RadiantElement<RuiTreegridBindings> {
 		}
 	}
 
-	override connectedCallback(): void {
-		super.connectedCallback();
-		queueMicrotask(() => {
-			this.syncExpanded();
-			this.syncSelection();
-		});
+	protected override onConnected(): void {
+		this.syncExpanded();
+		this.syncSelection();
 	}
 
 	@onUpdated('value')
@@ -306,13 +298,5 @@ export class RuiTreegrid extends RadiantElement<RuiTreegridBindings> {
 			default:
 				return;
 		}
-	}
-
-	override render() {
-		return (
-			<div class="rui-treegrid" role="treegrid" aria-label={this.resolvedAriaLabel}>
-				<slot></slot>
-			</div>
-		);
 	}
 }

--- a/packages/radiant-ui/src/components/ui/treegrid/treegrid.tsx
+++ b/packages/radiant-ui/src/components/ui/treegrid/treegrid.tsx
@@ -56,21 +56,34 @@ const TreegridRows = ({ rows }: { rows: RuiTreegridRow[] }) => (
 export function RuiTreegrid({
 	columns,
 	rows,
+	label,
+	children,
 	...props
 }: JsxCustomElementAttributes<
 	RuiTreegridElement,
-	RuiTreegridProps & { columns: JsxRenderable[]; rows: RuiTreegridRow[] }
+	RuiTreegridProps & { columns?: JsxRenderable[]; rows?: RuiTreegridRow[] }
 >) {
+	const content =
+		columns != null && rows != null ? (
+			<>
+				<div class="rui-treegrid__row rui-treegrid__row--header" role="row">
+					{columns.map((column) => (
+						<div class="rui-treegrid__cell rui-treegrid__cell--header" role="columnheader">
+							{column}
+						</div>
+					))}
+				</div>
+				<TreegridRows rows={rows} />
+			</>
+		) : (
+			children
+		);
+
 	return (
-		<rui-treegrid {...props}>
-			<div class="rui-treegrid__row rui-treegrid__row--header" role="row">
-				{columns.map((column) => (
-					<div class="rui-treegrid__cell rui-treegrid__cell--header" role="columnheader">
-						{column}
-					</div>
-				))}
+		<rui-treegrid {...props} label={label}>
+			<div class="rui-treegrid" data-ref="root" role="treegrid" aria-label={label || undefined}>
+				{content}
 			</div>
-			<TreegridRows rows={rows} />
 		</rui-treegrid>
 	);
 }


### PR DESCRIPTION
Migrate listbox, grid, tree, treegrid, and tag-group. Tree expandable
groups omit view-bound hidden so the script owns visibility.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>