### PR TITLE
refactor(radiant-ui): view-owned light DOM for overlays and pickers

### DIFF
--- a/packages/radiant-ui/src/components/ui/autocomplete/autocomplete.script.tsx
+++ b/packages/radiant-ui/src/components/ui/autocomplete/autocomplete.script.tsx
@@ -4,12 +4,12 @@ import { textContains, type TextFilterSensitivity } from '@/lib/text-filter';
 export type RuiAutocompleteProps = {
 	/** Filter sensitivity. Default: `base` (case-insensitive contains). */
 	sensitivity?: TextFilterSensitivity;
-	/** Controlled filter query. When unset, reads from the slotted input. */
+	/** Controlled filter query. When unset, reads from the composed input. */
 	inputValue?: string;
 };
 
 /**
- * `<rui-autocomplete>` — filters a slotted collection from a text input.
+ * `<rui-autocomplete>` — filters a composed collection from a text input.
  *
  * Wrap a search field (`data-autocomplete-input`) and a collection
  * (`data-autocomplete-collection` or default slot) containing `[role="option"]`,
@@ -23,10 +23,7 @@ export type RuiAutocompleteProps = {
  * @element rui-autocomplete
  *
  * @attr {string} sensitivity - Filter sensitivity: `base` (case-insensitive contains), `case`, or `accent`. Default: `base`.
- * @attr {string} input-value - Controlled filter query; when unset, reads from the slotted input. Default: `''`.
- *
- * @slot input - Search field (`RuiAutocompleteInput`).
- * @slot - Filterable collection of `[role="option"]`, `[role="menuitem"]`, or `[data-tag]` items.
+ * @attr {string} input-value - Controlled filter query; when unset, reads from the composed input. Default: `''`.
  *
  * @cssclass rui-autocomplete - Filter host.
  */
@@ -113,7 +110,7 @@ export class RuiAutocomplete extends RadiantElement {
 
 		const emptyState = this.querySelector<HTMLElement>('[data-autocomplete-empty]');
 		if (emptyState) {
-			emptyState.hidden = visibleCount > 0;
+			emptyState.toggleAttribute('hidden', visibleCount > 0);
 		}
 	}
 
@@ -121,12 +118,9 @@ export class RuiAutocomplete extends RadiantElement {
 		this.applyFilter();
 	}
 
-	override connectedCallback(): void {
-		super.connectedCallback();
-		queueMicrotask(() => {
-			this.bindExternalInput();
-			this.initialize();
-		});
+	protected override onConnected(): void {
+		this.bindExternalInput();
+		this.initialize();
 	}
 
 	override disconnectedCallback(): void {
@@ -142,14 +136,5 @@ export class RuiAutocomplete extends RadiantElement {
 	@onEvent({ selector: '[data-autocomplete-input]', type: 'input' })
 	onInput(): void {
 		this.applyFilter();
-	}
-
-	override render() {
-		return (
-			<div class="rui-autocomplete" data-ref="root">
-				<slot name="input"></slot>
-				<slot></slot>
-			</div>
-		);
 	}
 }

--- a/packages/radiant-ui/src/components/ui/autocomplete/autocomplete.stories.tsx
+++ b/packages/radiant-ui/src/components/ui/autocomplete/autocomplete.stories.tsx
@@ -1,7 +1,12 @@
 import type { Meta, StoryObj } from '@ecopages/storybook-radiant-vite';
 import { expect, userEvent } from 'storybook/test';
 import { isStaticSsrPreview } from '@/lib/storybook-ssr';
-import '../menu-button/menu-button.script';
+import {
+	RuiMenuButton,
+	RuiMenuButtonContent,
+	RuiMenuButtonItem,
+	RuiMenuButtonTrigger,
+} from '../menu-button';
 import { RuiLabel } from '../label';
 import { RuiListbox } from '../listbox';
 import {
@@ -58,6 +63,8 @@ const meta = {
 		radiant: {
 			element: RuiAutocompleteElement,
 			cssImports: [
+				'../../../styles/primitives.css',
+				'../button/button.css',
 				'./autocomplete.css',
 				'../listbox/listbox.css',
 				'../tag-group/tag-group.css',
@@ -211,43 +218,33 @@ export const WithSelect: Story = {
  */
 export const WithMenu: Story = {
 	render: () => (
-		<rui-menu-button>
-			<span slot="trigger">Add tag…</span>
-			<div class="flex max-h-64 flex-col">
+		<RuiMenuButton>
+			<RuiMenuButtonTrigger>Add tag…</RuiMenuButtonTrigger>
+			<RuiMenuButtonContent class="flex max-h-64 min-w-56 flex-col">
 				<RuiAutocomplete>
-					<RuiAutocompleteInput
-						aria-label="Search tags"
-						placeholder="Search tags"
-						class="m-1 w-[calc(100%-0.5rem)]"
-					/>
-					<RuiAutocompleteCollection class="flex-1 overflow-auto">
+					<RuiAutocompleteInput aria-label="Search tags" placeholder="Search tags" class="mb-1 w-full" />
+					<RuiAutocompleteCollection>
 						{MENU_TAGS.map((tag) => (
-							<button
-								type="button"
-								class="rui-menu-button__item"
-								role="menuitem"
-								data-value={tag.value}
-								tabindex={-1}
-							>
-								{tag.label}
-							</button>
+							<RuiMenuButtonItem value={tag.value}>{tag.label}</RuiMenuButtonItem>
 						))}
 						<RuiAutocompleteEmpty>No results.</RuiAutocompleteEmpty>
 					</RuiAutocompleteCollection>
 				</RuiAutocomplete>
-			</div>
-		</rui-menu-button>
+			</RuiMenuButtonContent>
+		</RuiMenuButton>
 	),
 	play: async ({ canvasElement, step }) => {
 		if (isStaticSsrPreview(canvasElement)) return;
 
 		const trigger = canvasElement.querySelector('[data-ref="trigger"]') as HTMLButtonElement;
 		const host = canvasElement.querySelector('rui-menu-button') as HTMLElement;
+		const menu = canvasElement.querySelector('[data-ref="menu"]') as HTMLElement;
 		const input = getInput(canvasElement);
 
 		await step('opening the menu and typing filters items', async () => {
 			await userEvent.click(trigger);
-			input.focus();
+			await expect(menu).not.toHaveAttribute('hidden');
+			await expect(input).toHaveFocus();
 			await userEvent.type(input, 'foo');
 			const items = Array.from(canvasElement.querySelectorAll('[role="menuitem"]')) as HTMLElement[];
 			const visible = items.filter((item) => !item.hidden);
@@ -264,6 +261,7 @@ export const WithMenu: Story = {
 			const food = items.find((item) => item.getAttribute('data-value') === 'food');
 			await userEvent.click(food!);
 			await expect(emissions).toEqual(['food']);
+			await expect(menu).toHaveAttribute('hidden');
 		});
 	},
 };

--- a/packages/radiant-ui/src/components/ui/autocomplete/autocomplete.tsx
+++ b/packages/radiant-ui/src/components/ui/autocomplete/autocomplete.tsx
@@ -1,4 +1,4 @@
-import type { JsxCustomElementAttributes, JsxElementProps } from '@ecopages/jsx';
+import type { JsxCustomElementAttributes, JsxElementProps, JsxRenderable } from '@ecopages/jsx';
 import { cx } from '@/lib/cx';
 import type { RuiAutocomplete as RuiAutocompleteElement, RuiAutocompleteProps } from './autocomplete.script';
 import './autocomplete.script';
@@ -8,13 +8,12 @@ export type RuiAutocompleteInputProps = JsxElementProps<HTMLInputElement> & {
 	disabled?: boolean;
 };
 
-/** Search field slotted into `RuiAutocomplete`. Also pairs with combobox inputs via `data-autocomplete-input`.
+/** Search field paired with `RuiAutocomplete` via `data-autocomplete-input`.
  *
  * @cssclass rui-autocomplete__input - Bordered search input.
  */
 export function RuiAutocompleteInput({
 	placeholder,
-	slot = 'input',
 	class: className,
 	disabled,
 	...props
@@ -23,7 +22,6 @@ export function RuiAutocompleteInput({
 		<input
 			{...props}
 			type="search"
-			slot={slot}
 			data-autocomplete-input
 			class={cx('rui-autocomplete__input', className)}
 			placeholder={placeholder}
@@ -55,7 +53,15 @@ export type RuiAutocompleteEmptyProps = JsxElementProps<HTMLDivElement>;
  */
 export function RuiAutocompleteEmpty({ children, class: className, ...props }: RuiAutocompleteEmptyProps) {
 	return (
-		<div {...props} data-autocomplete-empty class={cx('rui-autocomplete__empty', className)} hidden>
+		<div {...props} data-autocomplete-empty class={cx('rui-autocomplete__empty', className)}>
+			{children}
+		</div>
+	);
+}
+
+function AutocompleteShell({ children }: { children: JsxRenderable }) {
+	return (
+		<div class="rui-autocomplete" data-ref="root">
 			{children}
 		</div>
 	);
@@ -65,5 +71,9 @@ export function RuiAutocomplete({
 	children,
 	...props
 }: JsxCustomElementAttributes<RuiAutocompleteElement, RuiAutocompleteProps>) {
-	return <rui-autocomplete {...props}>{children}</rui-autocomplete>;
+	return (
+		<rui-autocomplete {...props}>
+			<AutocompleteShell>{children}</AutocompleteShell>
+		</rui-autocomplete>
+	);
 }

--- a/packages/radiant-ui/src/components/ui/combobox/combobox.css
+++ b/packages/radiant-ui/src/components/ui/combobox/combobox.css
@@ -1,6 +1,4 @@
 @reference '../../../styles/radiant-ui.css';
-@import '../shared/control-toggle.css';
-@import '../shared/popover.css';
 
 rui-combobox {
 	@apply relative inline-flex w-full flex-col;
@@ -13,6 +11,7 @@ rui-combobox {
 
 	.rui-combobox__control {
 		@apply flex w-full min-w-0 items-center gap-1 rounded-control border border-border bg-background px-1;
+		min-height: var(--size-control-md);
 	}
 
 	.rui-combobox__control:focus-within {

--- a/packages/radiant-ui/src/components/ui/combobox/combobox.script.tsx
+++ b/packages/radiant-ui/src/components/ui/combobox/combobox.script.tsx
@@ -43,9 +43,6 @@ export type RuiComboboxChangeDetail = { value: string };
  * @attr {boolean} disabled - Disable the input and trigger. Default: `false`.
  * @attr {boolean} open-on-focus - Open the listbox when the input gains focus. Default: `false`.
  *
- * @slot control - Input row (`RuiComboboxControl` with input and trigger).
- * @slot listbox - Popup shell (`RuiComboboxListbox`) containing an embedded `RuiListbox`.
- *
  * @fires rui-change - Emitted when an option is selected; detail carries `value`.
  *
  * @cssclass rui-combobox - Root surface.
@@ -233,7 +230,7 @@ export class RuiCombobox extends RadiantElement {
 		}
 
 		input.setAttribute('aria-expanded', String(next));
-		popup.hidden = !next;
+		popup.toggleAttribute('hidden', !next);
 		this.syncTrigger();
 
 		if (!next) {
@@ -331,9 +328,8 @@ export class RuiCombobox extends RadiantElement {
 		this.setOpen(false);
 	}
 
-	override connectedCallback(): void {
-		super.connectedCallback();
-		queueMicrotask(() => this.initialize());
+	protected override onConnected(): void {
+		this.initialize();
 	}
 
 	override disconnectedCallback(): void {
@@ -528,14 +524,5 @@ export class RuiCombobox extends RadiantElement {
 			return;
 		}
 		this.setOpen(false);
-	}
-
-	override render() {
-		return (
-			<div class="rui-combobox" data-ref="root">
-				<slot name="control"></slot>
-				<slot name="listbox"></slot>
-			</div>
-		);
 	}
 }

--- a/packages/radiant-ui/src/components/ui/combobox/combobox.stories.tsx
+++ b/packages/radiant-ui/src/components/ui/combobox/combobox.stories.tsx
@@ -20,7 +20,13 @@ const meta = {
 	parameters: {
 		radiant: {
 			element: RuiComboboxElement,
-			cssImports: ['./combobox.css', '../shared/control-toggle.css', '../../../lib/icons/icons.css'],
+			cssImports: [
+				'../../../styles/primitives.css',
+				'../autocomplete/autocomplete.css',
+				'../listbox/listbox.css',
+				'../field/field.css',
+				'./combobox.css',
+			],
 		},
 	},
 	args: {

--- a/packages/radiant-ui/src/components/ui/combobox/combobox.tsx
+++ b/packages/radiant-ui/src/components/ui/combobox/combobox.tsx
@@ -1,4 +1,4 @@
-import type { JsxCustomElementAttributes, JsxElementProps } from '@ecopages/jsx';
+import type { JsxCustomElementAttributes, JsxElementProps, JsxRenderable } from '@ecopages/jsx';
 import { withDefaultAriaLabel } from '@/aria';
 import { cx } from '@/lib/cx';
 import { RuiIconChevronDown } from '@/lib/icons';
@@ -13,14 +13,9 @@ export type RuiComboboxControlProps = JsxElementProps<HTMLDivElement>;
  *
  * @cssclass rui-combobox__control - Bordered control-height row.
  */
-export function RuiComboboxControl({
-	children,
-	slot = 'control',
-	class: className,
-	...props
-}: RuiComboboxControlProps) {
+export function RuiComboboxControl({ children, class: className, ...props }: RuiComboboxControlProps) {
 	return (
-		<div {...props} slot={slot} class={cx('rui-combobox__control', className)}>
+		<div {...props} class={cx('rui-combobox__control', className)}>
 			{children}
 		</div>
 	);
@@ -75,23 +70,16 @@ export function RuiComboboxTrigger({ children, class: className, aria, disabled,
 
 export type RuiComboboxListboxProps = JsxElementProps<HTMLDivElement>;
 
-/** Popup shell slotted into `listbox`. Place an embedded `RuiListbox` inside.
+/** Popup shell for the combobox listbox. Place an embedded `RuiListbox` inside.
  *
  * @cssclass rui-combobox__listbox - Popup shell (adds `rui-popover rui-popover--listbox rui-floating`).
  */
-export function RuiComboboxListbox({
-	children,
-	slot = 'listbox',
-	class: className,
-	...props
-}: RuiComboboxListboxProps) {
+export function RuiComboboxListbox({ children, class: className, ...props }: RuiComboboxListboxProps) {
 	return (
 		<div
 			{...props}
-			slot={slot}
 			data-combobox-listbox
 			class={cx('rui-combobox__listbox rui-popover rui-popover--listbox rui-floating', className)}
-			hidden
 		>
 			{children}
 		</div>
@@ -99,6 +87,14 @@ export function RuiComboboxListbox({
 }
 
 export type RuiComboboxOptionData = RuiListboxOptionData;
+
+function ComboboxShell({ children }: { children: JsxRenderable }) {
+	return (
+		<div class="rui-combobox" data-ref="root">
+			{children}
+		</div>
+	);
+}
 
 /**
  * Combobox view. Pair with `RuiLabel` (sibling or via `RuiField`) for the visible name —
@@ -117,21 +113,27 @@ export function RuiCombobox({
 	if (options != null) {
 		return (
 			<rui-combobox {...props}>
-				<RuiComboboxControl>
-					<RuiComboboxInput placeholder={props.placeholder} disabled={props.disabled} />
-					<RuiComboboxTrigger />
-				</RuiComboboxControl>
-				<RuiComboboxListbox>
-					<RuiAutocomplete>
-						<RuiAutocompleteCollection>
-							<RuiListbox embedded options={options} />
-							<RuiAutocompleteEmpty>No results found.</RuiAutocompleteEmpty>
-						</RuiAutocompleteCollection>
-					</RuiAutocomplete>
-				</RuiComboboxListbox>
+				<ComboboxShell>
+					<RuiComboboxControl>
+						<RuiComboboxInput placeholder={props.placeholder} disabled={props.disabled} />
+						<RuiComboboxTrigger />
+					</RuiComboboxControl>
+					<RuiComboboxListbox>
+						<RuiAutocomplete>
+							<RuiAutocompleteCollection>
+								<RuiListbox embedded options={options} />
+								<RuiAutocompleteEmpty>No results found.</RuiAutocompleteEmpty>
+							</RuiAutocompleteCollection>
+						</RuiAutocomplete>
+					</RuiComboboxListbox>
+				</ComboboxShell>
 			</rui-combobox>
 		);
 	}
 
-	return <rui-combobox {...props}>{children}</rui-combobox>;
+	return (
+		<rui-combobox {...props}>
+			<ComboboxShell>{children}</ComboboxShell>
+		</rui-combobox>
+	);
 }

--- a/packages/radiant-ui/src/components/ui/dialog/dialog-registry.test.tsx
+++ b/packages/radiant-ui/src/components/ui/dialog/dialog-registry.test.tsx
@@ -37,6 +37,14 @@ async function settled(): Promise<void> {
 	await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve(undefined))));
 }
 
+function getDialogRoot(dialog: HTMLElement): HTMLElement {
+	const root = dialog.querySelector<HTMLElement>('[data-ref="root"]');
+	if (!root) {
+		throw new Error('Expected dialog root');
+	}
+	return root;
+}
+
 describe('dialog registry', () => {
 	afterEach(() => {
 		uninstallDialogs();
@@ -65,6 +73,7 @@ describe('dialog registry', () => {
 
 		expect(dialog.open).toBe(true);
 		expect(dialog.hasAttribute('open')).toBe(true);
+		expect(getDialogRoot(dialog).hasAttribute('hidden')).toBe(false);
 		expect(getOpenDialogId()).toBe('edit-profile');
 
 		cleanup();
@@ -89,6 +98,7 @@ describe('dialog registry', () => {
 		expect(dialogHost).toBeTruthy();
 		expect(dialogHost.open).toBe(true);
 		expect(dialogHost.hasAttribute('open')).toBe(true);
+		expect(getDialogRoot(dialogHost).hasAttribute('hidden')).toBe(false);
 		expect(dialogHost.querySelector('[data-dialog-title]')?.textContent).toContain('Delete account?');
 		expect(dialogHost.querySelector('[data-dialog-body]')?.textContent).toContain('cannot be undone');
 		expect(dialogHost.querySelector('[data-ref="dialog"]')?.getAttribute('role')).toBe('alertdialog');
@@ -199,7 +209,9 @@ describe('dialog registry', () => {
 		await userEvent.click(trigger);
 		await settled();
 
-		expect((host.querySelector('#settings') as DialogEl).open).toBe(true);
+		const dialog = host.querySelector('#settings') as DialogEl;
+		expect(dialog.open).toBe(true);
+		expect(getDialogRoot(dialog).hasAttribute('hidden')).toBe(false);
 		expect(getOpenDialogId()).toBe('settings');
 
 		closeDialog();

--- a/packages/radiant-ui/src/components/ui/dialog/dialog-registry.ts
+++ b/packages/radiant-ui/src/components/ui/dialog/dialog-registry.ts
@@ -42,7 +42,6 @@ function resolveDialog(id: string): RuiDialog | null {
 
 function createCloseButton(): HTMLButtonElement {
 	const close = document.createElement('button');
-	close.slot = 'close';
 	close.type = 'button';
 	close.setAttribute('data-dialog-close', '');
 	close.setAttribute('data-ref', 'close');
@@ -54,7 +53,6 @@ function createCloseButton(): HTMLButtonElement {
 
 function createTitle(title: string): HTMLElement {
 	const el = document.createElement('div');
-	el.slot = 'title';
 	el.setAttribute('data-dialog-title', '');
 	el.setAttribute('data-ref', 'title');
 	el.className = 'rui-dialog__title';
@@ -75,7 +73,6 @@ function createBody(body: string): HTMLElement {
 
 function createActions(actions: DialogAction[]): HTMLElement {
 	const row = document.createElement('div');
-	row.slot = 'actions';
 	row.className = 'rui-dialog__actions';
 
 	for (const action of actions) {
@@ -93,6 +90,33 @@ function createActions(actions: DialogAction[]): HTMLElement {
 	return row;
 }
 
+/**
+ * Imperative twin of `DialogShell` in `dialog.tsx` (root / backdrop / surface).
+ *
+ * @remarks Edit both together. Unlike the view — which seeds SSR visibility
+ * from the `open` prop — the registry mounts with `open = true` and lets the
+ * controller's `syncOpenState()` manage `hidden` from connect onward.
+ */
+function createDialogSurface(alert: boolean): HTMLElement {
+	const root = document.createElement('div');
+	root.dataset.ref = 'root';
+	root.className = 'rui-dialog';
+
+	const backdrop = document.createElement('div');
+	backdrop.setAttribute('data-ref', 'backdrop');
+	backdrop.className = 'rui-dialog__backdrop';
+
+	const surface = document.createElement('div');
+	surface.setAttribute('data-ref', 'dialog');
+	surface.className = 'rui-dialog__surface';
+	surface.tabIndex = -1;
+	surface.setAttribute('role', alert ? 'alertdialog' : 'dialog');
+	surface.setAttribute('aria-modal', 'true');
+
+	root.append(backdrop, surface);
+	return root;
+}
+
 function destroyHostDialog(): void {
 	hostDialog?.remove();
 	hostDialog = null;
@@ -105,17 +129,25 @@ function mountHostDialog(options: DialogHostContent): RuiDialog {
 	dialog.id = RUI_DIALOG_HOST_ID;
 	dialog.alert = Boolean(options.alert);
 	dialog.label = options.label ?? '';
+	dialog.open = true;
 
-	dialog.append(createCloseButton());
+	const shell = createDialogSurface(dialog.alert);
+	const surface = shell.querySelector<HTMLElement>('[data-ref="dialog"]');
+	if (!surface) {
+		throw new Error('Failed to create the dialog surface.');
+	}
+
+	surface.append(createCloseButton());
 	if (options.title) {
-		dialog.append(createTitle(options.title));
+		surface.append(createTitle(options.title));
 	}
 	if (options.body) {
-		dialog.append(createBody(options.body));
+		surface.append(createBody(options.body));
 	}
 	if (options.actions?.length) {
-		dialog.append(createActions(options.actions));
+		surface.append(createActions(options.actions));
 	}
+	dialog.append(shell);
 
 	(mountParent ?? document.body).appendChild(dialog);
 	hostDialog = dialog;
@@ -152,8 +184,7 @@ function openNamed(id: string): void {
 function openHost(options: DialogHostContent): void {
 	ensureInstalled();
 	closeCurrentExcept(RUI_DIALOG_HOST_ID);
-	const dialog = mountHostDialog(options);
-	dialog.open = true;
+	mountHostDialog(options);
 	openId = RUI_DIALOG_HOST_ID;
 }
 

--- a/packages/radiant-ui/src/components/ui/dialog/dialog.script.tsx
+++ b/packages/radiant-ui/src/components/ui/dialog/dialog.script.tsx
@@ -34,10 +34,6 @@ type RuiDialogBindings = {
  * @see https://www.w3.org/WAI/ARIA/apg/patterns/alertdialog/
  *
  * @element rui-dialog
- * @slot close - Optional close control (`RuiDialogClose`).
- * @slot title - Optional visible dialog title (`RuiDialogTitle`).
- * @slot - Dialog body (`RuiDialogBody`).
- * @slot actions - Optional action buttons (`RuiDialogActions`).
  * @fires rui-close - Emitted when the dialog is dismissed.
  * @cssclass rui-dialog - Root; hidden until `open`.
  * @cssclass rui-dialog__backdrop - Scrim using the `overlay` role.
@@ -49,6 +45,7 @@ export class RuiDialog extends RadiantElement<RuiDialogBindings> {
 	@prop({ type: Boolean, reflect: true, defaultValue: false }) alert: boolean;
 	@prop({ type: String, defaultValue: '' }) label: string;
 
+	@query({ ref: 'root' }) rootTarget: HTMLElement;
 	@query({ ref: 'dialog' }) dialogTarget: HTMLElement;
 	@query({ selector: '[data-dialog-title]' }) titleTarget: HTMLElement;
 	@query({ selector: '[data-dialog-body]' }) descriptionTarget: HTMLElement;
@@ -56,21 +53,19 @@ export class RuiDialog extends RadiantElement<RuiDialogBindings> {
 	@event({ name: 'rui-close', bubbles: true, composed: true })
 	closeEvent: EventEmitter<RuiDialogCloseDetail>;
 
-	private readonly dialogHidden = this.$.open.map((open) => !open);
-	private readonly resolvedRole = this.$.alert.map((alert) => (alert ? 'alertdialog' : 'dialog'));
-
 	private previouslyFocused: HTMLElement | null = null;
 	private titleId = `rui-dialog-title-${Math.random().toString(36).slice(2, 9)}`;
 	private descriptionId = `rui-dialog-desc-${Math.random().toString(36).slice(2, 9)}`;
 
-	override connectedCallback(): void {
-		super.connectedCallback();
-		queueMicrotask(() => this.syncOpenState());
+	protected override onConnected(): void {
+		this.syncOpenState();
 	}
 
 	@bound
 	@onUpdated(['open', 'label'])
 	syncOpenState(): void {
+		this.rootTarget?.toggleAttribute('hidden', !this.open);
+
 		if (!this.dialogTarget) {
 			return;
 		}
@@ -162,25 +157,5 @@ export class RuiDialog extends RadiantElement<RuiDialogBindings> {
 	@onEvent({ selector: '[data-dialog-close]', type: 'click' })
 	onCloseClick(): void {
 		this.dismiss('dismiss');
-	}
-
-	override render() {
-		return (
-			<div class="rui-dialog" hidden={this.dialogHidden}>
-				<div data-ref="backdrop" class="rui-dialog__backdrop"></div>
-				<div
-					data-ref="dialog"
-					class="rui-dialog__surface"
-					tabindex={-1}
-					role={this.resolvedRole}
-					aria-modal="true"
-				>
-					<slot name="close"></slot>
-					<slot name="title"></slot>
-					<slot></slot>
-					<slot name="actions"></slot>
-				</div>
-			</div>
-		);
 	}
 }

--- a/packages/radiant-ui/src/components/ui/dialog/dialog.stories.tsx
+++ b/packages/radiant-ui/src/components/ui/dialog/dialog.stories.tsx
@@ -60,6 +60,7 @@ export const Default: Story = {
 		await step('opens from decorator trigger', async () => {
 			await openStoryDialog(canvasElement);
 			await expect(getHost(canvasElement)).toHaveAttribute('open');
+			await expect(getHost(canvasElement).querySelector('[data-ref="root"]')).not.toHaveAttribute('hidden');
 		});
 
 		const dialog = getDialog(canvasElement);

--- a/packages/radiant-ui/src/components/ui/dialog/dialog.tsx
+++ b/packages/radiant-ui/src/components/ui/dialog/dialog.tsx
@@ -7,13 +7,13 @@ import './dialog.script';
 export type RuiDialogTitleProps = JsxElementProps<HTMLDivElement>;
 
 /**
- * Dialog title slotted into `title` by default.
+ * Dialog title for the visible dialog name.
  *
  * @cssclass rui-dialog__title - Dialog title; `aria-labelledby` target.
  */
-export function RuiDialogTitle({ children, slot = 'title', class: className, ...props }: RuiDialogTitleProps) {
+export function RuiDialogTitle({ children, class: className, ...props }: RuiDialogTitleProps) {
 	return (
-		<div {...props} slot={slot} data-dialog-title data-ref="title" class={cx('rui-dialog__title', className)}>
+		<div {...props} data-dialog-title data-ref="title" class={cx('rui-dialog__title', className)}>
 			{children}
 		</div>
 	);
@@ -22,7 +22,7 @@ export function RuiDialogTitle({ children, slot = 'title', class: className, ...
 export type RuiDialogBodyProps = JsxElementProps<HTMLDivElement>;
 
 /**
- * Dialog body in the default slot.
+ * Dialog body content.
  *
  * @cssclass rui-dialog__body - Dialog body; `aria-describedby` target.
  */
@@ -37,13 +37,13 @@ export function RuiDialogBody({ children, class: className, ...props }: RuiDialo
 export type RuiDialogActionsProps = JsxElementProps<HTMLDivElement>;
 
 /**
- * Action row slotted into `actions` by default.
+ * Action row for dialog buttons.
  *
  * @cssclass rui-dialog__actions - Right-aligned action row.
  */
-export function RuiDialogActions({ children, slot = 'actions', class: className, ...props }: RuiDialogActionsProps) {
+export function RuiDialogActions({ children, class: className, ...props }: RuiDialogActionsProps) {
 	return (
-		<div {...props} slot={slot} class={cx('rui-dialog__actions', className)}>
+		<div {...props} class={cx('rui-dialog__actions', className)}>
 			{children}
 		</div>
 	);
@@ -52,16 +52,15 @@ export function RuiDialogActions({ children, slot = 'actions', class: className,
 export type RuiDialogCloseProps = JsxElementProps<HTMLButtonElement>;
 
 /**
- * Close control slotted into `close` by default.
+ * Close control for the dialog surface.
  *
  * @cssclass rui-dialog__close - Dismiss button; dispatches `data-dialog-close` click.
  */
-export function RuiDialogClose({ children, slot = 'close', class: className, aria, ...props }: RuiDialogCloseProps) {
+export function RuiDialogClose({ children, class: className, aria, ...props }: RuiDialogCloseProps) {
 	return (
 		<button
 			{...props}
 			aria={withDefaultAriaLabel(aria, 'Close')}
-			slot={slot}
 			type="button"
 			data-dialog-close
 			data-ref="close"
@@ -69,6 +68,38 @@ export function RuiDialogClose({ children, slot = 'close', class: className, ari
 		>
 			{children ?? '×'}
 		</button>
+	);
+}
+
+type DialogShellProps = {
+	alert?: boolean;
+	children: JsxRenderable;
+	open?: boolean;
+};
+
+/**
+ * View-owned dialog surface: root / backdrop / surface.
+ *
+ * @remarks Mirrored by `createDialogSurface` in `dialog-registry.ts`, which
+ * rebuilds this structure imperatively for the programmatic host dialog. Edit
+ * both together. Visibility differs by design: the view seeds SSR state with
+ * `hidden={open ? undefined : true}`, while the registry relies on
+ * `open = true` plus the controller's `syncOpenState()` on connect.
+ */
+function DialogShell({ alert, children, open }: DialogShellProps) {
+	return (
+		<div data-ref="root" class="rui-dialog" hidden={open ? undefined : true}>
+			<div data-ref="backdrop" class="rui-dialog__backdrop"></div>
+			<div
+				data-ref="dialog"
+				class="rui-dialog__surface"
+				tabindex={-1}
+				role={alert ? 'alertdialog' : 'dialog'}
+				aria-modal="true"
+			>
+				{children}
+			</div>
+		</div>
 	);
 }
 
@@ -82,20 +113,35 @@ export type RuiDialogViewProps = Omit<JsxCustomElementAttributes<RuiDialogElemen
  * `RuiDialogTitle`, `RuiDialogBody`, `RuiDialogActions`, and `RuiDialogClose` as children.
  *
  * @remarks The composite API SSRs a full `<rui-dialog>` shell (close button, title,
- * body, actions). When neither `title` nor `actions` is set, children are projected
- * as-is so callers can arrange slotted parts themselves.
+ * body, actions). When neither `title` nor `actions` is set, children are composed
+ * inside the view-owned dialog shell.
  */
-export function RuiDialog({ title, actions, children, ...props }: RuiDialogViewProps) {
+export function RuiDialog({
+	title,
+	actions,
+	children,
+	open,
+	alert,
+	...props
+}: RuiDialogViewProps) {
 	if (title != null || actions != null) {
 		return (
-			<rui-dialog {...props}>
-				<RuiDialogClose />
-				{title != null ? <RuiDialogTitle>{title}</RuiDialogTitle> : null}
-				{children != null ? <RuiDialogBody>{children}</RuiDialogBody> : null}
-				{actions != null ? <RuiDialogActions>{actions}</RuiDialogActions> : null}
+			<rui-dialog {...props} open={open} alert={alert}>
+				<DialogShell open={open} alert={alert}>
+					<RuiDialogClose />
+					{title != null ? <RuiDialogTitle>{title}</RuiDialogTitle> : null}
+					{children != null ? <RuiDialogBody>{children}</RuiDialogBody> : null}
+					{actions != null ? <RuiDialogActions>{actions}</RuiDialogActions> : null}
+				</DialogShell>
 			</rui-dialog>
 		);
 	}
 
-	return <rui-dialog {...props}>{children}</rui-dialog>;
+	return (
+		<rui-dialog {...props} open={open} alert={alert}>
+			<DialogShell open={open} alert={alert}>
+				{children}
+			</DialogShell>
+		</rui-dialog>
+	);
 }

--- a/packages/radiant-ui/src/components/ui/disclosure/disclosure-group.script.tsx
+++ b/packages/radiant-ui/src/components/ui/disclosure/disclosure-group.script.tsx
@@ -21,7 +21,6 @@ export type RuiDisclosureGroupProps = {
  * @element rui-disclosure-group
  * @attr {boolean} multiple - Allow more than one disclosure to stay open. Default: `false` (exclusive).
  * @attr {boolean} animated - Animate panel height for child disclosures. Default: `false`.
- * @slot - `rui-disclosure` children.
  * @cssclass rui-disclosure-group - Group surface (bordered card around stacked disclosures).
  */
 @customElement('rui-disclosure-group')
@@ -29,12 +28,9 @@ export class RuiDisclosureGroup extends RadiantElement {
 	@prop({ type: Boolean, reflect: true, defaultValue: false }) multiple: boolean;
 	@prop({ type: Boolean, reflect: true, attribute: 'animated', defaultValue: false }) animated: boolean;
 
-	override connectedCallback(): void {
-		super.connectedCallback();
-		queueMicrotask(() => {
-			this.syncChildrenAnimated();
-			this.syncTriggers();
-		});
+	protected override onConnected(): void {
+		this.syncChildrenAnimated();
+		this.syncTriggers();
 	}
 
 	private getTriggers(): HTMLElement[] {
@@ -141,13 +137,5 @@ export class RuiDisclosureGroup extends RadiantElement {
 		}
 
 		event.preventDefault();
-	}
-
-	override render() {
-		return (
-			<div class="rui-disclosure-group" data-ref="root">
-				<slot></slot>
-			</div>
-		);
 	}
 }

--- a/packages/radiant-ui/src/components/ui/disclosure/disclosure.script.tsx
+++ b/packages/radiant-ui/src/components/ui/disclosure/disclosure.script.tsx
@@ -27,10 +27,8 @@ export type RuiDisclosureToggleDetail = {
  * @attr {boolean} open - Whether the disclosure content starts expanded. Default: `false`.
  * @attr {string} value - Optional value used when coordinating disclosures inside a group.
  * @attr {boolean} animated - Animate panel height. Also enabled when inside an animated disclosure group. Default: `false`.
- * @slot trigger - Disclosure button (use `RuiDisclosureTrigger`).
- * @slot - Panel content (use `RuiDisclosurePanel`).
  * @fires rui-disclosure-toggle - Emitted on every trigger activation; `detail` is `{ value, open }`.
- * @cssclass rui-disclosure - Root wrapper around trigger and panel slots.
+ * @cssclass rui-disclosure - Root wrapper around trigger and panel.
  */
 @customElement('rui-disclosure')
 export class RuiDisclosure extends RadiantElement {
@@ -40,12 +38,9 @@ export class RuiDisclosure extends RadiantElement {
 
 	private panelId = `rui-disclosure-${Math.random().toString(36).slice(2, 9)}`;
 
-	override connectedCallback(): void {
-		super.connectedCallback();
-		queueMicrotask(() => {
-			this.syncAnimated();
-			this.syncExpanded();
-		});
+	protected override onConnected(): void {
+		this.syncAnimated();
+		this.syncExpanded();
 	}
 
 	private syncAnimated(): void {
@@ -87,21 +82,12 @@ export class RuiDisclosure extends RadiantElement {
 		panel.dataset.state = this.open ? 'open' : 'closed';
 
 		if (this.animated) {
-			panel.hidden = false;
+			panel.toggleAttribute('hidden', false);
 			panel.setAttribute('aria-hidden', String(!this.open));
 			return;
 		}
 
-		panel.hidden = !this.open;
+		panel.toggleAttribute('hidden', !this.open);
 		panel.removeAttribute('aria-hidden');
-	}
-
-	override render() {
-		return (
-			<div class="rui-disclosure">
-				<slot name="trigger"></slot>
-				<slot></slot>
-			</div>
-		);
 	}
 }

--- a/packages/radiant-ui/src/components/ui/disclosure/disclosure.tsx
+++ b/packages/radiant-ui/src/components/ui/disclosure/disclosure.tsx
@@ -39,7 +39,7 @@ export type RuiDisclosureTriggerProps = JsxElementProps<HTMLButtonElement> & {
 };
 
 /**
- * Disclosure button slotted into `trigger` by default.
+ * Disclosure trigger button. Place before `RuiDisclosurePanel`.
  *
  * @cssclass rui-disclosure__trigger - Trigger button; reflects `aria-expanded`.
  * @cssclass rui-disclosure__trigger--icon-end - Layout when `iconPosition="end"`.
@@ -47,7 +47,6 @@ export type RuiDisclosureTriggerProps = JsxElementProps<HTMLButtonElement> & {
  */
 export function RuiDisclosureTrigger({
 	children,
-	slot = 'trigger',
 	class: className,
 	disabled,
 	icon,
@@ -60,7 +59,6 @@ export function RuiDisclosureTrigger({
 	return (
 		<button
 			{...props}
-			slot={slot}
 			type="button"
 			data-disclosure-trigger
 			class={cx(
@@ -80,7 +78,7 @@ export function RuiDisclosureTrigger({
 export type RuiDisclosurePanelProps = JsxElementProps<HTMLDivElement>;
 
 /**
- * Disclosure panel in the default slot.
+ * Disclosure panel content. Place after `RuiDisclosureTrigger`.
  *
  * @cssclass rui-disclosure__panel - Panel content region.
  * @cssclass rui-disclosure__panel-inner - Panel padding wrapper (drives the height animation).
@@ -89,6 +87,14 @@ export function RuiDisclosurePanel({ children, class: className, ...props }: Rui
 	return (
 		<div {...props} data-disclosure-panel data-ref="panel" class={cx('rui-disclosure__panel', className)}>
 			<div class="rui-disclosure__panel-inner">{children}</div>
+		</div>
+	);
+}
+
+function DisclosureShell({ children }: { children: JsxRenderable }) {
+	return (
+		<div class="rui-disclosure" data-ref="root">
+			{children}
 		</div>
 	);
 }
@@ -106,18 +112,30 @@ export function RuiDisclosure({
 	if (trigger != null) {
 		return (
 			<rui-disclosure {...props}>
-				<RuiDisclosureTrigger>{trigger}</RuiDisclosureTrigger>
-				{children != null ? <RuiDisclosurePanel>{children}</RuiDisclosurePanel> : null}
+				<DisclosureShell>
+					<RuiDisclosureTrigger>{trigger}</RuiDisclosureTrigger>
+					{children != null ? <RuiDisclosurePanel>{children}</RuiDisclosurePanel> : null}
+				</DisclosureShell>
 			</rui-disclosure>
 		);
 	}
 
-	return <rui-disclosure {...props}>{children}</rui-disclosure>;
+	return (
+		<rui-disclosure {...props}>
+			<DisclosureShell>{children}</DisclosureShell>
+		</rui-disclosure>
+	);
 }
 
 export function RuiDisclosureGroup({
 	children,
 	...props
 }: JsxCustomElementAttributes<RuiDisclosureGroupElement, RuiDisclosureGroupProps>) {
-	return <rui-disclosure-group {...props}>{children}</rui-disclosure-group>;
+	return (
+		<rui-disclosure-group {...props}>
+			<div class="rui-disclosure-group" data-ref="root">
+				{children}
+			</div>
+		</rui-disclosure-group>
+	);
 }

--- a/packages/radiant-ui/src/components/ui/menu-button/menu-button.css
+++ b/packages/radiant-ui/src/components/ui/menu-button/menu-button.css
@@ -1,5 +1,4 @@
 @reference '../../../styles/radiant-ui.css';
-@import '../shared/popover.css';
 
 rui-menu-button {
 	@apply inline-flex;
@@ -15,9 +14,7 @@ rui-menu-button {
 	}
 
 	.rui-menu-button__chevron {
-		@apply inline-block border-x-4 border-t-[5px] border-x-transparent border-t-current;
-		width: 0;
-		height: 0;
+		@apply shrink-0;
 	}
 
 	.rui-menu-button__menu {

--- a/packages/radiant-ui/src/components/ui/menu-button/menu-button.script.tsx
+++ b/packages/radiant-ui/src/components/ui/menu-button/menu-button.script.tsx
@@ -37,6 +37,9 @@ const MENU_GAP = 6;
  * - `Enter` / `Space`: activate the focused item and close
  * - `Escape`: close and return focus to the trigger
  *
+ * @remarks When the menu contains `[data-autocomplete-input]`, opening focuses
+ * that field so the user can filter items immediately.
+ *
  * @element rui-menu-button
  * @attr {boolean} open - Whether the menu starts open. Default: `false`.
  * @attr {('top'|'top-start'|'top-end'|'right'|'right-start'|'right-end'|'bottom'|'bottom-start'|'bottom-end'|'left'|'left-start'|'left-end')} placement - Placement of the menu surface relative to its trigger. Default: `bottom-start`.
@@ -67,9 +70,8 @@ export class RuiMenuButton extends RadiantElement {
 	private popoverController: PopoverController | null = null;
 	private pendingFocus: 'first' | 'last' | 'trigger' | null = null;
 
-	override connectedCallback(): void {
-		super.connectedCallback();
-		queueMicrotask(() => this.syncOpenState());
+	protected override onConnected(): void {
+		this.syncOpenState();
 	}
 
 	override disconnectedCallback(): void {
@@ -82,6 +84,10 @@ export class RuiMenuButton extends RadiantElement {
 		return Array.from(this.menuTarget?.querySelectorAll<HTMLElement>('[role="menuitem"]') ?? []).filter(
 			(item) => !item.hidden && item.getAttribute('aria-disabled') !== 'true',
 		);
+	}
+
+	private getSearchInput(): HTMLInputElement | null {
+		return this.menuTarget?.querySelector<HTMLInputElement>('[data-autocomplete-input]') ?? null;
 	}
 
 	private ensurePopoverController(): PopoverController {
@@ -107,7 +113,7 @@ export class RuiMenuButton extends RadiantElement {
 		this.triggerTarget.setAttribute('aria-controls', this.menuId);
 		this.triggerTarget.setAttribute('aria-haspopup', 'menu');
 		this.triggerTarget.setAttribute('aria-expanded', String(this.open));
-		this.menuTarget.hidden = !this.open;
+		this.menuTarget.toggleAttribute('hidden', !this.open);
 
 		const controller = this.ensurePopoverController();
 		controller.updateConfig({
@@ -120,12 +126,22 @@ export class RuiMenuButton extends RadiantElement {
 		this.pendingFocus = null;
 		if (!focus) return;
 
+		if (focus === 'trigger') {
+			this.triggerTarget?.focus();
+			return;
+		}
+
+		const search = this.getSearchInput();
+		if (search) {
+			search.focus();
+			return;
+		}
+
 		if (focus === 'first') this.getItems()[0]?.focus();
 		if (focus === 'last') {
 			const items = this.getItems();
 			items[items.length - 1]?.focus();
 		}
-		if (focus === 'trigger') this.triggerTarget?.focus();
 	}
 
 	private setOpen(next: boolean, focus: 'first' | 'last' | 'trigger' | null = null): void {

--- a/packages/radiant-ui/src/components/ui/menu-button/menu-button.stories.tsx
+++ b/packages/radiant-ui/src/components/ui/menu-button/menu-button.stories.tsx
@@ -6,7 +6,12 @@ import { RuiMenuButton as RuiMenuButtonElement } from './menu-button.script';
 const meta = {
 	title: 'Components/Menu Button',
 	component: RuiMenuButton,
-	parameters: { radiant: { element: RuiMenuButtonElement, cssImports: ['./menu-button.css'] } },
+	parameters: {
+		radiant: {
+			element: RuiMenuButtonElement,
+			cssImports: ['../../../styles/primitives.css', '../button/button.css', './menu-button.css'],
+		},
+	},
 	args: {
 		open: false,
 		trigger: 'Actions',

--- a/packages/radiant-ui/src/components/ui/menu-button/menu-button.tsx
+++ b/packages/radiant-ui/src/components/ui/menu-button/menu-button.tsx
@@ -1,5 +1,6 @@
 import type { JsxCustomElementAttributes, JsxElementProps, JsxRenderable } from '@ecopages/jsx';
 import { cx } from '@/lib/cx';
+import { RuiIconChevronDown } from '@/lib/icons';
 import { RuiButton, type RuiButtonControlProps } from '../button';
 import type { RuiMenuButton as RuiMenuButtonElement, RuiMenuButtonProps } from './menu-button.script';
 import './menu-button.script';
@@ -30,7 +31,7 @@ export function RuiMenuButtonTrigger({
 			aria-haspopup="menu"
 		>
 			{children}
-			<span class="rui-menu-button__chevron" aria-hidden="true" />
+			<RuiIconChevronDown class="rui-menu-button__chevron" />
 		</RuiButton>
 	);
 }
@@ -45,7 +46,6 @@ export function RuiMenuButtonContent({ children, class: className, ...props }: R
 			data-ref="menu"
 			class={cx('rui-menu-button__menu', 'rui-popover', 'rui-floating', className)}
 			role="menu"
-			hidden
 		>
 			{children}
 		</div>

--- a/packages/radiant-ui/src/components/ui/menubar/menubar.css
+++ b/packages/radiant-ui/src/components/ui/menubar/menubar.css
@@ -1,5 +1,4 @@
 @reference '../../../styles/radiant-ui.css';
-@import '../shared/popover.css';
 
 rui-menubar {
 	@apply block;

--- a/packages/radiant-ui/src/components/ui/menubar/menubar.script.tsx
+++ b/packages/radiant-ui/src/components/ui/menubar/menubar.script.tsx
@@ -33,7 +33,6 @@ type RuiMenubarBindings = {
  * @see https://www.w3.org/WAI/ARIA/apg/patterns/menubar/
  * @element rui-menubar
  * @attr {string} label - Accessible name for the `role="menubar"` landmark.
- * @slot - Top-level menu roots (`[data-ref="menubar-root"]`), produced by the JSX view helper.
  * @fires rui-change - Emitted when a menu item is activated; `detail.value` is the item's `data-value` or text.
  * @cssclass rui-menubar - Menubar bar (`role="menubar"`).
  */
@@ -44,14 +43,12 @@ export class RuiMenubar extends RadiantElement<RuiMenubarBindings> {
 	@event({ name: 'rui-change', bubbles: true, composed: true })
 	changeEvent: EventEmitter<RuiMenubarChangeDetail>;
 
-	private readonly resolvedAriaLabel = this.$.label.map((label) => label || undefined);
-
 	private openRoot: HTMLElement | null = null;
 	private popoverController: PopoverController | null = null;
 
 	private getTopItems(): HTMLElement[] {
 		return Array.from(
-			this.querySelectorAll<HTMLElement>('[data-ref="menubar"] > [data-ref="menubar-root"] > [role="menuitem"]'),
+			this.querySelectorAll<HTMLElement>('[data-ref="root"] > [data-ref="menubar-root"] > [role="menuitem"]'),
 		);
 	}
 
@@ -66,9 +63,8 @@ export class RuiMenubar extends RadiantElement<RuiMenubarBindings> {
 		);
 	}
 
-	override connectedCallback(): void {
-		super.connectedCallback();
-		queueMicrotask(() => applyRovingTabindex(this.getTopItems(), 0));
+	protected override onConnected(): void {
+		applyRovingTabindex(this.getTopItems(), 0);
 	}
 
 	override disconnectedCallback(): void {
@@ -159,7 +155,7 @@ export class RuiMenubar extends RadiantElement<RuiMenubarBindings> {
 	/**
 	 * @remarks When a menu is open, roving focus across the bar opens the newly focused menu (APG).
 	 */
-	@onEvent({ selector: '[data-ref="menubar"] > [data-ref="menubar-root"] > [role="menuitem"]', type: 'keydown' })
+	@onEvent({ selector: '[data-ref="root"] > [data-ref="menubar-root"] > [role="menuitem"]', type: 'keydown' })
 	onTopKeydown(event: KeyboardEvent): void {
 		const items = this.getTopItems();
 		const current = (event.target as HTMLElement).closest('[role="menuitem"]') as HTMLElement | null;
@@ -194,7 +190,7 @@ export class RuiMenubar extends RadiantElement<RuiMenubarBindings> {
 		}
 	}
 
-	@onEvent({ selector: '[data-ref="menubar"] > [data-ref="menubar-root"] > [role="menuitem"]', type: 'click' })
+	@onEvent({ selector: '[data-ref="root"] > [data-ref="menubar-root"] > [role="menuitem"]', type: 'click' })
 	onTopClick(event: Event): void {
 		const current = (event.target as HTMLElement).closest('[role="menuitem"]') as HTMLElement | null;
 		if (!current || !this.getTopItems().includes(current)) return;
@@ -268,13 +264,5 @@ export class RuiMenubar extends RadiantElement<RuiMenubarBindings> {
 		const value = item.getAttribute('data-value') || item.textContent?.trim() || '';
 		this.changeEvent.emit({ value });
 		this.closeOpenMenu(true);
-	}
-
-	override render() {
-		return (
-			<div class="rui-menubar" data-ref="menubar" role="menubar" aria-label={this.resolvedAriaLabel}>
-				<slot></slot>
-			</div>
-		);
 	}
 }

--- a/packages/radiant-ui/src/components/ui/menubar/menubar.stories.tsx
+++ b/packages/radiant-ui/src/components/ui/menubar/menubar.stories.tsx
@@ -6,7 +6,7 @@ import { RuiMenubar as RuiMenubarElement } from './menubar.script';
 const meta = {
 	title: 'Components/Menubar',
 	component: RuiMenubar,
-	parameters: { radiant: { element: RuiMenubarElement, cssImports: ['./menubar.css'] } },
+	parameters: { radiant: { element: RuiMenubarElement, cssImports: ['../../../styles/primitives.css', './menubar.css'] } },
 	args: {
 		label: 'Application',
 		items: [

--- a/packages/radiant-ui/src/components/ui/menubar/menubar.tsx
+++ b/packages/radiant-ui/src/components/ui/menubar/menubar.tsx
@@ -22,39 +22,48 @@ export type RuiMenubarItem = {
  */
 export function RuiMenubar({
 	items,
+	label,
+	children,
 	...props
-}: JsxCustomElementAttributes<RuiMenubarElement, RuiMenubarProps & { items: RuiMenubarItem[] }>) {
+}: JsxCustomElementAttributes<RuiMenubarElement, RuiMenubarProps & { items?: RuiMenubarItem[] }>) {
+	const content =
+		items != null
+			? items.map((item) => (
+					<div class="rui-menubar__root" data-ref="menubar-root">
+						<button
+							type="button"
+							class="rui-menubar__item"
+							role="menuitem"
+							tabindex={-1}
+							aria-haspopup={item.items?.length ? 'true' : undefined}
+							aria-expanded={item.items?.length ? 'false' : undefined}
+						>
+							{item.label}
+						</button>
+						{item.items?.length ? (
+							<div class="rui-menubar__menu rui-popover rui-floating" role="menu" hidden>
+								{item.items.map((child) => (
+									<button
+										type="button"
+										class="rui-menubar__menu-item"
+										role="menuitem"
+										data-value={child.id}
+										tabindex={-1}
+									>
+										{child.label}
+									</button>
+								))}
+							</div>
+						) : null}
+					</div>
+				))
+			: children;
+
 	return (
-		<rui-menubar {...props}>
-			{items.map((item) => (
-				<div class="rui-menubar__root" data-ref="menubar-root">
-					<button
-						type="button"
-						class="rui-menubar__item"
-						role="menuitem"
-						tabindex={-1}
-						aria-haspopup={item.items?.length ? 'true' : undefined}
-						aria-expanded={item.items?.length ? 'false' : undefined}
-					>
-						{item.label}
-					</button>
-					{item.items?.length ? (
-						<div class="rui-menubar__menu rui-popover rui-floating" role="menu" hidden>
-							{item.items.map((child) => (
-								<button
-									type="button"
-									class="rui-menubar__menu-item"
-									role="menuitem"
-									data-value={child.id}
-									tabindex={-1}
-								>
-									{child.label}
-								</button>
-							))}
-						</div>
-					) : null}
-				</div>
-			))}
+		<rui-menubar {...props} label={label}>
+			<div class="rui-menubar" data-ref="root" role="menubar" aria-label={label || undefined}>
+				{content}
+			</div>
 		</rui-menubar>
 	);
 }

--- a/packages/radiant-ui/src/components/ui/navigation-menu/index.ts
+++ b/packages/radiant-ui/src/components/ui/navigation-menu/index.ts
@@ -1,5 +1,7 @@
 export {
 	RuiNavigationMenu,
+	RuiNavigationMenuBar,
+	RuiNavigationMenuPanels,
 	RuiNavigationMenuTrigger,
 	RuiNavigationMenuLink,
 	RuiNavigationMenuPanel,

--- a/packages/radiant-ui/src/components/ui/navigation-menu/navigation-menu.script.tsx
+++ b/packages/radiant-ui/src/components/ui/navigation-menu/navigation-menu.script.tsx
@@ -23,8 +23,6 @@ type RuiNavigationMenuBindings = {
  * @see https://www.w3.org/WAI/ARIA/apg/patterns/disclosure/examples/disclosure-navigation/
  * @element rui-navigation-menu
  * @attr {string} label - Accessible name for the `nav` landmark.
- * @slot triggers - Top-level navigation triggers and plain links.
- * @slot panels - Disclosure panels composed from other primitives.
  * @cssclass rui-navigation-menu - Root `nav` surface.
  * @cssclass rui-navigation-menu__bar - Top-level trigger / link bar.
  * @cssclass rui-navigation-menu__panels - Panel region (`aria-hidden` toggling).
@@ -33,16 +31,11 @@ type RuiNavigationMenuBindings = {
 export class RuiNavigationMenu extends RadiantElement<RuiNavigationMenuBindings> {
 	@prop({ type: String, defaultValue: '' }) label: string;
 
-	private readonly resolvedAriaLabel = this.$.label.map((label) => label || undefined);
-
 	private openValue: string | null = null;
 
-	override connectedCallback(): void {
-		super.connectedCallback();
-		queueMicrotask(() => {
-			this.syncPanels();
-			this.syncBarRovingTabindex();
-		});
+	protected override onConnected(): void {
+		this.syncPanels();
+		this.syncBarRovingTabindex();
 	}
 
 	private getBarItems(): HTMLElement[] {
@@ -106,7 +99,7 @@ export class RuiNavigationMenu extends RadiantElement<RuiNavigationMenuBindings>
 		for (const panel of this.getPanels()) {
 			const value = panel.getAttribute('data-value') ?? '';
 			const open = this.openValue === value;
-			panel.hidden = !open;
+			panel.toggleAttribute('hidden', !open);
 			panel.dataset.state = open ? 'open' : 'closed';
 			panel.setAttribute('aria-hidden', String(!open));
 
@@ -357,18 +350,5 @@ export class RuiNavigationMenu extends RadiantElement<RuiNavigationMenuBindings>
 		}
 
 		event.preventDefault();
-	}
-
-	override render() {
-		return (
-			<nav class="rui-navigation-menu" data-ref="root" aria-label={this.resolvedAriaLabel}>
-				<div class="rui-navigation-menu__bar">
-					<slot name="triggers"></slot>
-				</div>
-				<div class="rui-navigation-menu__panels">
-					<slot name="panels"></slot>
-				</div>
-			</nav>
-		);
 	}
 }

--- a/packages/radiant-ui/src/components/ui/navigation-menu/navigation-menu.stories.tsx
+++ b/packages/radiant-ui/src/components/ui/navigation-menu/navigation-menu.stories.tsx
@@ -3,8 +3,10 @@ import { expect, fireEvent, userEvent } from 'storybook/test';
 import { RuiDisclosure } from '../disclosure/disclosure';
 import {
 	RuiNavigationMenu,
+	RuiNavigationMenuBar,
 	RuiNavigationMenuLink,
 	RuiNavigationMenuPanel,
+	RuiNavigationMenuPanels,
 	RuiNavigationMenuTrigger,
 } from './navigation-menu';
 import { RuiNavigationMenu as RuiNavigationMenuElement } from './navigation-menu.script';
@@ -12,7 +14,9 @@ import { RuiNavigationMenu as RuiNavigationMenuElement } from './navigation-menu
 const meta = {
 	title: 'Components/Navigation Menu',
 	component: RuiNavigationMenu,
-	parameters: { radiant: { element: RuiNavigationMenuElement, cssImports: ['./navigation-menu.css'] } },
+	parameters: {
+		radiant: { element: RuiNavigationMenuElement, cssImports: ['../button/button.css', './navigation-menu.css'] },
+	},
 	args: {
 		label: 'Main',
 	},
@@ -49,11 +53,14 @@ export const MegamenuNavigation: Story = {
 	render: (args) => (
 		<div class="max-w-5xl">
 			<RuiNavigationMenu label={args.label}>
-				<RuiNavigationMenuTrigger value="products">Products</RuiNavigationMenuTrigger>
-				<RuiNavigationMenuTrigger value="solutions">Solutions</RuiNavigationMenuTrigger>
-				<RuiNavigationMenuLink href="/pricing">Pricing</RuiNavigationMenuLink>
+				<RuiNavigationMenuBar>
+					<RuiNavigationMenuTrigger value="products">Products</RuiNavigationMenuTrigger>
+					<RuiNavigationMenuTrigger value="solutions">Solutions</RuiNavigationMenuTrigger>
+					<RuiNavigationMenuLink href="/pricing">Pricing</RuiNavigationMenuLink>
+				</RuiNavigationMenuBar>
 
-				<RuiNavigationMenuPanel value="products">
+				<RuiNavigationMenuPanels>
+					<RuiNavigationMenuPanel value="products">
 					<nav aria-label="Products">
 						<ul class="rui-navigation-menu__link-list">
 							{productLinks.map((link) => (
@@ -94,6 +101,7 @@ export const MegamenuNavigation: Story = {
 						</p>
 					</RuiDisclosure>
 				</RuiNavigationMenuPanel>
+				</RuiNavigationMenuPanels>
 			</RuiNavigationMenu>
 		</div>
 	),
@@ -184,9 +192,12 @@ export const MixedLinksAndPanels: Story = {
 	render: (args) => (
 		<div class="max-w-3xl">
 			<RuiNavigationMenu label={args.label}>
-				<RuiNavigationMenuTrigger value="learn">Learn</RuiNavigationMenuTrigger>
-				<RuiNavigationMenuLink href="/docs">Docs</RuiNavigationMenuLink>
-				<RuiNavigationMenuPanel value="learn">
+				<RuiNavigationMenuBar>
+					<RuiNavigationMenuTrigger value="learn">Learn</RuiNavigationMenuTrigger>
+					<RuiNavigationMenuLink href="/docs">Docs</RuiNavigationMenuLink>
+				</RuiNavigationMenuBar>
+				<RuiNavigationMenuPanels>
+					<RuiNavigationMenuPanel value="learn">
 					<nav aria-label="Learn">
 						<ul class="rui-navigation-menu__link-list">
 							<li>
@@ -201,6 +212,7 @@ export const MixedLinksAndPanels: Story = {
 						</ul>
 					</nav>
 				</RuiNavigationMenuPanel>
+				</RuiNavigationMenuPanels>
 			</RuiNavigationMenu>
 		</div>
 	),
@@ -210,8 +222,11 @@ export const DecorativePanelAccent: Story = {
 	render: (args) => (
 		<div class="max-w-3xl">
 			<RuiNavigationMenu label={args.label}>
-				<RuiNavigationMenuTrigger value="resources">Resources</RuiNavigationMenuTrigger>
-				<RuiNavigationMenuPanel value="resources">
+				<RuiNavigationMenuBar>
+					<RuiNavigationMenuTrigger value="resources">Resources</RuiNavigationMenuTrigger>
+				</RuiNavigationMenuBar>
+				<RuiNavigationMenuPanels>
+					<RuiNavigationMenuPanel value="resources">
 					<nav aria-label="Resources">
 						<ul class="rui-navigation-menu__link-list">
 							<li>
@@ -231,6 +246,7 @@ export const DecorativePanelAccent: Story = {
 						</p>
 					</RuiDisclosure>
 				</RuiNavigationMenuPanel>
+				</RuiNavigationMenuPanels>
 			</RuiNavigationMenu>
 		</div>
 	),

--- a/packages/radiant-ui/src/components/ui/navigation-menu/navigation-menu.tsx
+++ b/packages/radiant-ui/src/components/ui/navigation-menu/navigation-menu.tsx
@@ -5,30 +5,59 @@ import './navigation-menu.script';
 
 import { RuiButton, type RuiButtonControlProps } from '../button/button';
 
+export type RuiNavigationMenuBarProps = JsxElementProps<HTMLDivElement>;
+
+/** Top-level trigger and link row inside `RuiNavigationMenu`. */
+export function RuiNavigationMenuBar({ children, class: className, ...props }: RuiNavigationMenuBarProps) {
+	return (
+		<div {...props} data-ref="bar" class={cx('rui-navigation-menu__bar', className)}>
+			{children}
+		</div>
+	);
+}
+
+export type RuiNavigationMenuPanelsProps = JsxElementProps<HTMLDivElement>;
+
+/** Megamenu panel region inside `RuiNavigationMenu`. */
+export function RuiNavigationMenuPanels({ children, class: className, ...props }: RuiNavigationMenuPanelsProps) {
+	return (
+		<div {...props} data-ref="panels" class={cx('rui-navigation-menu__panels', className)}>
+			{children}
+		</div>
+	);
+}
+
 export function RuiNavigationMenu({
 	children,
+	label,
 	...props
 }: JsxCustomElementAttributes<RuiNavigationMenuElement, RuiNavigationMenuProps>) {
-	return <rui-navigation-menu {...props}>{children}</rui-navigation-menu>;
+	return (
+		<rui-navigation-menu {...props} label={label}>
+			<nav class="rui-navigation-menu" data-ref="root" aria-label={label || undefined}>
+				{children}
+			</nav>
+		</rui-navigation-menu>
+	);
 }
 
 export type RuiNavigationMenuTriggerProps = RuiButtonControlProps & {
 	value: string;
 };
 
-/** Top-level megamenu trigger slotted into `triggers` by default. */
+/** Top-level megamenu trigger. Place inside `RuiNavigationMenuBar`. */
 export function RuiNavigationMenuTrigger({
 	children,
-	slot = 'triggers',
 	value,
 	variant = 'ghost',
+	class: className,
 	...props
 }: RuiNavigationMenuTriggerProps) {
 	return (
 		<RuiButton
 			{...props}
-			slot={slot}
 			variant={variant}
+			class={className}
 			data-navigation-item
 			data-navigation-trigger
 			data-value={value}
@@ -42,10 +71,9 @@ export type RuiNavigationMenuLinkProps = JsxElementProps<HTMLAnchorElement> & {
 	href: string;
 };
 
-/** Plain navigation link slotted into `triggers` by default. */
+/** Plain navigation link. Place inside `RuiNavigationMenuBar`. */
 export function RuiNavigationMenuLink({
 	children,
-	slot = 'triggers',
 	href,
 	class: className,
 	...props
@@ -53,7 +81,6 @@ export function RuiNavigationMenuLink({
 	return (
 		<a
 			{...props}
-			slot={slot}
 			href={href}
 			data-navigation-item
 			class={cx('rui-button', 'rui-button--ghost', 'rui-button--md', className)}
@@ -67,16 +94,15 @@ export type RuiNavigationMenuPanelProps = JsxElementProps<HTMLDivElement> & {
 	value: string;
 };
 
-/** Megamenu panel slotted into `panels` by default. */
+/** Megamenu panel paired with a trigger by `value`. Place inside `RuiNavigationMenuPanels`. */
 export function RuiNavigationMenuPanel({
 	children,
-	slot = 'panels',
 	value,
 	class: className,
 	...props
 }: RuiNavigationMenuPanelProps) {
 	return (
-		<div {...props} slot={slot} class={className} data-navigation-panel data-value={value}>
+		<div {...props} class={className} data-navigation-panel data-value={value}>
 			{children}
 		</div>
 	);

--- a/packages/radiant-ui/src/components/ui/popover/popover.css
+++ b/packages/radiant-ui/src/components/ui/popover/popover.css
@@ -1,5 +1,4 @@
 @reference '../../../styles/radiant-ui.css';
-@import '../shared/popover.css';
 
 rui-popover,
 rui-popover-trigger {

--- a/packages/radiant-ui/src/components/ui/popover/popover.script.tsx
+++ b/packages/radiant-ui/src/components/ui/popover/popover.script.tsx
@@ -35,12 +35,10 @@ export type RuiPopoverProps = {
 /**
  * `<rui-popover>` — a floating overlay positioned relative to an anchor.
  *
- * Pair with a trigger via the `trigger` slot, wrap in `rui-popover-trigger`,
- * or pass an `anchor` selector for a custom anchor element.
+ * Pair with `RuiPopoverTrigger`, a `[data-popover-trigger]` element in the
+ * view-owned shell, or pass an `anchor` selector for a custom anchor element.
  *
  * @element rui-popover
- * @slot trigger - Pressable anchor (when not using an external `anchor` selector).
- * @slot content - Popover body rendered inside the floating surface.
  * @fires rui-open-change - Emitted when open state changes; `detail.open`.
  * @cssclass rui-popover-host - Anchor + surface wrapper.
  * @cssclass rui-popover - Floating surface (`role="dialog"`); `background` + `rounded-container` + `shadow-overlay`.
@@ -66,9 +64,8 @@ export class RuiPopover extends RadiantElement {
 	private controller: PopoverController | null = null;
 	private anchorClickTarget: HTMLElement | null = null;
 
-	override connectedCallback(): void {
-		super.connectedCallback();
-		queueMicrotask(() => this.syncPopover());
+	protected override onConnected(): void {
+		this.syncPopover();
 	}
 
 	override disconnectedCallback(): void {
@@ -80,12 +77,12 @@ export class RuiPopover extends RadiantElement {
 
 	private getAnchorElement(): HTMLElement | null {
 		const triggerHost = this.closest('rui-popover-trigger');
-		const triggerFromHost = triggerHost?.querySelector<HTMLElement>('[slot="trigger"]');
+		const triggerFromHost = triggerHost?.querySelector<HTMLElement>('[data-popover-trigger]');
 		if (triggerFromHost instanceof HTMLElement) {
 			return resolvePopoverAnchor(triggerFromHost);
 		}
 
-		const slottedTrigger = this.querySelector<HTMLElement>('[slot="trigger"]');
+		const slottedTrigger = this.querySelector<HTMLElement>('[data-popover-trigger]');
 		if (slottedTrigger instanceof HTMLElement) {
 			return resolvePopoverAnchor(slottedTrigger);
 		}
@@ -198,7 +195,7 @@ export class RuiPopover extends RadiantElement {
 		if (this.closest('rui-popover-trigger')) {
 			return false;
 		}
-		return !this.querySelector('[slot="trigger"]');
+		return !this.querySelector('[data-popover-trigger]');
 	}
 
 	private syncExternalAnchorClick(anchor: HTMLElement | null): void {
@@ -239,18 +236,6 @@ export class RuiPopover extends RadiantElement {
 		const anchor = this.getAnchorElement();
 		anchor?.focus();
 	}
-
-	override render() {
-		const variantClass = this.variant === 'listbox' ? 'rui-popover--listbox' : '';
-		return (
-			<div class="rui-popover-host" data-ref="host">
-				<slot name="trigger"></slot>
-				<div data-ref="surface" class={`rui-popover rui-floating ${variantClass}`.trim()} role="dialog" hidden>
-					<slot name="content"></slot>
-				</div>
-			</div>
-		);
-	}
 }
 
 export type RuiPopoverTriggerProps = {
@@ -262,7 +247,6 @@ export type RuiPopoverTriggerProps = {
  * `<rui-popover-trigger>` — coordinates open state between a trigger and `rui-popover`.
  *
  * @element rui-popover-trigger
- * @slot trigger - Pressable element that toggles the child popover.
  * @cssclass rui-popover-trigger - Trigger + popover wrapper.
  */
 @customElement('rui-popover-trigger')
@@ -275,12 +259,8 @@ export class RuiPopoverTrigger extends RadiantElement {
 		return this.querySelector('rui-popover');
 	}
 
-	override connectedCallback(): void {
-		super.connectedCallback();
-		if (isServer) {
-			return;
-		}
-		queueMicrotask(() => this.syncToPopover());
+	protected override onConnected(): void {
+		this.syncToPopover();
 	}
 
 	@bound
@@ -302,7 +282,7 @@ export class RuiPopoverTrigger extends RadiantElement {
 	@onEvent({ ref: 'root', type: 'click' })
 	onHostClick(event: Event): void {
 		const target = event.target as HTMLElement | null;
-		if (!target?.closest('[slot="trigger"]')) {
+		if (!target?.closest('[data-popover-trigger]')) {
 			return;
 		}
 		this.open = !this.open;
@@ -319,15 +299,6 @@ export class RuiPopoverTrigger extends RadiantElement {
 			return;
 		}
 		this.open = event.detail.open;
-	}
-
-	override render() {
-		return (
-			<div class="rui-popover-trigger" data-ref="root">
-				<slot name="trigger"></slot>
-				<slot></slot>
-			</div>
-		);
 	}
 }
 

--- a/packages/radiant-ui/src/components/ui/popover/popover.stories.tsx
+++ b/packages/radiant-ui/src/components/ui/popover/popover.stories.tsx
@@ -8,7 +8,7 @@ import { RuiPopover as RuiPopoverElement } from './popover.script';
 const meta = {
 	title: 'Components/Popover',
 	component: RuiPopover,
-	parameters: { radiant: { element: RuiPopoverElement, cssImports: ['./popover.css'] } },
+	parameters: { radiant: { element: RuiPopoverElement, cssImports: ['../../../styles/primitives.css', './popover.css'] } },
 } satisfies Meta<typeof RuiPopover>;
 
 export default meta;
@@ -28,7 +28,7 @@ export const WithTriggerWrapper: Story = {
 	),
 	play: async ({ canvasElement, step }) => {
 		const host = canvasElement.querySelector('rui-popover-trigger') as HTMLElement;
-		const trigger = canvasElement.querySelector('[slot="trigger"] button') as HTMLButtonElement;
+		const trigger = canvasElement.querySelector('[data-popover-trigger] button') as HTMLButtonElement;
 		const surface = document.querySelector('.rui-popover') as HTMLElement;
 
 		await step('starts closed', async () => {

--- a/packages/radiant-ui/src/components/ui/popover/popover.tsx
+++ b/packages/radiant-ui/src/components/ui/popover/popover.tsx
@@ -10,10 +10,10 @@ import './popover.script';
 
 export type RuiPopoverContentProps = JsxElementProps<HTMLDivElement>;
 
-/** Popover body slotted into the floating surface. */
-export function RuiPopoverContent({ children, slot = 'content', class: className, ...props }: RuiPopoverContentProps) {
+/** Popover body in the floating surface. */
+export function RuiPopoverContent({ children, class: className, ...props }: RuiPopoverContentProps) {
 	return (
-		<div {...props} slot={slot} class={cx(className)}>
+		<div {...props} class={cx(className)}>
 			{children}
 		</div>
 	);
@@ -22,6 +22,7 @@ export function RuiPopoverContent({ children, slot = 'content', class: className
 export function RuiPopover({
 	trigger,
 	children,
+	variant = 'default',
 	...props
 }: JsxCustomElementAttributes<
 	RuiPopoverElement,
@@ -29,10 +30,19 @@ export function RuiPopover({
 		trigger?: JsxRenderable;
 	}
 >) {
+	const variantClass = variant === 'listbox' ? 'rui-popover--listbox' : '';
 	return (
-		<rui-popover {...props}>
-			{trigger != null ? <span slot="trigger">{trigger}</span> : null}
-			{children}
+		<rui-popover {...props} variant={variant}>
+			<div class="rui-popover-host" data-ref="host">
+				{trigger != null ? <span data-popover-trigger>{trigger}</span> : null}
+				<div
+					data-ref="surface"
+					class={`rui-popover rui-floating ${variantClass}`.trim()}
+					role="dialog"
+				>
+					{children}
+				</div>
+			</div>
 		</rui-popover>
 	);
 }
@@ -49,8 +59,10 @@ export function RuiPopoverTrigger({
 >) {
 	return (
 		<rui-popover-trigger {...props}>
-			<span slot="trigger">{trigger}</span>
-			{children}
+			<div class="rui-popover-trigger" data-ref="root">
+				<span data-popover-trigger>{trigger}</span>
+				{children}
+			</div>
 		</rui-popover-trigger>
 	);
 }

--- a/packages/radiant-ui/src/components/ui/select/select.css
+++ b/packages/radiant-ui/src/components/ui/select/select.css
@@ -1,14 +1,12 @@
 @reference '../../../styles/radiant-ui.css';
-@import '../shared/control-toggle.css';
-@import '../shared/popover.css';
 
 rui-select {
-	@apply relative inline-flex w-full flex-col;
+	@apply relative inline-flex flex-col;
 }
 
 @layer components {
 	.rui-select {
-		@apply relative w-full text-sm;
+		@apply relative text-sm;
 	}
 
 	.rui-select__control {

--- a/packages/radiant-ui/src/components/ui/select/select.script.tsx
+++ b/packages/radiant-ui/src/components/ui/select/select.script.tsx
@@ -38,8 +38,6 @@ export type RuiSelectChangeDetail = { value: string };
  *
  * @see https://www.w3.org/WAI/ARIA/apg/patterns/combobox/examples/combobox-select-only/
  * @element rui-select
- * @slot trigger - Control row (`RuiSelectControl` with value button and toggle).
- * @slot listbox - Popup shell (`RuiSelectListbox`) containing an embedded `RuiListbox`.
  * @fires rui-change
  */
 @customElement('rui-select')
@@ -368,14 +366,14 @@ export class RuiSelect extends RadiantElement {
 		const selected = this.getSelectedValues();
 		if (selected.length === 0) {
 			valueElement.textContent = '';
-			valueElement.setAttribute('data-placeholder', 'true');
+			valueElement.toggleAttribute('data-placeholder', true);
 			if (this.placeholder) {
 				valueElement.textContent = this.placeholder;
 			}
 			return;
 		}
 
-		valueElement.removeAttribute('data-placeholder');
+		valueElement.toggleAttribute('data-placeholder', false);
 		if (this.isMultiple()) {
 			const labels = selected.map((value) => {
 				const match = this.getOptions().find((option) => this.getOptionValue(option) === value);
@@ -408,7 +406,7 @@ export class RuiSelect extends RadiantElement {
 		}
 
 		trigger.setAttribute('aria-expanded', String(next));
-		popup.hidden = !next;
+		popup.toggleAttribute('hidden', !next);
 
 		if (!next) {
 			this.listboxBehavior.clearActiveOption();
@@ -508,9 +506,8 @@ export class RuiSelect extends RadiantElement {
 		this.setOpen(false);
 	}
 
-	override connectedCallback(): void {
-		super.connectedCallback();
-		queueMicrotask(() => this.initialize());
+	protected override onConnected(): void {
+		this.initialize();
 	}
 
 	override disconnectedCallback(): void {
@@ -641,14 +638,5 @@ export class RuiSelect extends RadiantElement {
 			return;
 		}
 		this.setOpen(false);
-	}
-
-	override render() {
-		return (
-			<div class="rui-select" data-ref="root">
-				<slot name="trigger"></slot>
-				<slot name="listbox"></slot>
-			</div>
-		);
 	}
 }

--- a/packages/radiant-ui/src/components/ui/select/select.stories.tsx
+++ b/packages/radiant-ui/src/components/ui/select/select.stories.tsx
@@ -1,10 +1,13 @@
 import type { Meta, StoryObj } from '@ecopages/storybook-radiant-vite';
 import { expect, userEvent } from 'storybook/test';
 import { isStaticSsrPreview } from '@/lib/storybook-ssr';
+import { withStylesheets } from '@sb/with-stylesheets';
+import autocompleteCss from '../autocomplete/autocomplete.css?url';
 import { RuiAutocomplete, RuiAutocompleteCollection, RuiAutocompleteEmpty } from '../autocomplete';
 import { RuiField, RuiFieldDescription, RuiFieldError } from '../field';
 import { RuiLabel } from '../label';
 import { RuiTagGroup, RuiTagList } from '../tag-group';
+import tagGroupCss from '../tag-group/tag-group.css?url';
 import { RuiListbox, RuiListboxOption } from '../listbox';
 import {
 	RuiSelect,
@@ -32,7 +35,12 @@ const meta = {
 	parameters: {
 		radiant: {
 			element: RuiSelectElement,
-			cssImports: ['./select.css', '../shared/control-toggle.css', '../../../lib/icons/icons.css'],
+			cssImports: [
+				'../../../styles/primitives.css',
+				'../listbox/listbox.css',
+				'./select.css',
+				'../field/field.css',
+			],
 		},
 	},
 	args: {
@@ -129,6 +137,7 @@ export const Multiple: Story = {
 };
 
 export const WithAutocomplete: Story = {
+	decorators: [withStylesheets([autocompleteCss])],
 	render: () => (
 		<div class="flex flex-col gap-2">
 			<RuiLabel>Category</RuiLabel>
@@ -212,6 +221,7 @@ export const WithAutocomplete: Story = {
 };
 
 export const WithTagGroup: Story = {
+	decorators: [withStylesheets([autocompleteCss, tagGroupCss])],
 	render: () => (
 		<div class="flex flex-col gap-2">
 			<RuiLabel>States</RuiLabel>

--- a/packages/radiant-ui/src/components/ui/select/select.tsx
+++ b/packages/radiant-ui/src/components/ui/select/select.tsx
@@ -1,4 +1,4 @@
-import type { JsxCustomElementAttributes, JsxElementProps } from '@ecopages/jsx';
+import type { JsxCustomElementAttributes, JsxElementProps, JsxRenderable } from '@ecopages/jsx';
 import { withDefaultAriaLabel } from '@/aria';
 import { cx } from '@/lib/cx';
 import { omitProps } from '@/lib/omit-props';
@@ -14,9 +14,9 @@ export type RuiSelectControlProps = JsxElementProps<HTMLDivElement>;
  *
  * @cssclass rui-select__control - Trigger row; bordered, control-height surface.
  */
-export function RuiSelectControl({ children, slot = 'trigger', class: className, ...props }: RuiSelectControlProps) {
+export function RuiSelectControl({ children, class: className, ...props }: RuiSelectControlProps) {
 	return (
-		<div {...props} slot={slot} class={cx('rui-select__control', className)}>
+		<div {...props} class={cx('rui-select__control', className)}>
 			{children}
 		</div>
 	);
@@ -80,9 +80,9 @@ export type RuiSelectValueProps = JsxElementProps<HTMLSpanElement>;
  *
  * @cssclass rui-select__value - Selected value / placeholder text.
  */
-export function RuiSelectValue({ children, slot, class: className, ...props }: RuiSelectValueProps) {
+export function RuiSelectValue({ children, class: className, ...props }: RuiSelectValueProps) {
 	return (
-		<span {...props} slot={slot} data-select-value class={cx('rui-select__value', className)}>
+		<span {...props} data-select-value class={cx('rui-select__value', className)}>
 			{children}
 		</span>
 	);
@@ -91,18 +91,16 @@ export function RuiSelectValue({ children, slot, class: className, ...props }: R
 export type RuiSelectListboxProps = JsxElementProps<HTMLDivElement>;
 
 /**
- * Popup shell slotted into `listbox`. Place an embedded `RuiListbox` inside.
+ * Popup shell composed inside `listbox`. Place an embedded `RuiListbox` inside.
  *
  * @cssclass rui-select__listbox - Popup shell; composes `rui-popover` surface roles.
  */
-export function RuiSelectListbox({ children, slot = 'listbox', class: className, ...props }: RuiSelectListboxProps) {
+export function RuiSelectListbox({ children, class: className, ...props }: RuiSelectListboxProps) {
 	return (
 		<div
 			{...props}
-			slot={slot}
 			data-select-listbox
 			class={cx('rui-select__listbox rui-popover rui-popover--listbox rui-floating', className)}
-			hidden
 		>
 			{children}
 		</div>
@@ -121,7 +119,6 @@ export type RuiSelectSearchProps = JsxElementProps<HTMLInputElement> & {
  */
 export function RuiSelectSearch({
 	placeholder,
-	slot = 'input',
 	class: className,
 	disabled,
 	...props
@@ -130,7 +127,6 @@ export function RuiSelectSearch({
 		<input
 			{...props}
 			type="search"
-			slot={slot}
 			data-autocomplete-input
 			class={cx('rui-select__search', className)}
 			placeholder={placeholder}
@@ -171,30 +167,36 @@ export type RuiSelectViewProps = JsxCustomElementAttributes<
 	}
 >;
 
+function SelectShell({ children }: { children: JsxRenderable }) {
+	return (
+		<div class="rui-select" data-ref="root">
+			{children}
+		</div>
+	);
+}
+
 export function RuiSelect({ options, children, ...props }: RuiSelectViewProps) {
 	const displayText = options != null ? resolveSelectDisplayText(options, props.value, props.placeholder) : '';
-	const isPlaceholder =
-		options != null && !(typeof props.value === 'string' && props.value.trim()) && Boolean(props.placeholder);
 
 	return (
 		<rui-select {...props}>
-			{options == null ? (
-				children
-			) : (
-				<>
-					<RuiSelectControl>
-						<RuiSelectTrigger>
-							<RuiSelectValue {...(isPlaceholder ? { 'data-placeholder': true } : {})}>
-								{displayText}
-							</RuiSelectValue>
-						</RuiSelectTrigger>
-						<RuiSelectToggle />
-					</RuiSelectControl>
-					<RuiSelectListbox>
-						<RuiListbox embedded options={options} />
-					</RuiSelectListbox>
-				</>
-			)}
+			<SelectShell>
+				{options == null ? (
+					children
+				) : (
+					<>
+						<RuiSelectControl>
+							<RuiSelectTrigger>
+								<RuiSelectValue>{displayText}</RuiSelectValue>
+							</RuiSelectTrigger>
+							<RuiSelectToggle />
+						</RuiSelectControl>
+						<RuiSelectListbox>
+							<RuiListbox embedded options={options} />
+						</RuiSelectListbox>
+					</>
+				)}
+			</SelectShell>
 		</rui-select>
 	);
 }

--- a/packages/radiant-ui/src/components/ui/sidebar/sidebar-trigger.script.tsx
+++ b/packages/radiant-ui/src/components/ui/sidebar/sidebar-trigger.script.tsx
@@ -29,9 +29,8 @@ export type RuiSidebarTriggerProps = {
  * sidebar's `data-state` in its own `aria-expanded` attribute.
  *
  * @remarks
- * Avoids a light-DOM `<slot>` inside the button. SSR hydrates the rendered
- * button as host children; projecting those back into an inner slot causes
- * `insertBefore` hierarchy errors and leaves a dead control.
+ * Button chrome and icons are authored in the `RuiSidebarTrigger` view; this host
+ * only syncs ARIA and presentation attrs on the light-DOM button.
  *
  * @element rui-sidebar-trigger
  */
@@ -50,26 +49,48 @@ export class RuiSidebarTrigger extends RadiantElement {
 
 	private sidebarListener: ((event: Event) => void) | null = null;
 	private attachedSidebar: HTMLElement | null = null;
+	private initialSyncFrame: number | null = null;
 
 	/**
-	 * @remarks JSX `.prop` bindings flush after connect when the trigger lives in a sidebar slot.
+	 * @remarks JSX `.prop` bindings flush after connect when the trigger is nested in sidebar chrome.
+	 *
+	 * The triple sync is deliberate, not redundant:
+	 * - the synchronous call covers triggers rendered outside any sidebar;
+	 * - the nested microtasks hop past the *sidebar's* own `onConnected` sync
+	 *   (connection order does not guarantee the sidebar ran first), so state
+	 *   read here is post-sync;
+	 * - the animation frame is a final pass after layout settles (mobile media
+	 *   query flips land there).
 	 */
 	override connectedCallback(): void {
 		super.connectedCallback();
 		this.syncWithSidebar();
-		queueMicrotask(() => this.syncWithSidebar());
+		queueMicrotask(() => queueMicrotask(() => this.syncWithSidebar()));
+		this.initialSyncFrame = requestAnimationFrame(() => {
+			this.initialSyncFrame = null;
+			this.syncWithSidebar();
+		});
 	}
 
 	override disconnectedCallback(): void {
+		if (this.initialSyncFrame != null) {
+			cancelAnimationFrame(this.initialSyncFrame);
+			this.initialSyncFrame = null;
+		}
 		this.detachFromSidebar();
 		super.disconnectedCallback();
 	}
 
 	@onUpdated(['controls', 'buttonLabel', 'placement'])
-	onControlsUpdated(): void {
+	onBindingUpdated(): void {
 		this.detachFromSidebar();
 		this.syncWithSidebar();
 		this.applyState(this.attachedSidebar ? this.readState(this.attachedSidebar) : 'expanded');
+	}
+
+	@onUpdated(['variant', 'size'])
+	onPresentationUpdated(): void {
+		this.syncButtonPresentation();
 	}
 
 	private resolveSidebar(): (HTMLElement & { toggle?: () => void }) | null {
@@ -149,9 +170,17 @@ export class RuiSidebarTrigger extends RadiantElement {
 		} else if (this.controls) {
 			button.setAttribute('aria-controls', this.controls);
 		}
+		this.syncButtonPresentation();
 	}
 
-	@onEvent({ selector: 'button[data-ref="button"]', type: 'click' })
+	private syncButtonPresentation(): void {
+		const button = this.buttonTarget;
+		if (!button) return;
+		button.className =
+			`rui-button rui-button--${this.variant} rui-button--${this.size} rui-sidebar__trigger ${this.placementClass()}`.trim();
+	}
+
+	@onEvent({ selector: '[data-ref="button"]', type: 'click' })
 	onButtonClick(event: Event): void {
 		event.preventDefault();
 		event.stopPropagation();
@@ -165,111 +194,5 @@ export class RuiSidebarTrigger extends RadiantElement {
 		if (this.resolvedPlacement() === 'header') return 'rui-sidebar__trigger--header';
 		if (this.resolvedPlacement() === 'inset') return 'rui-sidebar__trigger--inset';
 		return '';
-	}
-
-	private renderMenuIcon(state: 'expanded' | 'collapsed') {
-		if (state === 'expanded') {
-			return (
-				<svg
-					class="rui-sidebar__trigger-glyph rui-sidebar__trigger-glyph--close"
-					viewBox="0 0 24 24"
-					fill="none"
-					stroke="currentColor"
-					stroke-width="2"
-					stroke-linecap="round"
-					stroke-linejoin="round"
-				>
-					<path d="M18 6 6 18" />
-					<path d="m6 6 12 12" />
-				</svg>
-			);
-		}
-
-		return (
-			<svg
-				class="rui-sidebar__trigger-glyph rui-sidebar__trigger-glyph--menu"
-				viewBox="0 0 24 24"
-				fill="none"
-				stroke="currentColor"
-				stroke-width="2"
-				stroke-linecap="round"
-				stroke-linejoin="round"
-			>
-				<path d="M4 6h16" />
-				<path d="M4 12h16" />
-				<path d="M4 18h16" />
-			</svg>
-		);
-	}
-
-	private renderDefaultIcon() {
-		const state = this.sidebarState;
-		const placement = this.resolvedPlacement();
-
-		if (placement === 'inset') {
-			return (
-				<span class="rui-sidebar__trigger-icon" aria-hidden="true">
-					{this.renderMenuIcon(state)}
-				</span>
-			);
-		}
-
-		const showCollapse = placement === 'header' || state === 'expanded';
-		const showExpand = placement !== 'header' && state === 'collapsed';
-
-		return (
-			<span class="rui-sidebar__trigger-icon" aria-hidden="true">
-				{showCollapse ? (
-					<svg
-						class="rui-sidebar__trigger-glyph rui-sidebar__trigger-glyph--collapse"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						stroke-width="2"
-						stroke-linecap="round"
-						stroke-linejoin="round"
-					>
-						<path d="M3 5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
-						<path d="M9 3v18" />
-						<path d="m14 15 3-3-3-3" />
-					</svg>
-				) : null}
-				{showExpand ? (
-					<svg
-						class="rui-sidebar__trigger-glyph rui-sidebar__trigger-glyph--expand"
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						stroke-width="2"
-						stroke-linecap="round"
-						stroke-linejoin="round"
-					>
-						<path d="M3 5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
-						<path d="M9 3v18" />
-						<path d="m14 9-3 3 3 3" />
-					</svg>
-				) : null}
-			</span>
-		);
-	}
-
-	override render() {
-		const sidebar = this.resolveSidebar();
-		const controlsId = sidebar?.id || this.controls || null;
-		const state = this.sidebarState;
-		const buttonLabel = this.resolvedButtonLabel(state);
-		return (
-			<button
-				data-ref="button"
-				type="button"
-				class={`rui-button rui-button--${this.variant} rui-button--${this.size} rui-sidebar__trigger ${this.placementClass()}`.trim()}
-				data-sidebar-state={state}
-				aria-expanded={state === 'expanded' ? 'true' : 'false'}
-				aria-controls={controlsId || null}
-				aria-label={buttonLabel}
-			>
-				{this.renderDefaultIcon()}
-			</button>
-		);
 	}
 }

--- a/packages/radiant-ui/src/components/ui/sidebar/sidebar.css
+++ b/packages/radiant-ui/src/components/ui/sidebar/sidebar.css
@@ -13,7 +13,16 @@ rui-sidebar {
 	 * @remarks Use `clip` (not `hidden`) so focus `scrollIntoView` cannot scroll this
 	 * shell — `hidden` still creates a scroll container and jumps the inset off-screen.
 	 */
-	@apply relative flex h-svh min-w-0 w-full flex-1 overflow-clip bg-background;
+	@apply relative flex h-svh min-h-0 min-w-0 w-full flex-1 overflow-clip bg-background;
+}
+
+.rui-sidebar-provider:has(> rui-sidebar[data-variant='inset']) {
+	@apply box-border gap-4 bg-surface p-4;
+}
+
+.rui-sidebar-provider:has(> rui-sidebar[data-variant='inset']) > .rui-sidebar,
+.rui-sidebar-provider:has(> rui-sidebar[data-variant='inset']) > .rui-sidebar__inset {
+	@apply h-full max-h-full min-h-0;
 }
 
 .rui-sidebar-provider[data-layout='full'] {
@@ -122,7 +131,8 @@ rui-sidebar {
 }
 
 .rui-sidebar[data-variant='inset'] {
-	@apply rounded-container border border-border bg-background;
+	@apply max-h-full min-h-0 rounded-container border border-border bg-background;
+	--rui-sidebar-background: var(--color-background);
 }
 
 .rui-sidebar[data-state='collapsed'] {
@@ -344,6 +354,10 @@ rui-sidebar {
 	@apply flex min-h-0 min-w-0 w-full flex-1 flex-col gap-0 overflow-clip bg-background;
 }
 
+.rui-sidebar-provider:has(> rui-sidebar[data-variant='inset']) > .rui-sidebar__inset {
+	@apply rounded-container border border-border;
+}
+
 /* -------------------------------------------------------------------------- */
 /* Trigger                                                                    */
 /* -------------------------------------------------------------------------- */
@@ -357,7 +371,23 @@ rui-sidebar {
 }
 
 .rui-sidebar__trigger-glyph {
-	@apply size-4 shrink-0;
+	@apply hidden size-4 shrink-0;
+}
+
+.rui-sidebar__trigger[data-sidebar-state='expanded']:not(.rui-sidebar__trigger--inset)
+	.rui-sidebar__trigger-glyph--collapse,
+.rui-sidebar__trigger--header .rui-sidebar__trigger-glyph--collapse {
+	@apply block;
+}
+
+.rui-sidebar__trigger[data-sidebar-state='collapsed']:not(.rui-sidebar__trigger--header):not(.rui-sidebar__trigger--inset)
+	.rui-sidebar__trigger-glyph--expand {
+	@apply block;
+}
+
+.rui-sidebar__trigger--inset[data-sidebar-state='expanded'] .rui-sidebar__trigger-glyph--close,
+.rui-sidebar__trigger--inset[data-sidebar-state='collapsed'] .rui-sidebar__trigger-glyph--menu {
+	@apply block;
 }
 
 /* -------------------------------------------------------------------------- */

--- a/packages/radiant-ui/src/components/ui/sidebar/sidebar.script.tsx
+++ b/packages/radiant-ui/src/components/ui/sidebar/sidebar.script.tsx
@@ -91,8 +91,8 @@ function isHorizontalSide(side: RuiSidebarSide): boolean {
 /**
  * `<rui-sidebar>` — a resizable, collapsible side panel.
  *
- * The sidebar hosts the pane content in the default slot. When the parent
- * supplies a `RuiSidebarRail` element (or the `collapsible` mode is not
+ * The sidebar hosts pane content in the view-owned light-DOM shell. When the
+ * parent supplies a `RuiSidebarRail` element (or the `collapsible` mode is not
  * `off`), the sidebar manages open/closed state, a focusable resize handle,
  * and keyboard navigation that follows the APG Window Splitter pattern.
  *
@@ -108,7 +108,6 @@ function isHorizontalSide(side: RuiSidebarSide): boolean {
  * @see https://www.w3.org/WAI/ARIA/apg/patterns/windowsplitter/
  *
  * @element rui-sidebar
- * @slot - Pane content. Stack header, content, and footer inside.
  * @fires rui-sidebar-toggle - Emitted on every open/closed transition.
  *        `detail` is `{ open, state }`.
  * @fires rui-sidebar-resize - Emitted on every width change. `detail` is `{ width }`.
@@ -181,28 +180,27 @@ export class RuiSidebar extends RadiantElement<RuiSidebarBindings> {
 
 		this.setAttribute('role', 'complementary');
 		this.setAttribute('aria-label', this.label);
-		this.syncHostAttributes();
+		this.syncPresentation();
 		this.attachNavigationListeners();
-		queueMicrotask(() => {
-			this.ensureWidthInitialized();
-			this.openControlled = this.open !== undefined;
-			this.bindMobileMediaQuery();
-			if (!this.openControlled) {
-				this.open = this.isMobile ? this.mobileDefaultOpen : this.defaultOpen;
-			}
+	}
 
-			this.syncHostAttributes();
-			this.syncPaneWidthVar();
-			this.syncActiveLinksAfterRender(true);
-			this.mobileReady = true;
-		});
+	protected override onConnected(): void {
+		this.ensureWidthInitialized();
+		this.openControlled = this.open !== undefined;
+		this.bindMobileMediaQuery();
+		if (!this.openControlled) {
+			this.open = this.isMobile ? this.mobileDefaultOpen : this.defaultOpen;
+		}
+
+		this.syncPresentation();
+		this.syncPaneWidthVar();
+		this.syncActiveLinksAfterRender(true);
+		this.mobileReady = true;
 	}
 
 	/**
-	 * @remarks Light-DOM hydrate/update can recreate projected menu links after the
-	 * connect microtask sync. Re-apply active classes once the render commits so
-	 * imperative highlights survive slot projection. `requestUpdate()` commits through
-	 * the scheduler (not `update()`), so that path must re-sync too.
+	 * @remarks Light-DOM hydrate/update can recreate menu links after the connect
+	 * microtask sync. Re-apply active classes once the render commits.
 	 */
 	override hydrate(): void {
 		super.hydrate();
@@ -238,17 +236,61 @@ export class RuiSidebar extends RadiantElement<RuiSidebarBindings> {
 	}
 
 	/**
-	 * Keep host `data-*` in sync for `:has(> rui-sidebar[...])` and public API.
-	 * Visual styles target the inner `.rui-sidebar` root (host is `display: contents`).
+	 * Keep host and inner shell `data-*` in sync. Host attrs drive
+	 * `:has(> rui-sidebar[...])`; inner `.rui-sidebar` drives visual styles.
 	 */
-	private syncHostAttributes(): void {
-		const paneState: RuiSidebarState = this.isOpen() ? 'expanded' : 'collapsed';
+	private syncPresentation(): void {
+		const horizontal = isHorizontalSide(this.side);
+		const open = this.isOpen();
+		const paneState: RuiSidebarState = open ? 'expanded' : 'collapsed';
+		const showHandle = this.resizable && this.collapsible === 'off' && open && !this.isMobile;
+		const paneInert = !(open || (!this.isMobile && this.collapsible === 'icon'));
+		const paneWidth = this.paneWidth();
+
 		this.setAttribute('data-state', paneState);
 		this.setAttribute('data-collapsible', this.collapsible);
 		this.setAttribute('data-variant', this.variant);
 		this.setAttribute('data-side', this.side);
 		this.setAttribute('data-mobile', String(this.isMobile));
-		this.setAttribute('data-pane-width', String(this.paneWidth()));
+		this.setAttribute('data-pane-width', String(paneWidth));
+
+		const root = this.rootTarget;
+		if (root) {
+			root.dataset.state = paneState;
+			root.dataset.collapsible = this.collapsible;
+			root.dataset.variant = this.variant;
+			root.dataset.side = this.side;
+			root.dataset.mobile = String(this.isMobile);
+		}
+
+		const scrim = this.scrimTarget;
+		if (scrim) {
+			scrim.toggleAttribute('hidden', !(this.isMobile && open));
+		}
+
+		const pane = this.paneTarget;
+		if (pane) {
+			pane.dataset.side = this.side;
+			pane.dataset.variant = this.variant;
+			pane.setAttribute('aria-label', this.label);
+			if (paneInert) {
+				pane.setAttribute('inert', '');
+			} else {
+				pane.removeAttribute('inert');
+			}
+		}
+
+		const handle = this.handleTarget;
+		if (handle) {
+			handle.toggleAttribute('hidden', !showHandle);
+			if (showHandle) {
+				handle.setAttribute('aria-orientation', horizontal ? 'vertical' : 'horizontal');
+				handle.setAttribute('aria-valuenow', String(paneWidth));
+				handle.setAttribute('aria-valuemin', String(this.minWidth));
+				handle.setAttribute('aria-valuemax', String(this.maxWidth));
+				handle.setAttribute('aria-label', `${this.label} resize handle`);
+			}
+		}
 	}
 
 	private isOpen(): boolean {
@@ -278,9 +320,10 @@ export class RuiSidebar extends RadiantElement<RuiSidebarBindings> {
 		'maxWidth',
 		'isMobile',
 		'resizable',
+		'label',
 	])
 	onStateUpdated(): void {
-		this.syncHostAttributes();
+		this.syncPresentation();
 		this.syncPaneWidthVar();
 	}
 
@@ -447,12 +490,13 @@ export class RuiSidebar extends RadiantElement<RuiSidebarBindings> {
 	setOpen(next: boolean): void {
 		const wasOpen = this.isOpen();
 		if (next === wasOpen) {
+			this.syncPresentation();
 			this.syncPaneWidthVar();
 			return;
 		}
 		this.open = next;
 		const paneState: RuiSidebarState = next ? 'expanded' : 'collapsed';
-		this.setAttribute('data-state', paneState);
+		this.syncPresentation();
 		this.syncPaneWidthVar();
 		this.toggleEvent.emit({ open: next, state: paneState });
 	}
@@ -492,14 +536,14 @@ export class RuiSidebar extends RadiantElement<RuiSidebarBindings> {
 		this.endDrag();
 	}
 
-	@bound
-	private onHandlePointerDown(event: Event): void {
+	@onEvent({ ref: 'handle', type: 'pointerdown' })
+	onHandlePointerDown(event: Event): void {
 		event.preventDefault();
 		this.beginDrag(event as PointerEvent);
 	}
 
-	@bound
-	private onHandleKeydown(event: Event): void {
+	@onEvent({ ref: 'handle', type: 'keydown' })
+	onHandleKeydown(event: Event): void {
 		const keyboardEvent = event as KeyboardEvent;
 		const current = this.paneWidth();
 		const horizontal = isHorizontalSide(this.side);
@@ -523,8 +567,8 @@ export class RuiSidebar extends RadiantElement<RuiSidebarBindings> {
 		this.applyWidth(next, true);
 	}
 
-	@bound
-	private onScrimClick(): void {
+	@onEvent({ ref: 'scrim', type: 'click' })
+	onScrimClick(): void {
 		if (this.isMobile) {
 			this.setOpen(false);
 		}
@@ -550,77 +594,5 @@ export class RuiSidebar extends RadiantElement<RuiSidebarBindings> {
 			keyboardEvent.preventDefault();
 			this.toggle();
 		}
-	}
-
-	/**
-	 * Only the pane's `aria-label` is bound below. `data-state`/`data-collapsible`/
-	 * `data-variant`/`data-side`/`data-mobile` and the handle's `aria-value*`/
-	 * `aria-orientation` stay plain reads deliberately — this component's open/
-	 * close, drag-resize, and mobile-detection paths are the same high-frequency
-	 * interactive category where two sibling components in this migration
-	 * (tooltip, menu-button) hit real regressions from binding conversion that
-	 * weren't fully root-caused. Deferred as a follow-up rather than risking the
-	 * same class of bug here under the same review budget.
-	 *
-	 * @remarks The icon rail stays interactive when collapsed on desktop; the mobile drawer does not.
-	 */
-	override render() {
-		const horizontal = isHorizontalSide(this.side);
-		const open = this.isOpen();
-		const paneState: RuiSidebarState = open ? 'expanded' : 'collapsed';
-		const showHandle = this.resizable && this.collapsible === 'off' && open && !this.isMobile;
-		const widthVar = `${this.paneWidth()}px`;
-		const paneInert = open || (!this.isMobile && this.collapsible === 'icon') ? undefined : '';
-
-		return (
-			<div
-				class="rui-sidebar"
-				style={{ '--rui-sidebar-pane-width': widthVar } as Record<string, string>}
-				data-ref="root"
-				data-state={paneState}
-				data-collapsible={this.collapsible}
-				data-variant={this.variant}
-				data-side={this.side}
-				data-mobile={String(this.isMobile)}
-			>
-				{/* Scrim first so it stacks under the pane (dialog pattern). */}
-				<button
-					data-ref="scrim"
-					type="button"
-					class="rui-sidebar__scrim"
-					tabindex={-1}
-					aria-label="Close sidebar"
-					hidden={!this.isMobile || !open}
-					on:click={this.onScrimClick}
-				></button>
-				<div
-					data-ref="pane"
-					class="rui-sidebar__pane"
-					data-side={this.side}
-					data-variant={this.variant}
-					aria-label={this.$.label}
-					inert={paneInert}
-				>
-					<slot></slot>
-				</div>
-				{showHandle ? (
-					<div
-						data-ref="handle"
-						class="rui-sidebar__handle"
-						role="separator"
-						tabindex={0}
-						aria-orientation={horizontal ? 'vertical' : 'horizontal'}
-						aria-valuenow={this.paneWidth()}
-						aria-valuemin={this.minWidth}
-						aria-valuemax={this.maxWidth}
-						aria-label={`${this.label} resize handle`}
-						on:pointerdown={this.onHandlePointerDown}
-						on:keydown={this.onHandleKeydown}
-					>
-						<span class="rui-sidebar__handle-grip" aria-hidden="true"></span>
-					</div>
-				) : null}
-			</div>
-		);
 	}
 }

--- a/packages/radiant-ui/src/components/ui/sidebar/sidebar.stories.tsx
+++ b/packages/radiant-ui/src/components/ui/sidebar/sidebar.stories.tsx
@@ -9,18 +9,16 @@ import {
 	RuiSidebarProvider,
 	RuiSidebarHeader,
 	RuiSidebarContent,
-	RuiSidebarFooter,
 	RuiSidebarSeparator,
 	RuiSidebarGroup,
 	RuiSidebarGroupHeader,
-	RuiSidebarGroupAction,
 	RuiSidebarMenu,
 	RuiSidebarMenuItem,
 	RuiSidebarMenuButton,
-	RuiSidebarMenuAction,
 	RuiSidebarInset,
 } from './sidebar';
 import { RuiSidebar as RuiSidebarElement } from './sidebar.script';
+import { renderDemoSidebarContent } from '../../../stories/fixtures/sidebar-demo-nav';
 
 const icon = (paths: string | readonly string[]) => {
 	const d = Array.isArray(paths) ? paths : [paths];
@@ -41,38 +39,6 @@ const icon = (paths: string | readonly string[]) => {
 		</svg>
 	);
 };
-
-const ICONS = {
-	home: ['M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z', 'M9 22V12h6v10'],
-	sparkles: [
-		'M9.937 15.5A2 2 0 0 0 8.5 14.063l-6.135-1.582a.5.5 0 0 1 0-.962L8.5 9.936A2 2 0 0 0 9.937 8.5l1.582-6.135a.5.5 0 0 1 .962 0L14.063 8.5A2 2 0 0 0 15.5 9.937l6.135 1.581a.5.5 0 0 1 0 .964L15.5 14.063a2 2 0 0 0-1.437 1.437l-1.582 6.135a.5.5 0 0 1-.962 0z',
-		'M20 3v4',
-		'M22 5h-4',
-		'M4 17v2',
-		'M5 18H3',
-	],
-	message: 'M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z',
-	bot: ['M12 8V4H8', 'M16 16h6', 'M19 13v6', 'M16 8h-5a3 3 0 0 0-3 3v6a3 3 0 0 0 3 3h5', 'M9 22h6', 'M12 17v5'],
-	building: [
-		'M3 21h18',
-		'M9 8h1',
-		'M9 12h1',
-		'M9 16h1',
-		'M14 8h1',
-		'M14 12h1',
-		'M14 16h1',
-		'M5 21V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2v16',
-	],
-	plus: 'M5 12h14M12 5v14',
-	user: ['M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2', 'M12 11a4 4 0 0 1 0-8 4 4 0 0 1 0 8'],
-	settings: [
-		'M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z',
-		'M12 15a3 3 0 1 0 0-6 3 3 0 0 0 0 6',
-	],
-} as const;
-
-type IconKey = keyof typeof ICONS;
-const NavIcon = ({ name }: { name: IconKey }) => icon(ICONS[name]);
 
 type DocsNavGroup = {
 	name: string;
@@ -237,160 +203,6 @@ function renderDocsSiteHeader({ controlsId }: { controlsId: string }) {
 	);
 }
 
-const SIDEBAR_GROUPS = [
-	{
-		id: 'workspace',
-		label: 'Workspace',
-		items: [{ href: '/', label: 'Dashboard', icon: 'home' as IconKey }],
-	},
-	{
-		id: 'skills',
-		label: 'Skills',
-		items: [{ href: '/skills', label: 'All skills', icon: 'sparkles' as IconKey }],
-		actions: [
-			{ kind: 'link' as const, label: 'Create new skill', icon: 'plus' as IconKey, href: '/skills/create' },
-		],
-	},
-	{
-		id: 'admin',
-		label: 'Admin',
-		items: [{ href: '/admin/organizations', label: 'Organizations', icon: 'building' as IconKey }],
-	},
-	{
-		id: 'chat',
-		label: 'Chat',
-		items: [
-			{ href: '/chat', label: 'Chats', icon: 'message' as IconKey },
-			{ href: '/chat/agent', label: 'Agent', icon: 'bot' as IconKey },
-		],
-		actions: [
-			{ kind: 'button' as const, label: 'New DM', icon: 'plus' as IconKey },
-			{ kind: 'button' as const, label: 'New group', icon: 'plus' as IconKey },
-		],
-	},
-	{
-		id: 'account',
-		label: 'Account',
-		items: [
-			{ href: '/profile', label: 'Profile', icon: 'user' as IconKey },
-			{ href: '/settings', label: 'Settings', icon: 'settings' as IconKey },
-		],
-	},
-];
-
-function renderSidebarContent({
-	currentPath = '/',
-	onAction,
-}: {
-	currentPath?: string;
-	onAction?: (label: string) => void;
-} = {}) {
-	return (
-		<>
-			<RuiSidebarHeader aria-label="Workspace header">
-				<a
-					href="/"
-					class="rui-sidebar__brand flex min-w-0 flex-1 items-center gap-2 truncate text-base font-semibold"
-				>
-					<span class="rui-sidebar__brand-mark grid size-6 shrink-0 place-items-center rounded-md bg-primary text-on-primary text-xs font-bold">
-						R
-					</span>
-					<span class="rui-sidebar__brand-text">Radiant</span>
-				</a>
-				<RuiSidebarTrigger placement="header" controls="primary-sidebar" triggerLabel="Collapse sidebar" />
-			</RuiSidebarHeader>
-
-			<RuiSidebarContent aria-label="Primary navigation">
-				{SIDEBAR_GROUPS.map((group, index) => (
-					<>
-						<RuiSidebarGroup aria-label={group.label} key={group.id}>
-							<RuiSidebarGroupHeader
-								label={group.label}
-								action={
-									<RuiSidebarGroupAction aria-label={`Add ${group.label.toLowerCase()}`}>
-										<NavIcon name="plus" />
-									</RuiSidebarGroupAction>
-								}
-							/>
-							<RuiSidebarMenu aria-label={`${group.label} links`}>
-								{group.items.map((item) => (
-									<RuiSidebarMenuItem key={item.href}>
-										<RuiSidebarMenuButton
-											as="a"
-											href={item.href}
-											isActive={currentPath === item.href}
-											tooltip={item.label}
-										>
-											<NavIcon name={item.icon} />
-											<span>{item.label}</span>
-										</RuiSidebarMenuButton>
-									</RuiSidebarMenuItem>
-								))}
-							</RuiSidebarMenu>
-							{'actions' in group && group.actions?.length ? (
-								<div class="rui-sidebar__group-actions mt-1 flex flex-col gap-0.5 border-t border-border pt-1.5">
-									{group.actions.map((action) => {
-										const content = (
-											<>
-												{action.icon ? <NavIcon name={action.icon} /> : null}
-												<span>{action.label}</span>
-											</>
-										);
-
-										if (action.kind === 'link') {
-											return (
-												<RuiSidebarMenuAction
-													key={action.label}
-													as="a"
-													href={action.href}
-													tooltip={action.label}
-												>
-													{content}
-												</RuiSidebarMenuAction>
-											);
-										}
-
-										return (
-											<RuiSidebarMenuAction
-												key={action.label}
-												as="button"
-												tooltip={action.label}
-												onClick={onAction ? () => onAction(action.label) : undefined}
-											>
-												{content}
-											</RuiSidebarMenuAction>
-										);
-									})}
-								</div>
-							) : null}
-						</RuiSidebarGroup>
-						{index < SIDEBAR_GROUPS.length - 1 ? (
-							<RuiSidebarSeparator aria-label="Section divider" />
-						) : null}
-					</>
-				))}
-			</RuiSidebarContent>
-
-			<RuiSidebarFooter>
-				<RuiSidebarMenu aria-label="Account">
-					<RuiSidebarMenuItem>
-						<RuiSidebarMenuButton as="a" href="/settings" tooltip="Settings">
-							<NavIcon name="settings" />
-							<span>Settings</span>
-						</RuiSidebarMenuButton>
-					</RuiSidebarMenuItem>
-					<RuiSidebarMenuItem>
-						<RuiSidebarMenuButton as="a" href="/profile" tooltip="Profile">
-							<NavIcon name="user" />
-							<span>Profile</span>
-						</RuiSidebarMenuButton>
-					</RuiSidebarMenuItem>
-				</RuiSidebarMenu>
-			</RuiSidebarFooter>
-		</>
-	);
-}
-
 function renderInset({ title }: { title: string }) {
 	return (
 		<RuiSidebarInset id="main-content">
@@ -440,7 +252,7 @@ export const Default: Story = {
 		<RuiSidebarProvider
 			sidebar={
 				<RuiSidebar {...args} id="primary-sidebar">
-					{renderSidebarContent({ currentPath: '/' })}
+					{renderDemoSidebarContent({ currentPath: '/' })}
 				</RuiSidebar>
 			}
 		>
@@ -454,8 +266,8 @@ export const Default: Story = {
 		expect(sidebar).toHaveAttribute('role', 'complementary');
 		expect(sidebar.id).toBe('primary-sidebar');
 		expect(sidebar).toHaveAttribute('data-state', 'expanded');
-		expect(canvas.getByText('Workspace')).toBeInTheDocument();
-		expect(canvas.getByText('Chat')).toBeInTheDocument();
+		expect(canvas.getByText('Content')).toBeInTheDocument();
+		expect(canvas.getByText('Pages')).toBeInTheDocument();
 		expect(canvas.getByRole('link', { name: /Dashboard/ })).toHaveAttribute('aria-current', 'page');
 	},
 };
@@ -466,7 +278,7 @@ export const CollapsibleIcon: Story = {
 		<RuiSidebarProvider
 			sidebar={
 				<RuiSidebar {...args} id="primary-sidebar">
-					{renderSidebarContent({ currentPath: '/chat' })}
+					{renderDemoSidebarContent({ currentPath: '/content/pages' })}
 				</RuiSidebar>
 			}
 		>
@@ -493,7 +305,7 @@ export const RightSide: Story = {
 		<RuiSidebarProvider
 			sidebar={
 				<RuiSidebar {...args} id="primary-sidebar">
-					{renderSidebarContent({ currentPath: '/' })}
+					{renderDemoSidebarContent({ currentPath: '/' })}
 				</RuiSidebar>
 			}
 		>
@@ -509,17 +321,15 @@ export const RightSide: Story = {
 export const Inset: Story = {
 	args: { variant: 'inset', collapsible: 'icon' },
 	render: (args) => (
-		<div class="h-full w-full bg-surface p-4">
-			<RuiSidebarProvider
-				sidebar={
-					<RuiSidebar {...args} id="primary-sidebar">
-						{renderSidebarContent({ currentPath: '/' })}
-					</RuiSidebar>
-				}
-			>
-				{renderInset({ title: 'Inset sidebar' })}
-			</RuiSidebarProvider>
-		</div>
+		<RuiSidebarProvider
+			sidebar={
+				<RuiSidebar {...args} id="primary-sidebar">
+					{renderDemoSidebarContent({ currentPath: '/' })}
+				</RuiSidebar>
+			}
+		>
+			{renderInset({ title: 'Inset sidebar' })}
+		</RuiSidebarProvider>
 	),
 };
 
@@ -529,7 +339,7 @@ export const TriggerToggle: Story = {
 		<RuiSidebarProvider
 			sidebar={
 				<RuiSidebar {...args} id="primary-sidebar">
-					{renderSidebarContent({ currentPath: '/' })}
+					{renderDemoSidebarContent({ currentPath: '/' })}
 				</RuiSidebar>
 			}
 		>
@@ -556,7 +366,7 @@ export const KeyboardShortcut: Story = {
 		<RuiSidebarProvider
 			sidebar={
 				<RuiSidebar {...args} id="primary-sidebar">
-					{renderSidebarContent({ currentPath: '/' })}
+					{renderDemoSidebarContent({ currentPath: '/' })}
 				</RuiSidebar>
 			}
 		>
@@ -579,7 +389,7 @@ export const ResizeHandle: Story = {
 		<RuiSidebarProvider
 			sidebar={
 				<RuiSidebar {...args} id="primary-sidebar">
-					{renderSidebarContent({ currentPath: '/' })}
+					{renderDemoSidebarContent({ currentPath: '/' })}
 				</RuiSidebar>
 			}
 		>
@@ -606,7 +416,7 @@ export const Responsive: Story = {
 		<RuiSidebarProvider
 			sidebar={
 				<RuiSidebar id="primary-sidebar" collapsible="icon" mobileBreakpoint={10_000} label="Primary" open>
-					{renderSidebarContent({ currentPath: '/' })}
+					{renderDemoSidebarContent({ currentPath: '/' })}
 				</RuiSidebar>
 			}
 		>

--- a/packages/radiant-ui/src/components/ui/sidebar/sidebar.test.tsx
+++ b/packages/radiant-ui/src/components/ui/sidebar/sidebar.test.tsx
@@ -257,7 +257,7 @@ describe('RuiSidebar composition', () => {
 		cleanup();
 	});
 
-	it('does not render a resize handle by default', async () => {
+	it('keeps the inactive resize handle hidden by default', async () => {
 		const { host, cleanup } = mount(
 			<RuiSidebar id="primary-sidebar" collapsible="off" mobileBreakpoint={0} label="Primary">
 				<span>content</span>
@@ -266,7 +266,7 @@ describe('RuiSidebar composition', () => {
 
 		await settled();
 
-		expect(host.querySelector('[data-ref="handle"]')).toBeNull();
+		expect(host.querySelector('[data-ref="handle"]')?.hasAttribute('hidden')).toBe(true);
 
 		cleanup();
 	});
@@ -595,11 +595,11 @@ describe('RuiSidebar mobile drawer', () => {
 		cleanup();
 	});
 
-	it('does not render a resize handle in mobile mode', async () => {
+	it('keeps the resize handle hidden in mobile mode', async () => {
 		const { host, cleanup } = mountMobileSidebar({ collapsible: 'off', open: true });
 		await settled();
 
-		expect(host.querySelector('[data-ref="handle"]')).toBeNull();
+		expect(host.querySelector('[data-ref="handle"]')?.hasAttribute('hidden')).toBe(true);
 
 		cleanup();
 	});

--- a/packages/radiant-ui/src/components/ui/sidebar/sidebar.tsx
+++ b/packages/radiant-ui/src/components/ui/sidebar/sidebar.tsx
@@ -332,21 +332,102 @@ export function RuiSidebarInset({ children, class: className, ...props }: RuiSid
 
 export type RuiSidebarViewProps = JsxCustomElementAttributes<RuiSidebarElement, RuiSidebarProps & { id: string }>;
 
-export function RuiSidebar({ children, open, ...props }: RuiSidebarViewProps) {
+export function RuiSidebar({ children, open, label, ...props }: RuiSidebarViewProps) {
 	return (
-		<rui-sidebar {...props} prop:open={open}>
-			{children}
+		<rui-sidebar {...props} prop:open={open} label={label}>
+			<div class="rui-sidebar" data-ref="root">
+				<button
+					data-ref="scrim"
+					type="button"
+					class="rui-sidebar__scrim"
+					tabindex={-1}
+					aria-label="Close sidebar"
+					hidden
+				></button>
+				<div data-ref="pane" class="rui-sidebar__pane" aria-label={label}>
+					{children}
+				</div>
+				<div
+					data-ref="handle"
+					class="rui-sidebar__handle"
+					role="separator"
+					tabindex={0}
+					hidden
+				>
+					<span class="rui-sidebar__handle-grip" aria-hidden="true"></span>
+				</div>
+			</div>
 		</rui-sidebar>
 	);
 }
 
 export type RuiSidebarTriggerViewProps = JsxCustomElementAttributes<RuiSidebarTriggerElement, RuiSidebarTriggerProps>;
 
+function RuiSidebarTriggerIcon() {
+	return (
+		<span class="rui-sidebar__trigger-icon" aria-hidden="true">
+			<svg
+				class="rui-sidebar__trigger-glyph rui-sidebar__trigger-glyph--collapse"
+				viewBox="0 0 24 24"
+				fill="none"
+				stroke="currentColor"
+				stroke-width="2"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+			>
+				<path d="M3 5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
+				<path d="M9 3v18" />
+				<path d="m14 15 3-3-3-3" />
+			</svg>
+			<svg
+				class="rui-sidebar__trigger-glyph rui-sidebar__trigger-glyph--expand"
+				viewBox="0 0 24 24"
+				fill="none"
+				stroke="currentColor"
+				stroke-width="2"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+			>
+				<path d="M3 5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
+				<path d="M9 3v18" />
+				<path d="m14 9-3 3 3 3" />
+			</svg>
+			<svg
+				class="rui-sidebar__trigger-glyph rui-sidebar__trigger-glyph--close"
+				viewBox="0 0 24 24"
+				fill="none"
+				stroke="currentColor"
+				stroke-width="2"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+			>
+				<path d="M18 6 6 18" />
+				<path d="m6 6 12 12" />
+			</svg>
+			<svg
+				class="rui-sidebar__trigger-glyph rui-sidebar__trigger-glyph--menu"
+				viewBox="0 0 24 24"
+				fill="none"
+				stroke="currentColor"
+				stroke-width="2"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+			>
+				<path d="M4 6h16" />
+				<path d="M4 12h16" />
+				<path d="M4 18h16" />
+			</svg>
+		</span>
+	);
+}
+
 export function RuiSidebarTrigger({
 	children,
 	class: className,
 	triggerLabel,
 	placement,
+	variant = 'ghost',
+	size = 'md',
 	...props
 }: RuiSidebarTriggerViewProps) {
 	const buttonLabel = triggerLabel ?? 'Toggle sidebar';
@@ -358,8 +439,16 @@ export function RuiSidebarTrigger({
 			prop:buttonLabel={buttonLabel}
 			data={{ buttonLabel }}
 			placement={placement}
+			variant={variant}
+			size={size}
 		>
-			{children}
+			<button
+				data-ref="button"
+				type="button"
+				class={cx('rui-button', `rui-button--${variant}`, `rui-button--${size}`, 'rui-sidebar__trigger')}
+			>
+				{children ?? <RuiSidebarTriggerIcon />}
+			</button>
 		</rui-sidebar-trigger>
 	);
 }

--- a/packages/radiant-ui/src/components/ui/tooltip/tooltip.ssr.test.tsx
+++ b/packages/radiant-ui/src/components/ui/tooltip/tooltip.ssr.test.tsx
@@ -1,0 +1,18 @@
+import { renderToString } from '@ecopages/jsx/server';
+import { describe, expect, it } from 'vitest';
+import { RuiTooltip } from './tooltip';
+
+describe('RuiTooltip SSR', () => {
+	it('renders the view-owned trigger and tooltip shell', () => {
+		const html = renderToString(
+			<RuiTooltip content="Save your changes">
+				<button type="button">Save</button>
+			</RuiTooltip>,
+		);
+
+		expect(html).toContain('class="rui-tooltip"');
+		expect(html).toContain('role="tooltip"');
+		expect(html).toContain('Save your changes');
+		expect(html).not.toContain('slot');
+	});
+});

--- a/packages/radiant-ui/src/stories/fixtures/sidebar-demo-nav.tsx
+++ b/packages/radiant-ui/src/stories/fixtures/sidebar-demo-nav.tsx
@@ -1,0 +1,228 @@
+import {
+	RuiSidebarTrigger,
+	RuiSidebarHeader,
+	RuiSidebarContent,
+	RuiSidebarFooter,
+	RuiSidebarSeparator,
+	RuiSidebarGroup,
+	RuiSidebarGroupHeader,
+	RuiSidebarGroupAction,
+	RuiSidebarMenu,
+	RuiSidebarMenuItem,
+	RuiSidebarMenuButton,
+	RuiSidebarMenuAction,
+} from '../../components/ui/sidebar';
+
+const icon = (paths: string | readonly string[]) => {
+	const d = Array.isArray(paths) ? paths : [paths];
+	return (
+		<svg
+			class="rui-sidebar__icon"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			stroke-width="2"
+			stroke-linecap="round"
+			stroke-linejoin="round"
+			aria-hidden="true"
+		>
+			{d.map((path) => (
+				<path d={path} />
+			))}
+		</svg>
+	);
+};
+
+const ICONS = {
+	home: ['M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z', 'M9 22V12h6v10'],
+	chart: ['M3 3v18h18', 'M7 16l4-4 4 4 5-6'],
+	file: ['M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z', 'M14 2v6h6'],
+	pen: ['M12 20h9', 'M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z'],
+	image: [
+		'M5 3h14a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2z',
+		'M8 14l2-2 3 3 5-5 3 3',
+		'M9 8h.01',
+	],
+	layers: ['M12 2 2 7l10 5 10-5-10-5z', 'M2 17l10 5 10-5', 'M2 12l10 5 10-5'],
+	menu: ['M4 6h16', 'M4 12h16', 'M4 18h16'],
+	arrow: ['M5 12h14', 'M13 6l6 6-6 6'],
+	shield: 'M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z',
+	mail: ['M4 4h16v16H4z', 'M22 6l-10 7L2 6'],
+	plus: 'M5 12h14M12 5v14',
+	user: ['M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2', 'M12 11a4 4 0 0 1 0-8 4 4 0 0 1 0 8'],
+	settings: [
+		'M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z',
+		'M12 15a3 3 0 1 0 0-6 3 3 0 0 0 0 6',
+	],
+} as const;
+
+type IconKey = keyof typeof ICONS;
+const NavIcon = ({ name }: { name: IconKey }) => icon(ICONS[name]);
+
+type DemoNavAction =
+	{ kind: 'link'; label: string; icon: IconKey; href: string } | { kind: 'button'; label: string; icon: IconKey };
+
+type DemoNavGroup = {
+	id: string;
+	label: string;
+	items: Array<{ href: string; label: string; icon: IconKey }>;
+	actions?: DemoNavAction[];
+};
+
+export const DEMO_NAV_GROUPS: DemoNavGroup[] = [
+	{
+		id: 'overview',
+		label: 'Overview',
+		items: [
+			{ href: '/', label: 'Dashboard', icon: 'home' },
+			{ href: '/analytics', label: 'Analytics', icon: 'chart' },
+			{ href: '/reports', label: 'Reports', icon: 'file' },
+		],
+	},
+	{
+		id: 'content',
+		label: 'Content',
+		items: [
+			{ href: '/content/pages', label: 'Pages', icon: 'file' },
+			{ href: '/content/posts', label: 'Posts', icon: 'pen' },
+			{ href: '/content/media', label: 'Media', icon: 'image' },
+		],
+		actions: [{ kind: 'link', label: 'New page', icon: 'plus', href: '/content/pages/new' }],
+	},
+	{
+		id: 'structure',
+		label: 'Structure',
+		items: [
+			{ href: '/structure/collections', label: 'Collections', icon: 'layers' },
+			{ href: '/structure/navigation', label: 'Navigation', icon: 'menu' },
+			{ href: '/structure/redirects', label: 'Redirects', icon: 'arrow' },
+		],
+	},
+	{
+		id: 'users',
+		label: 'Users',
+		items: [
+			{ href: '/users/members', label: 'Members', icon: 'user' },
+			{ href: '/users/roles', label: 'Roles', icon: 'shield' },
+			{ href: '/users/invitations', label: 'Invitations', icon: 'mail' },
+		],
+		actions: [{ kind: 'button', label: 'Invite member', icon: 'plus' }],
+	},
+];
+
+export function renderDemoSidebarContent({
+	currentPath = '/',
+	onAction,
+	controlsId = 'primary-sidebar',
+	headerTriggerLabel = 'Collapse sidebar',
+}: {
+	currentPath?: string;
+	onAction?: (label: string) => void;
+	controlsId?: string;
+	headerTriggerLabel?: string;
+} = {}) {
+	return (
+		<>
+			<RuiSidebarHeader aria-label="Application header">
+				<a
+					href="/"
+					class="rui-sidebar__brand flex min-w-0 flex-1 items-center gap-2 truncate text-base font-semibold"
+				>
+					<span class="rui-sidebar__brand-mark grid size-6 shrink-0 place-items-center rounded-md bg-primary text-on-primary text-xs font-bold">
+						R
+					</span>
+					<span class="rui-sidebar__brand-text">Radiant</span>
+				</a>
+				<RuiSidebarTrigger placement="header" controls={controlsId} triggerLabel={headerTriggerLabel} />
+			</RuiSidebarHeader>
+
+			<RuiSidebarContent aria-label="Primary navigation">
+				{DEMO_NAV_GROUPS.map((group, index) => (
+					<>
+						<RuiSidebarGroup aria-label={group.label} key={group.id}>
+							<RuiSidebarGroupHeader
+								label={group.label}
+								action={
+									<RuiSidebarGroupAction aria-label={`Add ${group.label.toLowerCase()}`}>
+										<NavIcon name="plus" />
+									</RuiSidebarGroupAction>
+								}
+							/>
+							<RuiSidebarMenu aria-label={`${group.label} links`}>
+								{group.items.map((item) => (
+									<RuiSidebarMenuItem key={item.href}>
+										<RuiSidebarMenuButton
+											as="a"
+											href={item.href}
+											isActive={currentPath === item.href}
+											tooltip={item.label}
+										>
+											<NavIcon name={item.icon} />
+											<span>{item.label}</span>
+										</RuiSidebarMenuButton>
+									</RuiSidebarMenuItem>
+								))}
+							</RuiSidebarMenu>
+							{group.actions?.length ? (
+								<div class="rui-sidebar__group-actions mt-1 flex flex-col gap-0.5 border-t border-border pt-1.5">
+									{group.actions.map((action) => {
+										const content = (
+											<>
+												<NavIcon name={action.icon} />
+												<span>{action.label}</span>
+											</>
+										);
+
+										if (action.kind === 'link') {
+											return (
+												<RuiSidebarMenuAction
+													key={action.label}
+													as="a"
+													href={action.href}
+													tooltip={action.label}
+												>
+													{content}
+												</RuiSidebarMenuAction>
+											);
+										}
+
+										return (
+											<RuiSidebarMenuAction
+												key={action.label}
+												as="button"
+												tooltip={action.label}
+												onClick={onAction ? () => onAction(action.label) : undefined}
+											>
+												{content}
+											</RuiSidebarMenuAction>
+										);
+									})}
+								</div>
+							) : null}
+						</RuiSidebarGroup>
+						{index < DEMO_NAV_GROUPS.length - 1 ? (
+							<RuiSidebarSeparator aria-label="Section divider" />
+						) : null}
+					</>
+				))}
+			</RuiSidebarContent>
+
+			<RuiSidebarFooter>
+				<RuiSidebarMenu aria-label="Account">
+					<RuiSidebarMenuItem>
+						<RuiSidebarMenuButton as="a" href="/settings" tooltip="Settings">
+							<NavIcon name="settings" />
+							<span>Settings</span>
+						</RuiSidebarMenuButton>
+					</RuiSidebarMenuItem>
+					<RuiSidebarMenuItem>
+						<RuiSidebarMenuButton as="a" href="/profile" tooltip="Profile">
+							<NavIcon name="user" />
+							<span>Profile</span>
+						</RuiSidebarMenuButton>
+					</RuiSidebarMenuItem>
+				</RuiSidebarMenu>
+			</RuiSidebarFooter>
+		</>
+	);
+}


### PR DESCRIPTION
Migrate dialog, popover, tooltip, select, combobox, autocomplete,
menu-button, menubar, navigation-menu, disclosure, and sidebar.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>