### PR TITLE
refactor(radiant-ui): finish light-DOM migration and docs

### DIFF
--- a/.changeset/radiant-ui-table-range-ownership.md
+++ b/.changeset/radiant-ui-table-range-ownership.md
@@ -1,0 +1,15 @@
+---
+'@ecopages/radiant-ui': minor
+---
+
+Move composite JSX APIs to view-owned light-DOM shells so parent reconciliation no longer fights custom-element slot projection.
+
+**@ecopages/radiant-ui**
+
+- Composite `Rui*` views now own chrome and author children in the light DOM; coordinating custom elements query `data-ref` / `data-*` targets and toggle volatile attrs imperatively instead of re-rendering through CE `<slot>`.
+
+    This is a breaking pre-1.0 change for consumers who authored the previous slot-based markup directly: migrate to the documented `Rui*` view helpers or equivalent light-DOM structure.
+
+- Migrated composites include table, dialog, form, field, select, listbox, checkbox, combobox, autocomplete, menu-button, tooltip, hover-card, switch, breadcrumb, popover, toolbar, grid, tree, treegrid, tag-group, menubar, disclosure (and group), window-splitter, number-field, navigation-menu, carousel, and sidebar (with trigger).
+- Popup visibility and placeholder state use `toggleAttribute` so parent re-renders do not fight `moveRangeBefore`.
+- Table sync narrows imperative `tabIndex` updates to structure changes and keyboard focus, avoiding churn during `aria-busy` refreshes.

--- a/apps/docs/src/content/docs/components/slots.mdx
+++ b/apps/docs/src/content/docs/components/slots.mdx
@@ -46,6 +46,16 @@ export class ShellCard extends RadiantElement {
 </shell-card>
 ```
 
+## JSX-authored composites
+
+When a framework view (for example a `Rui*` helper in Radiant UI) owns the
+light-DOM shell, **do not** route parent JSX children through CE `<slot>` tags.
+Place chrome and author content in the view, query with `data-ref` / `data-*`,
+and toggle volatile visibility with `toggleAttribute`. Reserve CE slots for
+HTML-first hosts where consumers author unordered direct children.
+
+See [RadiantElement](/docs/components/radiant-element#authored-light-dom-host) and the Radiant UI composition guide.
+
 ## Semantics
 
 - Slots are resolved from direct host children.

--- a/apps/radiant-ui/src/content/components/alert.mdx
+++ b/apps/radiant-ui/src/content/components/alert.mdx
@@ -128,11 +128,11 @@ Follows the <a href="https://www.w3.org/WAI/ARIA/apg/patterns/alert/" data-wai-a
 | `dismissible` | `boolean` | `false` | Show dismiss control; enables `dismiss()`. |
 | `close-label` | `string` | `Dismiss` | Accessible name for the dismiss control. |
 
-### Slots
+### Composition
 
-| Slot | Description |
+| Piece | Description |
 | --- | --- |
-| *(default)* | Content inside the `role="alert"` region. `inline`: `RuiAlertIcon` + text. `banner`: `RuiAlertTitle` + `RuiAlertDescription`. |
+| `children` | Content inside the `role="alert"` region. `inline`: `RuiAlertIcon` + text. `banner`: `RuiAlertTitle` + `RuiAlertDescription`. |
 
 ### Events
 

--- a/apps/radiant-ui/src/content/components/autocomplete.mdx
+++ b/apps/radiant-ui/src/content/components/autocomplete.mdx
@@ -70,27 +70,27 @@ The filtered results themselves are `RuiListbox` / `RuiListboxOption` and follow
 
 ## API
 
-`RuiAutocomplete` is a custom element (`<rui-autocomplete>`) that filters its slotted collection; the view helpers own the composed input and empty-state markup.
+`RuiAutocomplete` is a custom element (`<rui-autocomplete>`) that filters its composed collection; the view helpers own the composed input and empty-state markup.
 
 ### Attributes
 
 | Attribute | Type | Default | Description |
 | --- | --- | --- | --- |
 | `sensitivity` | `base` · `case` · `accent` | `base` | Filter sensitivity for substring matching. |
-| `input-value` | `string` | `''` | Controlled filter query; when unset, reads from the slotted input. |
+| `input-value` | `string` | `''` | Controlled filter query; when unset, reads from the composed input. |
 
-### Slots
+### Composition
 
-| Slot | Description |
+| Piece | Description |
 | --- | --- |
 | `input` | Search field (`RuiAutocompleteInput`). |
-| *(default)* | Filterable collection of `[role="option"]`, `[role="menuitem"]`, or `[data-tag]` items. |
+| `children` | Filterable collection of `[role="option"]`, `[role="menuitem"]`, or `[data-tag]` items. |
 
 ### View helpers
 
 | Component | Renders |
 | --- | --- |
-| `RuiAutocompleteInput` | Bordered search input (slotted into `input`). |
+| `RuiAutocompleteInput` | Bordered search input (composed via `RuiAutocompleteInput`). |
 | `RuiAutocompleteCollection` | Scrollable wrapper for the filterable options. |
 | `RuiAutocompleteEmpty` | No-results state, hidden while matches exist. |
 

--- a/apps/radiant-ui/src/content/components/breadcrumb.mdx
+++ b/apps/radiant-ui/src/content/components/breadcrumb.mdx
@@ -91,9 +91,9 @@ Check the compiled `breadcrumb.css` for the exact roles. Override at the theme l
 | `label` | `string` | `Breadcrumb` | Accessible name for the navigation landmark. |
 | `separator` | `string` | `/` | Glyph used by empty `RuiBreadcrumbSeparator` nodes. |
 
-### Slots
+### Composition
 
-| Slot | Description |
+| Piece | Description |
 | --- | --- |
 | (default) | Authored breadcrumb list markup. |
 

--- a/apps/radiant-ui/src/content/components/button.mdx
+++ b/apps/radiant-ui/src/content/components/button.mdx
@@ -46,6 +46,14 @@ Use `filled` for the main action, `outline` for a supporting action, and `ghost`
 
 Pass `href` when the control should navigate; `variant` only changes appearance.
 
+Use the `square` modifier for an icon-only action. It keeps the selected control size on both axes; provide an `aria-label` because it has no visible text.
+
+```tsx
+<RuiButton size="sm" square aria-label="Add item">
+	<AddIcon />
+</RuiButton>
+```
+
 <Canvas of={Destructive} meta={ButtonMeta} />
 <br />
 <Canvas of={Ghost} meta={ButtonMeta} />
@@ -86,6 +94,7 @@ Override at the theme layer (`tokens/presets/colors/*.css`), not in component CS
 | --- | --- | --- | --- |
 | `variant` | `filled` · `outline` · `destructive` · `ghost` · `link` | `filled` | Visual tone. |
 | `size` | `none` · `sm` · `md` · `lg` | `md` | Control size; `none` for inline `link` chrome. |
+| `square` | `boolean` | `false` | Makes the selected control size square for icon-only actions. |
 | `aria-label` | `string` | | Accessible name when there is no visible text. |
 
 ### Button branch props
@@ -122,6 +131,7 @@ Public BEM classes on the rendered element (documented via `@cssclass` on `RuiBu
 | `.rui-button--link` | Inline link-styled action. |
 | `.rui-button--none` | No fixed size (inline `link` chrome). |
 | `.rui-button--sm` · `.rui-button--md` · `.rui-button--lg` | Control sizes. |
+| `.rui-button--square` | Square control for icon-only actions. |
 
 ### Theme roles (per `variant`)
 

--- a/apps/radiant-ui/src/content/components/carousel.mdx
+++ b/apps/radiant-ui/src/content/components/carousel.mdx
@@ -86,11 +86,11 @@ Override at the theme layer, not in component CSS.
 | `wrap` | `boolean` | `true` | Keep controls enabled at the ends. |
 | `slide-count` | `number` | `0` | Authored slide count for render-time control state. |
 
-### Slots
+### Composition
 
-| Slot | Description |
+| Piece | Description |
 | --- | --- |
-| *(default)* | Slides, each marked `data-slide` (see `RuiCarouselSlide`). |
+| `children` | Slides, each marked `data-slide` (see `RuiCarouselSlide`). |
 | `prev` | Custom previous control (`data-carousel-action="prev"`). |
 | `next` | Custom next control (`data-carousel-action="next"`). |
 | `rotation` | Custom play/pause control (`data-carousel-action="rotation"`). |

--- a/apps/radiant-ui/src/content/components/checkbox.mdx
+++ b/apps/radiant-ui/src/content/components/checkbox.mdx
@@ -73,7 +73,7 @@ Label text uses `on-background`. Override roles at the theme layer, not in compo
 
 ## API
 
-`RuiCheckbox` is a custom element (`<rui-checkbox>`) rendering a native `<input type="checkbox">` inside a `<label>`, the browser owns activation and Space-to-toggle.
+`RuiCheckbox` renders a view-owned `<label>` and native `<input type="checkbox">` inside the coordinating `<rui-checkbox>` custom element. Use the JSX view or compose equivalent marked-up light DOM; the browser owns activation and Space-to-toggle.
 
 ### Attributes (`<rui-checkbox>`)
 
@@ -85,11 +85,11 @@ Label text uses `on-background`. Override roles at the theme layer, not in compo
 | `value` | `string` | `on` | Value submitted with forms when checked. |
 | `name` | `string` | `''` | Form field name. |
 
-### Slots
+### Composition
 
-| Slot | Description |
+| Piece | Description |
 | --- | --- |
-| (default) | Visible label for the checkbox. |
+| `RuiCheckbox` children | Visible label for the checkbox. |
 
 ### Events
 

--- a/apps/radiant-ui/src/content/components/chip.mdx
+++ b/apps/radiant-ui/src/content/components/chip.mdx
@@ -1,6 +1,6 @@
 ---
 title: Chip
-description: Chips represent compact entities (tags, filters, or status markers) in a pill-shaped container.
+description: Chips represent compact entities such as tags and filters in a pill-shaped container.
 category: Data display
 ---
 
@@ -22,7 +22,7 @@ export const config = {
 
 # Chip
 
-<p class="docs-lede">Chips represent compact entities (tags, filters, or status markers) in a pill-shaped container that reads at a glance.</p>
+<p class="docs-lede">Chips represent compact entities such as tags and filters in a pill-shaped container that reads at a glance. For status and counts, use <code>RuiBadge</code>.</p>
 
 ## Try it
 
@@ -60,7 +60,8 @@ Rounded shape uses the `rounded-pill` radius token. Override roles at the theme 
 
 - Keep chip text short and self-explanatory; avoid abbreviations that need a legend.
 - When chips are interactive, use a button or link with an accessible name instead of a static chip.
-- Do not rely on chip color alone to convey status; include descriptive text.
+- Do not rely on chip color alone to convey meaning; include descriptive text.
+- For status labels (`Beta`, `Error`, counts), use `RuiBadge` instead.
 
 ## API
 

--- a/apps/radiant-ui/src/content/components/combobox.mdx
+++ b/apps/radiant-ui/src/content/components/combobox.mdx
@@ -73,7 +73,7 @@ Geometry shares control tokens (`--size-control-*`, `--radius-control`, `--space
 
 ## API
 
-`RuiCombobox` is a custom element (`<rui-combobox>`) that coordinates a slotted input row and listbox popup; the view helpers own the composed surface.
+`RuiCombobox` is a custom element (`<rui-combobox>`) that coordinates a composed input row and listbox popup; the view helpers own the composed surface.
 
 ### Attributes
 
@@ -85,9 +85,9 @@ Geometry shares control tokens (`--size-control-*`, `--radius-control`, `--space
 | `disabled` | `boolean` | `false` | Disable the input and trigger. |
 | `open-on-focus` | `boolean` | `false` | Open the listbox when the input gains focus. |
 
-### Slots
+### Composition
 
-| Slot | Description |
+| Piece | Description |
 | --- | --- |
 | `control` | Input row: `RuiComboboxControl` with `RuiComboboxInput` (+ optional `RuiComboboxTrigger`). |
 | `listbox` | Popup shell: `RuiComboboxListbox` containing an embedded `RuiListbox`. |
@@ -100,7 +100,7 @@ Geometry shares control tokens (`--size-control-*`, `--radius-control`, `--space
 
 ### View helpers
 
-| Component | Renders | Slot |
+| Component | Renders | Placement |
 | --- | --- | --- |
 | `RuiComboboxControl` | Input row wrapper | `control` |
 | `RuiComboboxInput` | Text input (`role="combobox"`) | |

--- a/apps/radiant-ui/src/content/components/cycle-toggle.mdx
+++ b/apps/radiant-ui/src/content/components/cycle-toggle.mdx
@@ -71,11 +71,11 @@ Button geometry (`--size-control-*`, `--radius-control`) is inherited from `rui-
 | `label` | `string` | `''` | Accessible name prefix for the cycle button. |
 | `disabled` | `boolean` | `false` | Disables the cycle button. |
 
-### Slots
+### Composition
 
-| Slot | Description |
+| Piece | Description |
 | --- | --- |
-| *(default)* | `RuiCycleToggleItem` nodes projected into the inner button by the view. |
+| `children` | `RuiCycleToggleItem` nodes projected into the inner button by the view. |
 
 ### Events
 

--- a/apps/radiant-ui/src/content/components/dialog.mdx
+++ b/apps/radiant-ui/src/content/components/dialog.mdx
@@ -94,14 +94,14 @@ Body uses the `p-inset` spacing token. Override roles at the theme layer, not in
 | `alert` | `boolean` | `false` | Uses `role="alertdialog"` for workflow-interrupting confirmations. |
 | `label` | `string` | `''` | Accessible name when there is no visible title. |
 
-### Slots
+### Composition
 
-| Slot | Description |
+| Piece | Description |
 | --- | --- |
-| `close` | Optional close control (`RuiDialogClose`). |
-| `title` | Optional visible dialog title (`RuiDialogTitle`). |
-| (default) | Dialog body (`RuiDialogBody`). |
-| `actions` | Optional action buttons (`RuiDialogActions`). |
+| `RuiDialogTitle` | Optional visible title. |
+| `RuiDialogBody` | Main dialog content. |
+| `RuiDialogActions` | Optional action button row. |
+| `RuiDialogClose` | Optional dismiss control. |
 
 ### Events
 
@@ -111,12 +111,12 @@ Body uses the `p-inset` spacing token. Override roles at the theme layer, not in
 
 ### View helpers
 
-| Component | Slots into |
+| Component | Placement |
 | --- | --- |
-| `RuiDialogTitle` | `title` |
-| `RuiDialogBody` | (default) |
-| `RuiDialogActions` | `actions` |
-| `RuiDialogClose` | `close` |
+| `RuiDialogTitle` | Inside dialog shell |
+| `RuiDialogBody` | Inside dialog shell |
+| `RuiDialogActions` | Inside dialog shell |
+| `RuiDialogClose` | Inside dialog shell |
 
 ### CSS classes
 

--- a/apps/radiant-ui/src/content/components/disclosure.mdx
+++ b/apps/radiant-ui/src/content/components/disclosure.mdx
@@ -88,12 +88,13 @@ Disclosure provides two custom elements: `<rui-disclosure>` (show/hide) and `<ru
 | `multiple` | `boolean` | `false` | Allow more than one disclosure open (exclusive by default). |
 | `animated` | `boolean` | `false` | Animate panel height for child disclosures. |
 
-### Slots
+### Composition
 
-| Slot | Description |
+| Piece | Description |
 | --- | --- |
-| `trigger` | Disclosure button (`RuiDisclosureTrigger`). |
-| *(default)* | Panel content (`RuiDisclosurePanel`). For `<rui-disclosure-group>`, `rui-disclosure` children. |
+| `RuiDisclosureTrigger` | Disclosure button. |
+| `RuiDisclosurePanel` | Panel content region. |
+| `rui-disclosure` children | Stacked disclosures inside `RuiDisclosureGroup`. |
 
 ### Events
 
@@ -117,7 +118,7 @@ Public BEM classes on the composed light-DOM surface (documented via `@cssclass`
 
 | Class | Description |
 | --- | --- |
-| `.rui-disclosure` | Root wrapper around trigger and panel slots. |
+| `.rui-disclosure` | Root wrapper around trigger and panel regions. |
 | `.rui-disclosure__trigger` | Trigger button; reflects `aria-expanded`. |
 | `.rui-disclosure__trigger--icon-end` | Layout when `iconPosition="end"`. |
 | `.rui-disclosure__icon` | Indicator wrapper (decorative, `aria-hidden`). |

--- a/apps/radiant-ui/src/content/components/field.mdx
+++ b/apps/radiant-ui/src/content/components/field.mdx
@@ -71,7 +71,7 @@ The nested control keeps its own control tokens (`--size-control-*`, `--radius-c
 
 ## API
 
-`RuiField` is a custom element (`<rui-field>`) connecting a slotted control to an ancestor `<rui-form>`.
+`RuiField` is a custom element (`<rui-field>`) connecting a composed control to an ancestor `<rui-form>`.
 
 ### Attributes
 
@@ -91,11 +91,11 @@ The nested control keeps its own control tokens (`--size-control-*`, `--radius-c
 | `defaultValue` | `unknown` | Default value when uncontrolled. |
 | `defaultValueData` | `string` | JSON default value; falls back to `data-default-value`. |
 
-### Slots
+### Composition
 
-| Slot | Description |
+| Piece | Description |
 | --- | --- |
-| *(default)* | Field content: label (`RuiLabel`), control, `RuiFieldDescription`, `RuiFieldError`. |
+| `children` | Field content: label (`RuiLabel`), control, `RuiFieldDescription`, `RuiFieldError`. |
 
 ### View helpers
 

--- a/apps/radiant-ui/src/content/components/form.mdx
+++ b/apps/radiant-ui/src/content/components/form.mdx
@@ -74,7 +74,7 @@ The form itself carries no color roles; fields, labels, and controls inside keep
 
 ## API
 
-`RuiForm` is a custom element (`<rui-form>`). The `RuiForm` view is a passthrough that maps `defaultValues` / `resolver` to `prop:` bindings.
+`RuiForm` renders a view-owned native `<form>` inside the coordinating `<rui-form>` custom element. The view maps `defaultValues` / `resolver` to `prop:` bindings and keeps authored children inside that native form.
 
 ### Attributes
 

--- a/apps/radiant-ui/src/content/components/grid.mdx
+++ b/apps/radiant-ui/src/content/components/grid.mdx
@@ -69,11 +69,11 @@ Override at the theme layer, not in component CSS.
 | --- | --- | --- | --- |
 | `label` | `string` | `''` | Accessible name announced when focus enters the grid. |
 
-### Slots
+### Composition
 
-| Slot | Description |
+| Piece | Description |
 | --- | --- |
-| *(default)* | Grid cells authored as `role="row"` / `role="gridcell"` children. Use the `RuiGrid` view for BEM classes. |
+| `children` | Grid cells authored as `role="row"` / `role="gridcell"` children. Use the `RuiGrid` view for BEM classes. |
 
 ### Props
 

--- a/apps/radiant-ui/src/content/components/input.mdx
+++ b/apps/radiant-ui/src/content/components/input.mdx
@@ -4,16 +4,14 @@ description: Inputs capture single-line text, numbers, emails, and other native 
 category: Forms
 ---
 
-import { meta as InputMeta, Default, WithInputGroup } from '@/content/stories/input';
-import Canvas from '@/components/component-docs/canvas';
+import { meta as InputMeta, Default } from '@/content/stories/input';
 import Demo from '@/components/component-docs/demo';
 
 export const config = {
 	dependencies: {
-		components: [Canvas, Demo],
+		components: [Demo],
 		scripts: [
 			'../../components/component-docs/demo.script.tsx',
-			'../../components/component-docs/canvas.script.tsx',
 			'../../components/component-docs/controls.script.tsx',
 		],
 	},
@@ -58,8 +56,6 @@ import { RuiLabel } from '@ecopages/radiant-ui/label';
 ## Input groups
 
 <p>Use `RuiInputGroup` to add leading prefixes, trailing icons, or inline buttons around `RuiInput`. See the [Input Group](/docs/components/input-group) page for the full API.</p>
-
-<Canvas of={WithInputGroup} meta={InputMeta} />
 
 ```tsx
 import { RuiField } from '@ecopages/radiant-ui/field';

--- a/apps/radiant-ui/src/content/components/input.mdx
+++ b/apps/radiant-ui/src/content/components/input.mdx
@@ -4,7 +4,7 @@ description: Inputs capture single-line text, numbers, emails, and other native 
 category: Forms
 ---
 
-import { meta as InputMeta, Default } from '@/content/stories/input';
+import { meta as InputMeta, Default, WithInputGroup } from '@/content/stories/input';
 import Canvas from '@/components/component-docs/canvas';
 import Demo from '@/components/component-docs/demo';
 
@@ -54,6 +54,33 @@ import { RuiLabel } from '@ecopages/radiant-ui/label';
 ## Input masks
 
 <p>Pass a `mask` pattern for structured entry like phone numbers or credit card segments.</p>
+
+## Input groups
+
+<p>Use `RuiInputGroup` to add leading prefixes, trailing icons, or inline buttons around `RuiInput`. See the [Input Group](/docs/components/input-group) page for the full API.</p>
+
+<Canvas of={WithInputGroup} meta={InputMeta} />
+
+```tsx
+import { RuiField } from '@ecopages/radiant-ui/field';
+import { RuiInput } from '@ecopages/radiant-ui/input';
+import {
+  RuiInputGroup,
+  RuiInputGroupAddon,
+  RuiInputGroupText,
+} from '@ecopages/radiant-ui/input-group';
+import { RuiLabel } from '@ecopages/radiant-ui/label';
+
+<RuiField name="url">
+  <RuiLabel>Website URL</RuiLabel>
+  <RuiInputGroup>
+    <RuiInputGroupAddon>
+      <RuiInputGroupText>https://</RuiInputGroupText>
+    </RuiInputGroupAddon>
+    <RuiInput placeholder="example.com" />
+  </RuiInputGroup>
+</RuiField>
+```
 
 ## Theming
 

--- a/apps/radiant-ui/src/content/components/listbox.mdx
+++ b/apps/radiant-ui/src/content/components/listbox.mdx
@@ -63,7 +63,7 @@ Override at the theme layer (`tokens/presets/colors/*.css`), not in component CS
 
 ## API
 
-`RuiListbox` is a custom element (`<rui-listbox>`) that renders a `role="listbox"` surface around slotted options.
+`RuiListbox` is a custom element (`<rui-listbox>`) that renders a `role="listbox"` surface around composed options.
 
 ### Attributes
 
@@ -75,11 +75,11 @@ Override at the theme layer (`tokens/presets/colors/*.css`), not in component CS
 | `embedded` | `boolean` | `false` | Parent-owned listbox: border chrome omitted, selection handled by the parent. |
 | `bordered` | `boolean` | follows `embedded` | Override the border (`true` standalone, `false` embedded). |
 
-### Slots
+### Composition
 
-| Slot | Description |
+| Piece | Description |
 | --- | --- |
-| *(default)* | Option elements (`RuiListboxOption`), each with `role="option"`. |
+| `children` | Option elements (`RuiListboxOption`), each with `role="option"`. |
 
 ### Events
 

--- a/apps/radiant-ui/src/content/components/menu-button.mdx
+++ b/apps/radiant-ui/src/content/components/menu-button.mdx
@@ -76,12 +76,12 @@ The trigger shares control geometry (`--size-control-md`, `--space-control-x`, `
 | `open` | `boolean` | `false` | Whether the menu starts open. |
 | `placement` | `top` · `top-start` · `top-end` · `right` · `right-start` · `right-end` · `bottom` · `bottom-start` · `bottom-end` · `left` · `left-start` · `left-end` | `bottom-start` | Placement of the menu surface relative to its trigger. |
 
-### Slots
+### Composition
 
-| Slot | Description |
+| Piece | Description |
 | --- | --- |
 | `trigger` | Label for the menu button. |
-| *(default)* | Menu items (`role="menuitem"`), typically buttons or anchors. |
+| `children` | Menu items (`role="menuitem"`), typically buttons or anchors. |
 
 ### Events
 

--- a/apps/radiant-ui/src/content/components/menubar.mdx
+++ b/apps/radiant-ui/src/content/components/menubar.mdx
@@ -69,11 +69,11 @@ Geometry shares control tokens (`--size-control-*`, `--space-control-*`, `--radi
 | --- | --- | --- | --- |
 | `label` | `string` | `''` | Accessible name for the menubar landmark. |
 
-### Slots
+### Composition
 
-| Slot | Description |
+| Piece | Description |
 | --- | --- |
-| *(default)* | Top-level menu roots (`[data-ref="menubar-root"]`). |
+| `children` | Top-level menu roots (`[data-ref="menubar-root"]`). |
 
 ### Events
 

--- a/apps/radiant-ui/src/content/components/meter.mdx
+++ b/apps/radiant-ui/src/content/components/meter.mdx
@@ -69,7 +69,7 @@ Meters use the **surface / text roles** from the active theme (`--on-surface` fo
 | `max` | `number` | `100` | Range maximum. |
 | `label` | `string` | `''` | Text describing what is measured (accessible name). |
 
-### Slots
+### Composition
 
 The meter is self-contained; `label`, bar, and value are composed by the element. Pass content via props, not slotted children.
 

--- a/apps/radiant-ui/src/content/components/navigation-menu.mdx
+++ b/apps/radiant-ui/src/content/components/navigation-menu.mdx
@@ -68,7 +68,7 @@ Override roles at the theme layer, not in component CSS.
 
 ## API
 
-`RuiNavigationMenu` is a custom element (`<rui-navigation-menu>`) rendering a `nav` landmark. Compose the view helpers for triggers, links, and panels, or use the slots directly.
+`RuiNavigationMenu` is a custom element (`<rui-navigation-menu>`) rendering a `nav` landmark. Compose the view helpers for triggers, links, and panels, using `RuiNavigationMenuBar` and `RuiNavigationMenuPanels`.
 
 ### Attributes
 
@@ -76,21 +76,23 @@ Override roles at the theme layer, not in component CSS.
 | --- | --- | --- | --- |
 | `label` | `string` | `''` | Accessible name for the `nav` landmark. |
 
-### Slots
+### Composition
 
-| Slot | Description |
+| Piece | Description |
 | --- | --- |
-| `triggers` | Top-level navigation triggers and plain links. |
-| `panels` | Disclosure panels composed from other primitives. |
+| `RuiNavigationMenuBar` | Top-level triggers and plain links. |
+| `RuiNavigationMenuPanels` | Megamenu panels paired with triggers by `value`. |
 
 ### View helpers
 
-| Component | Renders | Slot |
+| Component | Renders | Placement |
 | --- | --- | --- |
-| `RuiNavigationMenu` | `<rui-navigation-menu>` | |
-| `RuiNavigationMenuTrigger` | `RuiButton` trigger | `triggers` |
-| `RuiNavigationMenuLink` | Anchor styled as a button | `triggers` |
-| `RuiNavigationMenuPanel` | Panel `div` | `panels` |
+| `RuiNavigationMenu` | `<rui-navigation-menu>` with view-owned `nav` shell | Root |
+| `RuiNavigationMenuBar` | Trigger / link row | Inside menu root |
+| `RuiNavigationMenuPanels` | Panel region | Inside menu root |
+| `RuiNavigationMenuTrigger` | `RuiButton` trigger | Inside `RuiNavigationMenuBar` |
+| `RuiNavigationMenuLink` | Anchor styled as a button | Inside `RuiNavigationMenuBar` |
+| `RuiNavigationMenuPanel` | Panel `div` | Inside `RuiNavigationMenuPanels` |
 
 ### CSS classes
 

--- a/apps/radiant-ui/src/content/components/number-field.mdx
+++ b/apps/radiant-ui/src/content/components/number-field.mdx
@@ -99,9 +99,9 @@ Geometry shares control tokens (`--size-control-sm`, `--space-control-*`, `--rad
 | `decrement-aria-label` | `string` | `Decrement` | Accessible name for the decrement stepper. |
 | `wheel-disabled` | `boolean` | `false` | Disables scroll-wheel value changes. |
 
-### Slots
+### Composition
 
-| Slot | Description |
+| Piece | Description |
 | --- | --- |
 | `group` | Input + stepper row (`RuiNumberFieldGroup`). |
 | `input` | Text input (`RuiNumberFieldInput`). |
@@ -116,7 +116,7 @@ Geometry shares control tokens (`--size-control-sm`, `--space-control-*`, `--rad
 
 ### View helpers
 
-| Component | Renders | Slot |
+| Component | Renders | Placement |
 | --- | --- | --- |
 | `RuiNumberFieldGroup` | Input + stepper row | `group` |
 | `RuiNumberFieldInput` | Text input (`role="spinbutton"`) | `input` |

--- a/apps/radiant-ui/src/content/components/popover.mdx
+++ b/apps/radiant-ui/src/content/components/popover.mdx
@@ -94,9 +94,9 @@ Overrides go at the theme layer, not in component CSS.
 | --- | --- | --- | --- |
 | `open` | `boolean` | `false` | Whether the popover starts open. |
 
-### Slots
+### Composition
 
-| Component | Slot | Description |
+| Component | Piece | Description |
 | --- | --- | --- |
 | `RuiPopover` | `trigger` | Pressable anchor (when not using an external `anchor`). |
 | `RuiPopover` | `content` | Popover body rendered inside the floating surface. |

--- a/apps/radiant-ui/src/content/components/radio-group.mdx
+++ b/apps/radiant-ui/src/content/components/radio-group.mdx
@@ -76,14 +76,14 @@ The custom control dot is decorative (`aria-hidden`), the visually hidden native
 | --- | --- | --- | --- |
 | `value` | `string` | `''` | Selected radio value. |
 | `name` | `string` | `''` | Form field name shared by all radios in the group. |
-| `label` | `string` | `''` | Accessible name when no visible legend is slotted. |
+| `label` | `string` | `''` | Accessible name when no visible legend is composed in the view. |
 | `disabled` | `boolean` | `false` | Disables every radio in the group. |
 
-### Slots
+### Composition
 
-| Slot | Description |
+| Piece | Description |
 | --- | --- |
-| *(default)* | One or more `<label>` children, each wrapping a radio input with a unique `value`. |
+| `children` | One or more `<label>` children, each wrapping a radio input with a unique `value`. |
 
 ### Events
 

--- a/apps/radiant-ui/src/content/components/select.mdx
+++ b/apps/radiant-ui/src/content/components/select.mdx
@@ -97,7 +97,7 @@ Geometry shares control tokens (`--size-control-*`, `--radius-control`, `--space
 
 ### View helpers
 
-| Component | Renders | Slot |
+| Component | Renders | Placement |
 | --- | --- | --- |
 | `RuiSelectControl` | Trigger row wrapper | `trigger` |
 | `RuiSelectTrigger` | Value button (`role="combobox"`) | |

--- a/apps/radiant-ui/src/content/components/slider.mdx
+++ b/apps/radiant-ui/src/content/components/slider.mdx
@@ -30,7 +30,7 @@ export const config = {
 
 ## Usage
 
-Set `min`, `max`, and `step` to define the range. Use `variant="range"` with `rangeMin` and `rangeMax` for dual-thumb selection.
+Set `min`, `max`, and `step` to define the range. Use `variant="range"` with `rangeMin` and `rangeMax` for dual-thumb selection. Set `orientation="vertical"` for a vertical track.
 
 ```tsx
 import { RuiSlider } from '@ecopages/radiant-ui/slider';
@@ -60,21 +60,33 @@ Slider surfaces map to **semantic surface roles**, never Tailwind palette steps:
 | Track (`.rui-slider__range-track`) | `surface` |
 | Fill (`.rui-slider__range-fill`) | `primary` |
 | Thumb (`.rui-slider__thumb`) | `background` surface, `primary` border, `shadow-sm` |
-| Native input (`.rui-slider__input`) | `primary` accent |
+| Hidden input | form value (`name`, plus `name-max` in range mode) |
 | Value readout (`.rui-slider__value`) | `on-surface` |
 | Focus ring | `focus-ring` |
 
 Range thumb positions come from `--rui-slider-min` / `--rui-slider-max`, set inline by the element from the live range, not theme tokens. Override at the theme layer, not in component CSS.
 
+Range mode also accepts presentation variables on `rui-slider`. Set track and thumb corner radii independently — they follow shape tokens such as `--radius-control` and `--radius-container`:
+
+```css
+rui-slider {
+  --rui-slider-track-radius: var(--radius-container);
+  --rui-slider-thumb-radius: var(--radius-control);
+}
+```
+
+Switching the radius pack (sharp, default, soft) updates both when they reference shape tokens.
+
 ## API
 
-`RuiSlider` is a custom element (`<rui-slider>`); the view is a thin passthrough that maps `values` to `rangeMin` / `rangeMax`.
+`RuiSlider` owns the light-DOM surface. Pass `showValue` for the default readout, `valueTitle` for hover tooltips, or compose a custom readout with `RuiSliderValue`.
 
 ### Attributes
 
 | Attribute | Type | Default | Description |
 | --- | --- | --- | --- |
 | `variant` | `single` · `range` | `single` | Single-thumb or dual-thumb range. |
+| `orientation` | `horizontal` · `vertical` | `horizontal` | Track axis. |
 | `value` | `number` | `50` | Selected value (single mode). |
 | `range-min` | `number` | `25` | Lower thumb value (range mode). |
 | `range-max` | `number` | `75` | Upper thumb value (range mode). |
@@ -83,8 +95,11 @@ Range thumb positions come from `--rui-slider-min` / `--rui-slider-max`, set inl
 | `step` | `number` | `1` | Arrow-key and pointer snap interval. |
 | `min-distance` | `number` | `0` | Minimum gap enforced between range thumbs. |
 | `disabled` | `boolean` | `false` | Disables interaction. |
+| `read-only` | `boolean` | `false` | Prevents value changes while leaving thumbs focusable. |
 | `label` | `string` | `''` | Accessible name for the slider. |
-| `name` | `string` | `''` | Form field name (single mode native input). |
+| `name` | `string` | `''` | Form field name. Range mode also submits `{name}-max`. |
+| `show-value` | `boolean` | `false` | Shows the default value readout below the track. |
+| `value-title` | `boolean` | `false` | Mirrors the live value in the control `title` on hover. |
 
 ### Events
 
@@ -100,13 +115,13 @@ Public BEM classes (documented via `@cssclass` on the element):
 | --- | --- |
 | `.rui-slider` | Root; wraps the label, track, and value readout. |
 | `.rui-slider--range` | Range-mode surface. |
+| `.rui-slider--vertical` | Vertical track layout. |
 | `.rui-slider__label` | Optional visible label. |
-| `.rui-slider__input` | Native range input (single mode). |
 | `.rui-slider__value` | Live numeric readout. |
-| `.rui-slider__range` | Range-mode track wrapper. |
-| `.rui-slider__range-track` | Track surface behind both thumbs. |
-| `.rui-slider__range-fill` | Filled span between the thumbs. |
-| `.rui-slider__thumb` | Range thumb (`role="slider"`). |
+| `.rui-slider__range` | Track wrapper. |
+| `.rui-slider__range-track` | Track surface behind the thumb(s). |
+| `.rui-slider__range-fill` | Filled span from the origin to the current value (single) or between thumbs (range). |
+| `.rui-slider__thumb` | Thumb button (`role="slider"`). |
 
 ### Theme roles
 
@@ -117,6 +132,24 @@ Public BEM classes (documented via `@cssclass` on the element):
 | Thumb surface | `--background` |
 | Value readout | `--on-surface` |
 | Focus | `--focus-ring` |
+
+### Component CSS variables
+
+Set on `rui-slider`. Defaults shown; all accept any length or shape token.
+
+| Variable | Default | Applies to |
+| --- | --- | --- |
+| `--rui-slider-track-size` | `0.375rem` | Track thickness |
+| `--rui-slider-track-length` | `12rem` | Max track length (vertical / horizontal cap) |
+| `--rui-slider-track-color` | `--surface` | Track background |
+| `--rui-slider-fill-color` | `--primary` | Selected range fill |
+| `--rui-slider-track-radius` | `--radius-control` | Track and fill corner radius |
+| `--rui-slider-thumb-size` | `1.25rem` | Thumb width and height |
+| `--rui-slider-thumb-radius` | `--radius-control` | Thumb corner radius |
+| `--rui-slider-thumb-border-width` | `2px` | Thumb border |
+| `--rui-slider-thumb-border-color` | `--primary` | Thumb border color |
+| `--rui-slider-thumb-background` | `--background` | Thumb fill |
+| `--rui-slider-thumb-shadow` | `0 2px 8px rgb(0 0 0 / 0.12)` | Thumb shadow |
 
 ## Accessibility
 

--- a/apps/radiant-ui/src/content/components/switch.mdx
+++ b/apps/radiant-ui/src/content/components/switch.mdx
@@ -65,7 +65,7 @@ Label text uses `on-background`; track uses the `rounded-pill` radius token. Ove
 
 ## API
 
-`RuiSwitch` is a custom element (`<rui-switch>`) rendering a native `<input type="checkbox" role="switch">` inside a `<label>`, the browser owns activation and Space-to-toggle.
+`RuiSwitch` renders a view-owned `<label>` and native `<input type="checkbox" role="switch">` inside the coordinating `<rui-switch>` custom element. Use the JSX view or compose equivalent marked-up light DOM; the browser owns activation and Space-to-toggle.
 
 ### Attributes (`<rui-switch>`)
 
@@ -75,11 +75,11 @@ Label text uses `on-background`; track uses the `rounded-pill` radius token. Ove
 | `disabled` | `boolean` | `false` | Disabled state. |
 | `name` | `string` | `''` | Form field name. |
 
-### Slots
+### Composition
 
-| Slot | Description |
+| Piece | Description |
 | --- | --- |
-| (default) | Visible label for the switch. Must not change with state. |
+| `RuiSwitch` children | Visible label for the switch. Must not change with state. |
 
 ### Events
 

--- a/apps/radiant-ui/src/content/components/tabs.mdx
+++ b/apps/radiant-ui/src/content/components/tabs.mdx
@@ -89,9 +89,9 @@ Overrides go at the theme layer, not in component CSS.
 | `label` | `string` | `''` | Accessible name for the tab list (prefer `aria-label` on `RuiTabList`). |
 | `automatic` | `boolean` | `true` | Automatic (focus activates) vs manual (Enter/Space) activation. |
 
-### Slots
+### Composition
 
-| Slot | Description |
+| Piece | Description |
 | --- | --- |
 | (default) | `RuiTabList` and `RuiTabPanels` (or matching tablist / tabpanel markup). |
 

--- a/apps/radiant-ui/src/content/components/tag-group.mdx
+++ b/apps/radiant-ui/src/content/components/tag-group.mdx
@@ -74,11 +74,11 @@ Override roles at the theme layer, not in component CSS.
 | `selection-mode` | `single` · `multiple` | `multiple` | Allow one or many selected tags. |
 | `embedded` | `boolean` | `false` | Disable selection when a parent component owns the selected values. |
 
-### Slots
+### Composition
 
-| Slot | Description |
+| Piece | Description |
 | --- | --- |
-| *(default)* | Tag content, `RuiTagList` / `RuiTag` / `RuiTagRemove`, or `data-tag` markup. |
+| `children` | Tag content, `RuiTagList` / `RuiTag` / `RuiTagRemove`, or `data-tag` markup. |
 
 ### Events
 

--- a/apps/radiant-ui/src/content/components/toolbar.mdx
+++ b/apps/radiant-ui/src/content/components/toolbar.mdx
@@ -68,11 +68,11 @@ Geometry shares control tokens (`--size-control-*`, `--space-control-*`) with `R
 | `label` | `string` | `''` | Accessible name for the toolbar region. |
 | `exclusive-toggles` | `boolean` | `false` | Only one toggle button stays pressed at a time. |
 
-### Slots
+### Composition
 
-| Slot | Description |
+| Piece | Description |
 | --- | --- |
-| *(default)* | Toolbar controls, buttons, links, inputs, selects. |
+| `children` | Toolbar controls, buttons, links, inputs, selects. |
 
 ### CSS classes
 

--- a/apps/radiant-ui/src/content/components/tooltip.mdx
+++ b/apps/radiant-ui/src/content/components/tooltip.mdx
@@ -64,7 +64,7 @@ Text uses the `text-xs` token. Override roles at the theme layer, not in compone
 
 ## API
 
-`RuiTooltip` is a custom element (`<rui-tooltip>`) that shows a `role="tooltip"` surface on hover or focus of its slotted trigger, referenced via `aria-describedby`.
+`RuiTooltip` is a custom element (`<rui-tooltip>`) that shows a `role="tooltip"` surface on hover or focus of its composed trigger, referenced via `aria-describedby`.
 
 ### Attributes (`<rui-tooltip>`)
 
@@ -74,9 +74,9 @@ Text uses the `text-xs` token. Override roles at the theme layer, not in compone
 | `placement` | `RuiPlacement` | `top` | Placement relative to the anchor. |
 | `delay` | `number` | `200` | Show delay in ms (0 shows immediately). |
 
-### Slots
+### Composition
 
-| Slot | Description |
+| Piece | Description |
 | --- | --- |
 | (default) | The trigger element (typically a button or focusable control). |
 
@@ -87,7 +87,7 @@ Public BEM classes (documented via `@cssclass`):
 | Class | Description |
 | --- | --- |
 | `.rui-tooltip` | Root wrapper. |
-| `.rui-tooltip__trigger` | Host wrapper for the slotted trigger. |
+| `.rui-tooltip__trigger` | Host wrapper for the composed trigger. |
 | `.rui-tooltip__content` | Tooltip surface (`role="tooltip"`); `on-background` fill. |
 
 ### Theme roles

--- a/apps/radiant-ui/src/content/components/tree.mdx
+++ b/apps/radiant-ui/src/content/components/tree.mdx
@@ -71,11 +71,11 @@ Override at the theme layer, not in component CSS.
 | `label` | `string` | `''` | Accessible name for the tree. |
 | `value` | `string` | `''` | Selected item's `data-value` / id. |
 
-### Slots
+### Composition
 
-| Slot | Description |
+| Piece | Description |
 | --- | --- |
-| *(default)* | Tree items authored as `role="treeitem"` markup. |
+| `children` | Tree items authored as `role="treeitem"` markup. |
 
 ### Events
 

--- a/apps/radiant-ui/src/content/components/treegrid.mdx
+++ b/apps/radiant-ui/src/content/components/treegrid.mdx
@@ -72,11 +72,11 @@ Override at the theme layer, not in component CSS.
 | `label` | `string` | `''` | Accessible name for the treegrid. |
 | `value` | `string` | `''` | Selected row's `data-row-id`. |
 
-### Slots
+### Composition
 
-| Slot | Description |
+| Piece | Description |
 | --- | --- |
-| *(default)* | Rows and groups authored as `role="row"` / `role="rowgroup"` markup. |
+| `children` | Rows and groups authored as `role="row"` / `role="rowgroup"` markup. |
 
 ### Events
 

--- a/apps/radiant-ui/src/content/components/window-splitter.mdx
+++ b/apps/radiant-ui/src/content/components/window-splitter.mdx
@@ -74,9 +74,9 @@ Override at the theme layer, not in component CSS.
 | `orientation` | `horizontal` · `vertical` | `horizontal` | Split axis. |
 | `label` | `string` | `Split view` | Accessible name for the separator. |
 
-### Slots
+### Composition
 
-| Slot | Description |
+| Piece | Description |
 | --- | --- |
 | `primary` | First pane content. |
 | `secondary` | Second pane content. |

--- a/packages/radiant-ui/src/components/ui/breadcrumb/breadcrumb.script.tsx
+++ b/packages/radiant-ui/src/components/ui/breadcrumb/breadcrumb.script.tsx
@@ -11,11 +11,6 @@ export type RuiBreadcrumbProps = {
 	separator?: string;
 };
 
-type RuiBreadcrumbBindings = {
-	label: string;
-	separator: string;
-};
-
 /**
  * `<rui-breadcrumb>` — a trail of links to ancestor pages in hierarchical order.
  *
@@ -24,33 +19,16 @@ type RuiBreadcrumbBindings = {
  *
  * Compose with the JSX helpers (`RuiBreadcrumbList`, `RuiBreadcrumbItem`,
  * `RuiBreadcrumbLink`, `RuiBreadcrumbPage`, `RuiBreadcrumbSeparator`,
- * `RuiBreadcrumbEllipsis`), or author equivalent light-DOM markup into the slot.
+ * `RuiBreadcrumbEllipsis`).
  *
  * @see https://www.w3.org/WAI/ARIA/apg/patterns/breadcrumb/
  *
  * Keyboard interaction: standard link navigation (`Tab`, `Enter`).
  *
  * @element rui-breadcrumb
- * @slot - Authored breadcrumb list markup.
  */
 @customElement('rui-breadcrumb')
-export class RuiBreadcrumb extends RadiantElement<RuiBreadcrumbBindings> {
+export class RuiBreadcrumb extends RadiantElement {
 	@prop({ type: String, defaultValue: 'Breadcrumb' }) label: string;
 	@prop({ type: String, defaultValue: '/' }) separator: string;
-
-	private readonly resolvedAriaLabel = this.$.label.map((label) => label || 'Breadcrumb');
-	private readonly separatorStyle = this.$.separator.map(
-		(separator) =>
-			({
-				'--rui-breadcrumb-separator': JSON.stringify(separator || '/'),
-			}) as Record<string, string>,
-	);
-
-	override render() {
-		return (
-			<nav class="rui-breadcrumb" aria-label={this.resolvedAriaLabel} style={this.separatorStyle}>
-				<slot></slot>
-			</nav>
-		);
-	}
 }

--- a/packages/radiant-ui/src/components/ui/breadcrumb/breadcrumb.tsx
+++ b/packages/radiant-ui/src/components/ui/breadcrumb/breadcrumb.tsx
@@ -12,8 +12,20 @@ export type RuiBreadcrumbViewProps = JsxCustomElementAttributes<RuiBreadcrumbEle
  *
  * @cssclass rui-breadcrumb - `<nav>` landmark root.
  */
-export function RuiBreadcrumb({ children, ...props }: RuiBreadcrumbViewProps) {
-	return <rui-breadcrumb {...props}>{children}</rui-breadcrumb>;
+export function RuiBreadcrumb({ children, label, separator, ...props }: RuiBreadcrumbViewProps) {
+	const resolvedLabel = label || 'Breadcrumb';
+	const resolvedSeparator = separator || '/';
+	return (
+		<rui-breadcrumb {...props} label={label} separator={separator}>
+			<nav
+				class="rui-breadcrumb"
+				aria-label={resolvedLabel}
+				style={{ '--rui-breadcrumb-separator': JSON.stringify(resolvedSeparator) }}
+			>
+				{children}
+			</nav>
+		</rui-breadcrumb>
+	);
 }
 
 export type RuiBreadcrumbListProps = JsxElementProps<HTMLOListElement>;

--- a/packages/radiant-ui/src/components/ui/button/button.css
+++ b/packages/radiant-ui/src/components/ui/button/button.css
@@ -125,10 +125,9 @@
 		font-size: var(--text-body);
 	}
 
-	.rui-button--icon {
-		height: var(--size-control-md);
-		width: var(--size-control-md);
+	.rui-button--square {
 		padding-inline: 0;
+		aspect-ratio: 1;
 		font-size: var(--text-control, 0.875rem);
 	}
 

--- a/packages/radiant-ui/src/components/ui/button/button.tsx
+++ b/packages/radiant-ui/src/components/ui/button/button.tsx
@@ -9,6 +9,8 @@ type RuiButtonChrome = {
 	variant?: RuiButtonVariant;
 	/** Control size. Default: `md` (Default in docs). Use `none` for inline `link` chrome. */
 	size?: RuiButtonSize;
+	/** Makes a control-sized button square, for example for an icon-only action. */
+	square?: boolean;
 };
 
 export type RuiButtonControlProps = JsxElementProps<HTMLButtonElement> &
@@ -73,7 +75,8 @@ function invokeClickListener(listener: unknown, event: Event) {
  * @remarks
  * Default/`md` height uses `--size-control-md`, the same token as `RuiInput`, so
  * form rows align. `none` omits fixed height and padding for inline `link`
- * actions. Styles live in `./button.css`.
+ * actions. `square` makes the selected control size equal on both axes, making
+ * it suitable for icon-only actions. Styles live in `./button.css`.
  *
  * Variant tones map to semantic action roles — `primary` for filled, `error`
  * (destructive) for destructive — never palette steps.
@@ -90,10 +93,11 @@ function invokeClickListener(listener: unknown, event: Event) {
  * @cssclass rui-button--sm - Small control height.
  * @cssclass rui-button--md - Default control height.
  * @cssclass rui-button--lg - Large control height.
+ * @cssclass rui-button--square - Square control for icon-only actions.
  */
 export function RuiButton(props: RuiButtonProps) {
 	if (props.href !== undefined) {
-		const { href, target, rel, download, children, class: className, variant, size, ...host } = props;
+		const { href, target, rel, download, children, class: className, variant, size, square, ...host } = props;
 
 		return (
 			<a
@@ -102,7 +106,7 @@ export function RuiButton(props: RuiButtonProps) {
 				target={target}
 				rel={rel}
 				download={download}
-				class={cx('rui-button', `rui-button--${variant ?? 'filled'}`, `rui-button--${size ?? 'md'}`, className)}
+				class={cx('rui-button', `rui-button--${variant ?? 'filled'}`, `rui-button--${size ?? 'md'}`, square && 'rui-button--square', className)}
 			>
 				{children}
 			</a>
@@ -112,6 +116,7 @@ export function RuiButton(props: RuiButtonProps) {
 	const {
 		variant,
 		size,
+		square,
 		class: className,
 		children,
 		type = 'button',
@@ -136,7 +141,7 @@ export function RuiButton(props: RuiButtonProps) {
 		<button
 			{...host}
 			type={type}
-			class={cx('rui-button', `rui-button--${variant ?? 'filled'}`, `rui-button--${size ?? 'md'}`, className)}
+			class={cx('rui-button', `rui-button--${variant ?? 'filled'}`, `rui-button--${size ?? 'md'}`, square && 'rui-button--square', className)}
 			disabled={disabled}
 			aria-pressed={resolveAriaPressed(pressed, toggle, defaultPressed)}
 			data-toggle={toggle && pressed === undefined ? '' : undefined}

--- a/packages/radiant-ui/src/components/ui/carousel/carousel.script.tsx
+++ b/packages/radiant-ui/src/components/ui/carousel/carousel.script.tsx
@@ -5,6 +5,18 @@ export type RuiCarouselTransition = 'none' | 'slide' | 'fade';
 /** Where default prev/next chrome is laid out. `toolbar` places controls below the slide; `overlay` pins them to the slide edges. */
 export type RuiCarouselControlsVariant = 'toolbar' | 'overlay';
 
+/**
+ * Defaults the SSR shell depends on.
+ *
+ * @remarks Must match the host `@prop` defaults: the view composes classes and
+ * the accessible name from these before hydration.
+ */
+export const CAROUSEL_DEFAULTS = {
+	label: 'Carousel',
+	transition: 'none',
+	controlsVariant: 'toolbar',
+} as const;
+
 export type RuiCarouselProps = {
 	label?: string;
 	index?: number;
@@ -52,11 +64,6 @@ type RuiCarouselBindings = {
  * @attr {boolean} wrap - Keep controls enabled at the ends. Default: `true`.
  * @attr {number} slide-count - Authored slide count for render-time control state. Default: `0`.
  *
- * @slot - Slides, each marked with `data-slide` (see `RuiCarouselSlide`).
- * @slot prev - Optional custom previous control. Use `data-carousel-action="prev"`.
- * @slot next - Optional custom next control. Use `data-carousel-action="next"`.
- * @slot rotation - Optional play/pause control when `show-rotation-control` is set. Use `data-carousel-action="rotation"`.
- *
  * @cssclass rui-carousel - Root region (`aria-roledescription="carousel"`).
  * @cssclass rui-carousel--none - No animation between slides.
  * @cssclass rui-carousel--slide - Horizontal slide transition.
@@ -87,12 +94,12 @@ type RuiCarouselBindings = {
  */
 @customElement('rui-carousel')
 export class RuiCarousel extends RadiantElement<RuiCarouselBindings> {
-	@prop({ type: String, defaultValue: 'Carousel' }) label: string;
+	@prop({ type: String, defaultValue: CAROUSEL_DEFAULTS.label }) label: string;
 	@prop({ type: Number, reflect: true, defaultValue: 0 }) index: number;
 	@prop({ type: Boolean, reflect: true, defaultValue: false }) autoplay: boolean;
 	@prop({ type: Number, defaultValue: 4000 }) interval: number;
-	@prop({ type: String, defaultValue: 'none' }) transition: RuiCarouselTransition;
-	@prop({ type: String, defaultValue: 'toolbar', attribute: 'controls-variant' })
+	@prop({ type: String, defaultValue: CAROUSEL_DEFAULTS.transition }) transition: RuiCarouselTransition;
+	@prop({ type: String, defaultValue: CAROUSEL_DEFAULTS.controlsVariant, attribute: 'controls-variant' })
 	controlsVariant: RuiCarouselControlsVariant;
 	@prop({ type: Boolean, defaultValue: false }) showIndicators: boolean;
 	@prop({ type: Boolean, defaultValue: false }) showRotationControl: boolean;
@@ -108,17 +115,14 @@ export class RuiCarousel extends RadiantElement<RuiCarouselBindings> {
 	private swipeStartX = 0;
 	private swipeStartY = 0;
 
-	override connectedCallback(): void {
-		super.connectedCallback();
-		queueMicrotask(() => {
-			if (this.autoplay && this.prefersReducedMotion()) {
-				this.paused = true;
-			}
-			this.sync();
-			this.syncAutoplay();
-			this.syncIndicators();
-			this.syncAriaLive();
-		});
+	protected override onConnected(): void {
+		if (this.autoplay && this.prefersReducedMotion()) {
+			this.paused = true;
+		}
+		this.sync();
+		this.syncAutoplay();
+		this.syncIndicators();
+		this.syncAriaLive();
 	}
 
 	override disconnectedCallback(): void {
@@ -166,11 +170,6 @@ export class RuiCarousel extends RadiantElement<RuiCarouselBindings> {
 	private tabId(index: number): string {
 		return `${this.getCarouselId()}-tab-${index}`;
 	}
-
-	private shouldShowRotationControl(): boolean {
-		return this.autoplay || this.showRotationControl;
-	}
-
 	private syncSlideAccessibility(slides: HTMLElement[], activeIndex: number): void {
 		const count = slides.length;
 
@@ -579,159 +578,5 @@ export class RuiCarousel extends RadiantElement<RuiCarouselBindings> {
 		if (this.swipePointerId === event.pointerId) {
 			this.swipePointerId = null;
 		}
-	}
-
-	/**
-	 * Only `aria-label` is bound below. Everything else in this render() stays
-	 * a plain read — audited, not an outstanding gap:
-	 * - disablePrev/disableNext must apply uniformly to the default button AND
-	 *   any consumer-supplied `[data-carousel-action="prev"/"next"]` element
-	 *   slotted in (see syncPrevNextDisabled()) — a binding only patches this
-	 *   host's own template position, not a slotted replacement.
-	 * - playing/ariaLive derive from `paused` and the live `timer` handle,
-	 *   plain instance fields mutated across pointer/focus/keyboard handlers
-	 *   and `setInterval`, not reactive members — promoting them would add an
-	 *   explicit notify step at every one of those call sites for no behavior
-	 *   change and real drift risk.
-	 * - the indicator buttons are a variable-length list built with
-	 *   `replaceChildren()` (see syncIndicators()) — bindings patch one value
-	 *   at one position, they don't reconcile a dynamic list.
-	 */
-	override render() {
-		const showRotation = this.shouldShowRotationControl();
-		const slideCount = Math.max(this.getSlides().length, this.slideCount);
-		const normalized = this.normalizeIndex(this.index, slideCount || 1);
-		const disablePrev = !this.shouldWrap && slideCount > 0 && normalized <= 0;
-		const disableNext = !this.shouldWrap && slideCount > 0 && normalized >= slideCount - 1;
-		const playing = this.autoplay && !this.paused;
-		const ariaLive = playing && this.timer !== null ? 'off' : 'polite';
-		const overlay = this.controlsVariant === 'overlay';
-
-		queueMicrotask(() => {
-			this.sync();
-			this.syncIndicators();
-			this.syncRotationControl();
-			this.syncAriaLive();
-		});
-
-		const prevControl = (
-			<slot name="prev">
-				<button
-					type="button"
-					data-carousel-action="prev"
-					data-ref="prev"
-					class={`rui-carousel__nav rui-button rui-button--outline rui-button--sm${overlay ? ' rui-carousel__nav--overlay' : ' rui-carousel__nav--toolbar'}`}
-					aria-label="Previous slide"
-					disabled={disablePrev}
-				>
-					{overlay ? (
-						<span class="rui-carousel__nav-icon" aria-hidden="true">
-							‹
-						</span>
-					) : (
-						<span class="rui-carousel__nav-label">
-							<span class="rui-carousel__nav-icon" aria-hidden="true">
-								‹
-							</span>
-							Previous
-						</span>
-					)}
-				</button>
-			</slot>
-		);
-
-		const nextControl = (
-			<slot name="next">
-				<button
-					type="button"
-					data-carousel-action="next"
-					data-ref="next"
-					class={`rui-carousel__nav rui-button rui-button--outline rui-button--sm${overlay ? ' rui-carousel__nav--overlay' : ' rui-carousel__nav--toolbar'}`}
-					aria-label="Next slide"
-					disabled={disableNext}
-				>
-					{overlay ? (
-						<span class="rui-carousel__nav-icon" aria-hidden="true">
-							›
-						</span>
-					) : (
-						<span class="rui-carousel__nav-label">
-							Next
-							<span class="rui-carousel__nav-icon" aria-hidden="true">
-								›
-							</span>
-						</span>
-					)}
-				</button>
-			</slot>
-		);
-
-		const rotationControl = showRotation ? (
-			<slot name="rotation">
-				<button
-					type="button"
-					data-carousel-action="rotation"
-					data-ref="rotation"
-					class={`rui-carousel__rotation rui-button rui-button--ghost rui-button--sm${overlay ? ' rui-carousel__rotation--overlay' : ''}`}
-					aria-pressed={playing}
-					aria-label={playing ? 'Pause rotation' : 'Start rotation'}
-				>
-					{playing ? 'Pause' : 'Play'}
-				</button>
-			</slot>
-		) : null;
-
-		const indicators = this.showIndicators ? (
-			<div
-				class={`rui-carousel__indicators${overlay ? ' rui-carousel__indicators--overlay' : ''}`}
-				data-ref="indicators"
-				role="tablist"
-				aria-label="Choose slide to display"
-			/>
-		) : null;
-
-		const toolbarControls = (
-			<div class="rui-carousel__toolbar">
-				{showRotation ? <div class="rui-carousel__toolbar-rotation">{rotationControl}</div> : null}
-				<div class="rui-carousel__toolbar-side rui-carousel__toolbar-side--start">{prevControl}</div>
-				<div class="rui-carousel__toolbar-center">{indicators}</div>
-				<div class="rui-carousel__toolbar-side rui-carousel__toolbar-side--end">{nextControl}</div>
-			</div>
-		);
-
-		const overlayChrome = overlay ? (
-			<div class="rui-carousel__overlay-chrome">
-				{showRotation ? <div class="rui-carousel__overlay-rotation">{rotationControl}</div> : null}
-				<div class="rui-carousel__controls rui-carousel__controls--overlay">
-					{prevControl}
-					{nextControl}
-				</div>
-				{indicators}
-			</div>
-		) : null;
-
-		return (
-			<section
-				class={`rui-carousel rui-carousel--${this.transition} rui-carousel--controls-${this.controlsVariant}`}
-				data-ref="root"
-				aria-roledescription="carousel"
-				aria-label={this.$.label}
-			>
-				<div class="rui-carousel__stage">
-					<div class="rui-carousel__viewport" data-ref="viewport" aria-live={ariaLive} aria-atomic={false}>
-						<div
-							class="rui-carousel__track"
-							style={
-								this.transition === 'slide' ? { '--rui-carousel-index': String(this.index) } : undefined
-							}
-						>
-							<slot></slot>
-						</div>
-						{overlayChrome}
-					</div>
-				</div>
-				{!overlay ? <div class="rui-carousel__footer">{toolbarControls}</div> : null}
-			</section>
-		);
 	}
 }

--- a/packages/radiant-ui/src/components/ui/carousel/carousel.stories.tsx
+++ b/packages/radiant-ui/src/components/ui/carousel/carousel.stories.tsx
@@ -240,18 +240,9 @@ export const WithOverlayControls: Story = {
 export const CustomControls: Story = {
 	args: {
 		controlsVariant: 'overlay',
-		children: (
-			<>
-				<RuiCarouselPrev overlay />
-				<RuiCarouselNext overlay />
-				{slides.map((slide) => (
-					<div class="rui-carousel__slide" data-slide={slide.id}>
-						{slide.children}
-					</div>
-				))}
-			</>
-		),
-		slides: undefined,
+		prev: <RuiCarouselPrev overlay />,
+		next: <RuiCarouselNext overlay />,
+		slides,
 	},
 	play: async ({ canvasElement, step }) => {
 		const prev = getPrevButton(canvasElement);

--- a/packages/radiant-ui/src/components/ui/carousel/carousel.tsx
+++ b/packages/radiant-ui/src/components/ui/carousel/carousel.tsx
@@ -1,7 +1,13 @@
 import { type JsxCustomElementAttributes, type JsxElementProps, type JsxRenderable } from '@ecopages/jsx';
 import { withDefaultAriaLabel } from '@/aria';
 import { cx } from '@/lib/cx';
-import type { RuiCarousel as RuiCarouselElement, RuiCarouselProps } from './carousel.script';
+import {
+	CAROUSEL_DEFAULTS,
+	type RuiCarousel as RuiCarouselElement,
+	type RuiCarouselControlsVariant,
+	type RuiCarouselProps,
+	type RuiCarouselTransition,
+} from './carousel.script';
 import './carousel.script';
 
 export type RuiCarouselSlideData = { id: string; children: JsxRenderable };
@@ -11,7 +17,7 @@ export type RuiCarouselSlideProps = Omit<JsxElementProps<HTMLDivElement>, 'id'> 
 };
 
 /**
- * Slide in the default carousel slot (APG `group` / `tabpanel` roles are applied by the host).
+ * Slide in the carousel track (APG `group` / `tabpanel` roles are applied by the host).
  *
  * @cssclass rui-carousel__slide - Slide surface.
  */
@@ -52,17 +58,12 @@ function toolbarNextLabel() {
 }
 
 /**
- * Previous control slotted into `prev` by default.
+ * Previous carousel control.
  *
  * @cssclass rui-carousel__nav - Prev nav button (composed with `rui-button`).
- * @cssclass rui-carousel__nav--overlay - Circular on-slide chrome for `controls-variant="overlay"`.
- * @cssclass rui-carousel__nav--toolbar - Toolbar chrome (default).
- * @cssclass rui-carousel__nav-label - Icon + label row (toolbar variant).
- * @cssclass rui-carousel__nav-icon - Decorative chevron glyph.
  */
 export function RuiCarouselPrev({
 	children,
-	slot = 'prev',
 	class: className,
 	disabled,
 	overlay,
@@ -73,7 +74,6 @@ export function RuiCarouselPrev({
 		<button
 			{...props}
 			aria={withDefaultAriaLabel(aria, 'Previous slide')}
-			slot={slot}
 			type="button"
 			data-carousel-action="prev"
 			data-ref="prev"
@@ -96,18 +96,9 @@ export function RuiCarouselPrev({
 	);
 }
 
-/**
- * Next control slotted into `next` by default.
- *
- * @cssclass rui-carousel__nav - Next nav button (composed with `rui-button`).
- * @cssclass rui-carousel__nav--overlay - Circular on-slide chrome for `controls-variant="overlay"`.
- * @cssclass rui-carousel__nav--toolbar - Toolbar chrome (default).
- * @cssclass rui-carousel__nav-label - Icon + label row (toolbar variant).
- * @cssclass rui-carousel__nav-icon - Decorative chevron glyph.
- */
+/** Next carousel control. */
 export function RuiCarouselNext({
 	children,
-	slot = 'next',
 	class: className,
 	disabled,
 	overlay,
@@ -118,7 +109,6 @@ export function RuiCarouselNext({
 		<button
 			{...props}
 			aria={withDefaultAriaLabel(aria, 'Next slide')}
-			slot={slot}
 			type="button"
 			data-carousel-action="next"
 			data-ref="next"
@@ -145,15 +135,9 @@ export type RuiCarouselRotationProps = JsxElementProps<HTMLButtonElement> & {
 	overlay?: boolean;
 };
 
-/**
- * Play/pause rotation control slotted into `rotation` by default.
- *
- * @cssclass rui-carousel__rotation - Rotation toggle button (composed with `rui-button`).
- * @cssclass rui-carousel__rotation--overlay - Overlay pill chrome.
- */
+/** Play/pause rotation control when `autoplay` or `show-rotation-control` is set. */
 export function RuiCarouselRotation({
 	children,
-	slot = 'rotation',
 	class: className,
 	overlay,
 	aria,
@@ -163,7 +147,6 @@ export function RuiCarouselRotation({
 		<button
 			{...props}
 			aria={withDefaultAriaLabel(aria, 'Start rotation')}
-			slot={slot}
 			type="button"
 			data-carousel-action="rotation"
 			data-ref="rotation"
@@ -179,24 +162,135 @@ export function RuiCarouselRotation({
 	);
 }
 
+type CarouselShellProps = {
+	autoplay?: boolean;
+	children: JsxRenderable;
+	controlsVariant: RuiCarouselControlsVariant;
+	label: string;
+	next?: JsxRenderable;
+	prev?: JsxRenderable;
+	rotation?: JsxRenderable;
+	showIndicators?: boolean;
+	showRotationControl?: boolean;
+	transition: RuiCarouselTransition;
+};
+
+function CarouselShell({
+	autoplay,
+	children,
+	controlsVariant,
+	label,
+	next,
+	prev,
+	rotation,
+	showIndicators,
+	showRotationControl,
+	transition,
+}: CarouselShellProps) {
+	const overlay = controlsVariant === 'overlay';
+	const showRotation = autoplay || showRotationControl;
+	const prevControl = prev ?? <RuiCarouselPrev overlay={overlay} />;
+	const nextControl = next ?? <RuiCarouselNext overlay={overlay} />;
+	const rotationControl = showRotation ? (rotation ?? <RuiCarouselRotation overlay={overlay} />) : null;
+	const indicators = showIndicators ? (
+		<div
+			class={cx('rui-carousel__indicators', overlay && 'rui-carousel__indicators--overlay')}
+			data-ref="indicators"
+			role="tablist"
+			aria-label="Choose slide to display"
+		/>
+	) : null;
+
+	const toolbarControls = (
+		<div class="rui-carousel__toolbar">
+			{showRotation ? <div class="rui-carousel__toolbar-rotation">{rotationControl}</div> : null}
+			<div class="rui-carousel__toolbar-side rui-carousel__toolbar-side--start">{prevControl}</div>
+			<div class="rui-carousel__toolbar-center">{indicators}</div>
+			<div class="rui-carousel__toolbar-side rui-carousel__toolbar-side--end">{nextControl}</div>
+		</div>
+	);
+
+	const overlayChrome = overlay ? (
+		<div class="rui-carousel__overlay-chrome">
+			{showRotation ? <div class="rui-carousel__overlay-rotation">{rotationControl}</div> : null}
+			<div class="rui-carousel__controls rui-carousel__controls--overlay">
+				{prevControl}
+				{nextControl}
+			</div>
+			{indicators}
+		</div>
+	) : null;
+
+	return (
+		<section
+			class={cx('rui-carousel', `rui-carousel--${transition}`, `rui-carousel--controls-${controlsVariant}`)}
+			data-ref="root"
+			aria-roledescription="carousel"
+			aria-label={label}
+		>
+			<div class="rui-carousel__stage">
+				<div class="rui-carousel__viewport" data-ref="viewport">
+					<div class="rui-carousel__track">{children}</div>
+					{overlayChrome}
+				</div>
+			</div>
+			{!overlay ? <div class="rui-carousel__footer">{toolbarControls}</div> : null}
+		</section>
+	);
+}
+
 export function RuiCarousel({
 	slides,
 	children,
+	prev,
+	next,
+	rotation,
+	label = CAROUSEL_DEFAULTS.label,
+	transition = CAROUSEL_DEFAULTS.transition,
+	controlsVariant = CAROUSEL_DEFAULTS.controlsVariant,
+	showIndicators,
+	showRotationControl,
+	autoplay,
 	...props
-}: JsxCustomElementAttributes<RuiCarouselElement, RuiCarouselProps> & {
-	slides?: RuiCarouselSlideData[];
-}) {
-	if (children != null) {
-		return <rui-carousel {...props}>{children}</rui-carousel>;
+}: JsxCustomElementAttributes<
+	RuiCarouselElement,
+	RuiCarouselProps & {
+		slides?: RuiCarouselSlideData[];
+		prev?: JsxRenderable;
+		next?: JsxRenderable;
+		rotation?: JsxRenderable;
 	}
-
+>) {
 	const slideList = slides ?? [];
+	const slideContent =
+		slides != null
+			? slideList.map((slide) => <RuiCarouselSlide id={slide.id}>{slide.children}</RuiCarouselSlide>)
+			: children;
 
 	return (
-		<rui-carousel {...props} slideCount={slideList.length}>
-			{slideList.map((slide) => (
-				<RuiCarouselSlide id={slide.id}>{slide.children}</RuiCarouselSlide>
-			))}
+		<rui-carousel
+			{...props}
+			label={label}
+			transition={transition}
+			controlsVariant={controlsVariant}
+			showIndicators={showIndicators}
+			showRotationControl={showRotationControl}
+			autoplay={autoplay}
+			slideCount={slideList.length}
+		>
+			<CarouselShell
+				autoplay={autoplay}
+				controlsVariant={controlsVariant}
+				label={label}
+				next={next}
+				prev={prev}
+				rotation={rotation}
+				showIndicators={showIndicators}
+				showRotationControl={showRotationControl}
+				transition={transition}
+			>
+				{slideContent}
+			</CarouselShell>
 		</rui-carousel>
 	);
 }

--- a/packages/radiant-ui/src/components/ui/component-styles.ssr.test.ts
+++ b/packages/radiant-ui/src/components/ui/component-styles.ssr.test.ts
@@ -1,0 +1,76 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const componentDirectory = dirname(fileURLToPath(import.meta.url));
+const stylesDirectory = join(componentDirectory, '..', '..', 'styles');
+const componentImportPattern = /import\s+(?:type\s+)?\{([\s\S]*?)\}\s+from\s+'(\.\.\/[^']+)'/g;
+const primitiveStylePattern = /rui-(?:control-toggle|popover|floating|icon)|<RuiIcon[A-Z]/;
+const classStyleDependencies = [{ pattern: /rui-button/, component: 'button' }];
+
+type StyleDependencyManifest = {
+	components: Record<string, { direct: string[]; styles: string[] }>;
+};
+
+function renderedComponentName(bindings: string, viewSource: string): string | undefined {
+	const componentNames = bindings.match(/\bRui[A-Z]\w*/g) ?? [];
+	return componentNames.find((componentName) => new RegExp(`<${componentName}(?:\\s|/|>)`).test(viewSource));
+}
+
+function componentNameFromImport(importPath: string): string {
+	return importPath.slice(3).split('/')[0];
+}
+
+describe('component stylesheet dependencies', () => {
+	it('declares default-composition dependencies without inlining their styles', () => {
+		const manifest = JSON.parse(
+			readFileSync(join(stylesDirectory, 'style-dependencies.json'), 'utf8'),
+		) as StyleDependencyManifest;
+		const componentFolders = readdirSync(componentDirectory, { withFileTypes: true }).filter((entry) =>
+			entry.isDirectory(),
+		);
+		const componentNames = new Set(componentFolders.map((folder) => folder.name));
+
+		for (const folder of componentFolders) {
+			const viewPath = join(componentDirectory, folder.name, `${folder.name}.tsx`);
+			const stylesheetPath = join(componentDirectory, folder.name, `${folder.name}.css`);
+			let viewSource: string;
+			let stylesheetSource: string;
+
+			try {
+				viewSource = readFileSync(viewPath, 'utf8');
+				stylesheetSource = readFileSync(stylesheetPath, 'utf8');
+			} catch {
+				continue;
+			}
+
+			const expected = new Set<string>();
+			for (const match of viewSource.matchAll(componentImportPattern)) {
+				const [, bindings, importPath] = match;
+				const dependency = componentNameFromImport(importPath);
+				if (
+					dependency !== folder.name &&
+					componentNames.has(dependency) &&
+					renderedComponentName(bindings, viewSource)
+				) {
+					expected.add(dependency);
+				}
+			}
+
+			if (primitiveStylePattern.test(viewSource)) {
+				expected.add('primitives');
+			}
+			for (const dependency of classStyleDependencies) {
+				if (dependency.component !== folder.name && dependency.pattern.test(viewSource)) {
+					expected.add(dependency.component);
+				}
+			}
+
+			expect(manifest.components[folder.name]?.direct, `${folder.name} style dependencies`).toEqual(
+				[...expected].sort(),
+			);
+			expect(stylesheetSource, `${folder.name} stylesheet must stay atomic`).not.toMatch(/^@import /m);
+		}
+	});
+});

--- a/packages/radiant-ui/src/components/ui/date-field/date-field.css
+++ b/packages/radiant-ui/src/components/ui/date-field/date-field.css
@@ -1,6 +1,4 @@
 @reference '../../../styles/radiant-ui.css';
-@import '../shared/control-toggle.css';
-@import '../shared/popover.css';
 
 rui-date-field {
 	@apply relative inline-flex w-full;

--- a/packages/radiant-ui/src/components/ui/date-field/date-field.stories.tsx
+++ b/packages/radiant-ui/src/components/ui/date-field/date-field.stories.tsx
@@ -20,12 +20,7 @@ const meta = {
 	parameters: {
 		radiant: {
 			element: RuiDateFieldElement,
-			cssImports: [
-				'./date-field.css',
-				'../shared/control-toggle.css',
-				'../../../lib/icons/icons.css',
-				'../calendar/calendar.css',
-			],
+			cssImports: ['../../../styles/primitives.css', '../calendar/calendar.css', './date-field.css'],
 		},
 	},
 	args: {

--- a/packages/radiant-ui/src/components/ui/date-range-picker/date-range-picker.css
+++ b/packages/radiant-ui/src/components/ui/date-range-picker/date-range-picker.css
@@ -1,6 +1,4 @@
 @reference '../../../styles/radiant-ui.css';
-@import '../shared/control-toggle.css';
-@import '../shared/popover.css';
 
 rui-date-range-picker {
 	@apply relative inline-flex w-full;

--- a/packages/radiant-ui/src/components/ui/date-range-picker/date-range-picker.stories.tsx
+++ b/packages/radiant-ui/src/components/ui/date-range-picker/date-range-picker.stories.tsx
@@ -23,12 +23,7 @@ const meta = {
 	parameters: {
 		radiant: {
 			element: RuiDateRangePickerElement,
-			cssImports: [
-				'./date-range-picker.css',
-				'../shared/control-toggle.css',
-				'../../../lib/icons/icons.css',
-				'../calendar/calendar.css',
-			],
+			cssImports: ['../../../styles/primitives.css', '../calendar/calendar.css', './date-range-picker.css'],
 		},
 	},
 	args: {

--- a/packages/radiant-ui/src/components/ui/shared/control-toggle.css
+++ b/packages/radiant-ui/src/components/ui/shared/control-toggle.css
@@ -1,5 +1,4 @@
 @reference '../../../styles/radiant-ui.css';
-@import '../../../lib/icons/icons.css';
 
 @layer components {
 	.rui-control-toggle {

--- a/packages/radiant-ui/src/components/ui/toc/toc.script.tsx
+++ b/packages/radiant-ui/src/components/ui/toc/toc.script.tsx
@@ -97,13 +97,10 @@ export class RuiToc extends RadiantElement<RuiTocBindings> {
 	override connectedCallback(): void {
 		super.connectedCallback();
 		this.attachNavigationListeners();
-		queueMicrotask(() => {
-			if (!this.isConnected) {
-				return;
-			}
+	}
 
-			this.rebuild();
-		});
+	protected override onConnected(): void {
+		this.rebuild();
 	}
 
 	override disconnectedCallback(): void {

--- a/packages/radiant-ui/src/components/ui/toc/toc.stories.tsx
+++ b/packages/radiant-ui/src/components/ui/toc/toc.stories.tsx
@@ -1,37 +1,62 @@
-import type { Meta, StoryObj } from '@ecopages/storybook-radiant-vite';
+import type { Decorator, Meta, StoryObj } from '@ecopages/storybook-radiant-vite';
+import type { JsxRenderable } from '@ecopages/jsx';
 import { expect } from 'storybook/test';
 import { RuiToc } from './toc';
 import { RuiToc as RuiTocElement } from './toc.script';
 
 const Article = () => (
-	<article class="toc-story-article">
-		<h2 id="overview">Overview</h2>
-		<p>First section content.</p>
-		<h2 id="configuration">Configuration</h2>
-		<p>Second section content.</p>
-		<h3 id="tokens">Design tokens</h3>
-		<p>Nested section content.</p>
-		<h2 id="next-steps">Next steps</h2>
-		<p>Final section content.</p>
+	<article class="toc-story-article min-w-0 pb-48">
+		<section class="min-h-56 scroll-mt-20">
+			<h2 id="overview" class="text-xl font-semibold">
+				Overview
+			</h2>
+			<p class="mt-3 max-w-prose text-sm text-on-surface">First section content.</p>
+		</section>
+		<section class="min-h-56 scroll-mt-20 border-t border-border pt-8">
+			<h2 id="configuration" class="text-xl font-semibold">
+				Configuration
+			</h2>
+			<p class="mt-3 max-w-prose text-sm text-on-surface">Second section content.</p>
+			<h3 id="tokens" class="mt-10 text-base font-semibold">
+				Design tokens
+			</h3>
+			<p class="mt-3 max-w-prose text-sm text-on-surface">Nested section content.</p>
+		</section>
+		<section class="min-h-56 scroll-mt-20 border-t border-border pt-8">
+			<h2 id="next-steps" class="text-xl font-semibold">
+				Next steps
+			</h2>
+			<p class="mt-3 max-w-prose text-sm text-on-surface">Final section content.</p>
+		</section>
 	</article>
+);
+
+const withTocArticle: Decorator = (Story) => (
+	<section
+		class="h-[30rem] overflow-y-auto rounded-lg bg-background p-5"
+		data-toc-story-scroll-root
+	>
+		<div class="grid gap-8 md:grid-cols-[10rem_minmax(0,1fr)]">
+			<aside class="sticky top-0 z-10 self-start bg-background py-1">
+				{Story() as JsxRenderable}
+			</aside>
+			<Article />
+		</div>
+	</section>
 );
 
 const meta = {
 	title: 'Components/Table of contents',
 	component: RuiToc,
 	parameters: { radiant: { element: RuiTocElement, cssImports: ['./toc.css'] } },
+	decorators: [withTocArticle],
 	args: {
 		target: '.toc-story-article',
 		label: 'On this page',
 		headingSelector: 'h2,h3',
 		scrollOffset: 80,
 	},
-	render: (args) => (
-		<div class="toc-story-layout">
-			<RuiToc {...args} />
-			<Article />
-		</div>
-	),
+	render: (args) => <RuiToc {...args} />,
 } satisfies Meta<typeof RuiToc>;
 
 export default meta;
@@ -40,6 +65,11 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
 	play: async ({ canvasElement, step }) => {
 		const root = canvasElement.querySelector('rui-toc');
+		const scrollRoot = canvasElement.querySelector('[data-toc-story-scroll-root]');
+		await step('provides a scrollable article context', async () => {
+			await expect(scrollRoot).toBeInTheDocument();
+			await expect(canvasElement.querySelector('.toc-story-article')).toBeInTheDocument();
+		});
 		await step('builds links for headings', async () => {
 			await expect(root?.querySelectorAll('.rui-toc__link').length).toBe(4);
 		});

--- a/packages/radiant-ui/src/components/ui/toolbar/toolbar.script.tsx
+++ b/packages/radiant-ui/src/components/ui/toolbar/toolbar.script.tsx
@@ -22,7 +22,6 @@ type RuiToolbarBindings = {
  * @element rui-toolbar
  * @attr {string} label - Accessible name for the `role="toolbar"` region.
  * @attr {boolean} exclusive-toggles - Only one toggle button stays pressed at a time. Default: `false`.
- * @slot - Toolbar controls (`button`, `a[href]`, `input`, …).
  * @cssclass rui-toolbar - Toolbar surface (`role="toolbar"`).
  */
 @customElement('rui-toolbar')
@@ -30,15 +29,12 @@ export class RuiToolbar extends RadiantElement<RuiToolbarBindings> {
 	@prop({ type: String, defaultValue: '' }) label: string;
 	@prop({ type: Boolean, reflect: true, defaultValue: false }) exclusiveToggles: boolean;
 
-	private readonly resolvedAriaLabel = this.$.label.map((label) => label || undefined);
-
 	private getItems(): HTMLElement[] {
 		return queryRovingTabindexItems(this);
 	}
 
-	override connectedCallback(): void {
-		super.connectedCallback();
-		queueMicrotask(() => applyRovingTabindex(this.getItems(), 0));
+	protected override onConnected(): void {
+		applyRovingTabindex(this.getItems(), 0);
 	}
 
 	@onEvent({ type: 'keydown', selector: 'button, a[href], input, select, [tabindex]' })
@@ -92,13 +88,5 @@ export class RuiToolbar extends RadiantElement<RuiToolbarBindings> {
 		}
 
 		button.setAttribute('aria-pressed', String(!wasPressed));
-	}
-
-	override render() {
-		return (
-			<div class="rui-toolbar" role="toolbar" aria-label={this.resolvedAriaLabel}>
-				<slot></slot>
-			</div>
-		);
 	}
 }

--- a/packages/radiant-ui/src/components/ui/toolbar/toolbar.tsx
+++ b/packages/radiant-ui/src/components/ui/toolbar/toolbar.tsx
@@ -2,6 +2,16 @@ import type { JsxCustomElementAttributes } from '@ecopages/jsx';
 import type { RuiToolbar as RuiToolbarElement, RuiToolbarProps } from './toolbar.script';
 import './toolbar.script';
 
-export function RuiToolbar({ children, ...props }: JsxCustomElementAttributes<RuiToolbarElement, RuiToolbarProps>) {
-	return <rui-toolbar {...props}>{children}</rui-toolbar>;
+export function RuiToolbar({
+	children,
+	label,
+	...props
+}: JsxCustomElementAttributes<RuiToolbarElement, RuiToolbarProps>) {
+	return (
+		<rui-toolbar {...props} label={label}>
+			<div class="rui-toolbar" data-ref="root" role="toolbar" aria-label={label || undefined}>
+				{children}
+			</div>
+		</rui-toolbar>
+	);
 }

--- a/packages/radiant-ui/src/components/ui/window-splitter/window-splitter.script.tsx
+++ b/packages/radiant-ui/src/components/ui/window-splitter/window-splitter.script.tsx
@@ -34,9 +34,6 @@ type RuiWindowSplitterBindings = {
  * @attr {('horizontal'|'vertical')} orientation - Split axis. Default: `horizontal`.
  * @attr {string} label - Accessible name for the separator. Default: `Split view`.
  *
- * @slot primary - First (primary) pane content.
- * @slot secondary - Second pane content.
- *
  * @fires rui-splitter-change - Emitted with `{ value }` when the separator moves.
  *
  * @cssclass rui-window-splitter - Root surface.
@@ -44,10 +41,6 @@ type RuiWindowSplitterBindings = {
  * @cssclass rui-window-splitter--vertical - Stacked panes.
  * @cssclass rui-window-splitter__pane - A pane region.
  * @cssclass rui-window-splitter__separator - Focusable separator (`role="separator"`).
- *
- * @remarks
- * The element authors the full composed surface in `render()`; the
- * `RuiWindowSplitter` view only projects the two pane slots.
  */
 @customElement('rui-window-splitter')
 export class RuiWindowSplitter extends RadiantElement<RuiWindowSplitterBindings> {
@@ -61,16 +54,11 @@ export class RuiWindowSplitter extends RadiantElement<RuiWindowSplitterBindings>
 	@event({ name: 'rui-splitter-change', bubbles: true, composed: true })
 	changeEvent: EventEmitter<RuiWindowSplitterChangeDetail>;
 
-	/** `class` stays a plain-read composition; only the derived aria-orientation string is bound. */
-	private readonly resolvedAriaOrientation = this.$.orientation.map((orientation) =>
-		orientation !== 'vertical' ? 'vertical' : 'horizontal',
-	);
-
 	private dragging = false;
 
-	override connectedCallback(): void {
-		super.connectedCallback();
-		queueMicrotask(() => this.applySize());
+	protected override onConnected(): void {
+		this.syncSeparatorPresentation();
+		this.applySize();
 	}
 
 	override disconnectedCallback(): void {
@@ -79,9 +67,27 @@ export class RuiWindowSplitter extends RadiantElement<RuiWindowSplitterBindings>
 		super.disconnectedCallback();
 	}
 
-	@onUpdated(['value', 'orientation'])
+	@onUpdated(['value', 'orientation', 'label'])
 	onPropsUpdated(): void {
+		this.syncSeparatorPresentation();
 		this.applySize();
+	}
+
+	private syncSeparatorPresentation(): void {
+		const separator = this.separatorTarget;
+		const root = this.querySelector<HTMLElement>('[data-ref="root"]');
+		if (!separator || !root) {
+			return;
+		}
+
+		const horizontal = this.orientation !== 'vertical';
+		root.classList.toggle('rui-window-splitter--horizontal', horizontal);
+		root.classList.toggle('rui-window-splitter--vertical', !horizontal);
+		separator.setAttribute('aria-orientation', horizontal ? 'vertical' : 'horizontal');
+		separator.setAttribute('aria-valuenow', String(this.value));
+		separator.setAttribute('aria-valuemin', '20');
+		separator.setAttribute('aria-valuemax', '80');
+		separator.setAttribute('aria-label', this.label);
 	}
 
 	private applySize(): void {
@@ -145,30 +151,5 @@ export class RuiWindowSplitter extends RadiantElement<RuiWindowSplitterBindings>
 		this.dragging = false;
 		document.removeEventListener('pointermove', this.onPointerMove);
 		document.removeEventListener('pointerup', this.onPointerUp);
-	}
-
-	override render() {
-		const horizontal = this.orientation !== 'vertical';
-		return (
-			<div class={`rui-window-splitter rui-window-splitter--${horizontal ? 'horizontal' : 'vertical'}`}>
-				<div data-ref="primary" class="rui-window-splitter__pane">
-					<slot name="primary"></slot>
-				</div>
-				<div
-					data-ref="separator"
-					class="rui-window-splitter__separator"
-					role="separator"
-					tabindex={0}
-					aria-orientation={this.resolvedAriaOrientation}
-					aria-valuenow={this.$.value}
-					aria-valuemin={20}
-					aria-valuemax={80}
-					aria-label={this.$.label}
-				></div>
-				<div class="rui-window-splitter__pane">
-					<slot name="secondary"></slot>
-				</div>
-			</div>
-		);
 	}
 }

--- a/packages/radiant-ui/src/components/ui/window-splitter/window-splitter.tsx
+++ b/packages/radiant-ui/src/components/ui/window-splitter/window-splitter.tsx
@@ -1,19 +1,38 @@
 import type { JsxCustomElementAttributes, JsxRenderable } from '@ecopages/jsx';
+import { cx } from '@/lib/cx';
 import type { RuiWindowSplitter as RuiWindowSplitterElement, RuiWindowSplitterProps } from './window-splitter.script';
 import './window-splitter.script';
 
 export function RuiWindowSplitter({
 	primary,
 	secondary,
+	orientation = 'horizontal',
 	...props
 }: JsxCustomElementAttributes<RuiWindowSplitterElement, RuiWindowSplitterProps> & {
 	primary: JsxRenderable;
 	secondary: JsxRenderable;
 }) {
+	const horizontal = orientation !== 'vertical';
+
 	return (
-		<rui-window-splitter {...props}>
-			<div slot="primary">{primary}</div>
-			<div slot="secondary">{secondary}</div>
+		<rui-window-splitter {...props} orientation={orientation}>
+			<div
+				class={cx('rui-window-splitter', horizontal ? 'rui-window-splitter--horizontal' : 'rui-window-splitter--vertical')}
+				data-ref="root"
+			>
+				<div data-ref="primary" class="rui-window-splitter__pane">
+					{primary}
+				</div>
+				<div
+					data-ref="separator"
+					class="rui-window-splitter__separator"
+					role="separator"
+					tabindex={0}
+				></div>
+				<div data-ref="secondary" class="rui-window-splitter__pane">
+					{secondary}
+				</div>
+			</div>
 		</rui-window-splitter>
 	);
 }

--- a/packages/radiant-ui/src/host-contract.ssr.test.tsx
+++ b/packages/radiant-ui/src/host-contract.ssr.test.tsx
@@ -121,13 +121,13 @@ describe('class composition and locked invariants', () => {
 		expect(html).toMatch(/<div[^>]*role="alert"/);
 	});
 
-	it('locks the select trigger type and listbox hidden state', () => {
+	it('locks the select trigger type without binding popup visibility in the view', () => {
 		const trigger = renderToString(<RuiSelectTrigger attr:type="submit">Value</RuiSelectTrigger>);
 		const listbox = renderToString(<RuiSelectListbox hidden={false}>Options</RuiSelectListbox>);
 
 		expect(trigger).toContain('type="button"');
 		expect(trigger).not.toContain('type="submit"');
-		expect(listbox).toContain(' hidden');
+		expect(listbox).not.toContain(' hidden');
 	});
 
 	it('does not serialize view-only options, slides, or rows', () => {

--- a/packages/radiant-ui/src/lib/roving-tabindex.ts
+++ b/packages/radiant-ui/src/lib/roving-tabindex.ts
@@ -7,7 +7,10 @@ export type RovingNavResult = { handled: false } | { handled: true; index: numbe
  */
 export function applyRovingTabindex(items: HTMLElement[], activeIndex: number): void {
 	items.forEach((item, index) => {
-		item.tabIndex = index === activeIndex ? 0 : -1;
+		const next = index === activeIndex ? 0 : -1;
+		if (item.tabIndex !== next) {
+			item.tabIndex = next;
+		}
 	});
 }
 

--- a/packages/radiant-ui/src/styles/style-dependencies.json
+++ b/packages/radiant-ui/src/styles/style-dependencies.json
@@ -253,8 +253,11 @@
 			]
 		},
 		"sidebar": {
-			"direct": [],
+			"direct": [
+				"button"
+			],
 			"styles": [
+				"@ecopages/radiant-ui/button/styles.css",
 				"@ecopages/radiant-ui/sidebar/styles.css"
 			]
 		},


### PR DESCRIPTION
Migrate remaining composites, regenerate style-dependencies, update
component docs, and add breaking changesets for the slot removal.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>