### PR TITLE
feat(radiant-ui): view-owned slider with range form support

### DIFF
--- a/.changeset/slider-knob-shared-range.md
+++ b/.changeset/slider-knob-shared-range.md
@@ -1,0 +1,5 @@
+---
+'@ecopages/radiant-ui': minor
+---
+
+Range sliders now submit `[min, max]` through forms (`name` plus `name-max`), share the numeric keyboard model with knobs, and keep vertical fill positioning in CSS.

--- a/apps/radiant-ui/src/content/stories/index.ts
+++ b/apps/radiant-ui/src/content/stories/index.ts
@@ -36,6 +36,7 @@ import './popover';
 import './radio-group';
 import './select';
 import './sidebar';
+import './slider';
 import './spinner';
 import './tabs';
 import './tag-group';

--- a/packages/radiant-ui/src/components/ui/slider/index.ts
+++ b/packages/radiant-ui/src/components/ui/slider/index.ts
@@ -1,2 +1,2 @@
-export { RuiSlider as RuiSliderElement, type RuiSliderProps, type RuiSliderChangeDetail } from './slider.script';
-export { RuiSlider } from './slider';
+export { RuiSlider as RuiSliderElement, type RuiSliderProps, type RuiSliderChangeDetail, type RuiSliderOrientation } from './slider.script';
+export { RuiSlider, RuiSliderValue, type RuiSliderValueProps } from './slider';

--- a/packages/radiant-ui/src/components/ui/slider/slider.css
+++ b/packages/radiant-ui/src/components/ui/slider/slider.css
@@ -1,44 +1,132 @@
 @reference '../../../styles/radiant-ui.css';
 
 rui-slider {
-	@apply block w-full max-w-full min-w-0;
+	--rui-slider-track-size: 0.375rem;
+	--rui-slider-track-length: 12rem;
+	--rui-slider-width: 100%;
+	--rui-slider-height: auto;
+	--rui-slider-gap: var(--space-inline);
+	--rui-slider-track-color: var(--surface);
+	--rui-slider-fill-color: var(--primary);
+	--rui-slider-track-radius: var(--radius-control);
+	--rui-slider-thumb-size: 1.25rem;
+	--rui-slider-thumb-border-width: 2px;
+	--rui-slider-thumb-border-color: var(--primary);
+	--rui-slider-thumb-background: var(--background);
+	--rui-slider-thumb-shadow: 0 2px 8px rgb(0 0 0 / 0.12);
+	--rui-slider-thumb-radius: var(--radius-control);
+	--rui-slider-value-color: var(--on-surface);
+	--rui-slider-focus-ring: var(--focus-ring);
+	--rui-slider-focus-ring-width: 2px;
+
+	@apply block max-w-full min-w-0;
+	inline-size: var(--rui-slider-width);
+	block-size: var(--rui-slider-height);
+}
+
+rui-slider:has(.rui-slider--vertical) {
+	--rui-slider-width: auto;
+	inline-size: auto;
+	max-inline-size: 100%;
 }
 
 @layer components {
 	.rui-slider {
-		@apply flex w-full min-w-0 max-w-full flex-col gap-inline text-sm text-on-background;
+		@apply flex min-w-0 max-w-full flex-col text-sm text-on-background;
+		gap: var(--rui-slider-gap);
+		inline-size: var(--rui-slider-width, 100%);
+		block-size: var(--rui-slider-height, auto);
 	}
 
-	.rui-slider__input {
-		@apply block w-full min-w-0 max-w-full accent-primary;
+	.rui-slider__header {
+		@apply flex items-baseline justify-between gap-2;
+	}
+
+	.rui-slider__label {
+		@apply font-medium;
 	}
 
 	.rui-slider__value {
-		@apply tabular-nums text-on-surface;
+		@apply tabular-nums;
+		color: var(--rui-slider-value-color, var(--on-surface));
+	}
+
+	.rui-slider--vertical {
+		@apply max-w-none items-center;
+		inline-size: var(--rui-slider-width, auto);
+		block-size: var(--rui-slider-height, auto);
+	}
+
+	.rui-slider--vertical .rui-slider__header {
+		@apply w-full flex-col items-center text-center;
 	}
 
 	.rui-slider__range {
-		@apply w-full min-w-0 py-2;
+		@apply min-w-0 py-2;
+		inline-size: var(--rui-slider-width, 100%);
+	}
+
+	.rui-slider--vertical .rui-slider__range {
+		@apply flex w-auto justify-center px-0 py-2;
 	}
 
 	.rui-slider__range-track {
-		@apply relative h-2 w-full min-w-0 rounded-full bg-surface;
+		@apply relative min-w-0;
+		border-radius: var(--rui-slider-track-radius, var(--radius-control));
+		background: var(--rui-slider-track-color, var(--surface));
+		block-size: var(--rui-slider-track-size, 0.375rem);
+		inline-size: 100%;
+		max-inline-size: var(--rui-slider-track-length, 100%);
+	}
+
+	.rui-slider--vertical .rui-slider__range-track {
+		inline-size: var(--rui-slider-track-size, 0.375rem);
+		block-size: var(--rui-slider-track-length, 12rem);
+		max-inline-size: none;
 	}
 
 	.rui-slider__range-fill {
-		@apply absolute top-0 h-full rounded-full bg-primary;
+		position: absolute;
+		border-radius: var(--rui-slider-track-radius, var(--radius-control));
+		background: var(--rui-slider-fill-color, var(--primary));
+		inset-block: 0;
+		inset-inline-start: var(--rui-slider-fill-start, 0%);
+		inline-size: var(--rui-slider-fill-size, 0%);
+	}
+
+	.rui-slider--vertical .rui-slider__range-fill {
+		inset-inline: 0;
+		inset-block-start: auto;
+		inset-block-end: var(--rui-slider-fill-start, 0%);
+		inline-size: 100%;
+		block-size: var(--rui-slider-fill-size, 0%);
 	}
 
 	.rui-slider__thumb {
-		@apply absolute top-1/2 h-4 w-4 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-primary bg-background shadow-sm;
+		@apply absolute top-1/2 -translate-x-1/2 -translate-y-1/2;
+		touch-action: none;
+		inline-size: var(--rui-slider-thumb-size, 1.25rem);
+		block-size: var(--rui-slider-thumb-size, 1.25rem);
+		border: var(--rui-slider-thumb-border-width, 2px) solid var(--rui-slider-thumb-border-color, var(--primary));
+		border-radius: var(--rui-slider-thumb-radius, var(--radius-control));
+		background: var(--rui-slider-thumb-background, var(--background));
+		box-shadow: var(--rui-slider-thumb-shadow, 0 2px 8px rgb(0 0 0 / 0.12));
+	}
+
+	.rui-slider__thumb::before {
+		position: absolute;
+		inset: 50%;
+		inline-size: 2.75rem;
+		block-size: 2.75rem;
+		content: '';
+		transform: translate(-50%, -50%);
 	}
 
 	.rui-slider__thumb:focus-visible {
-		@apply rounded-full outline-hidden ring-2 ring-focus-ring;
-	}
-
-	.rui-slider__thumb:active:not(:disabled) {
-		@apply rounded-full;
+		@apply outline-hidden;
+		box-shadow:
+			var(--rui-slider-thumb-shadow, 0 2px 8px rgb(0 0 0 / 0.12)),
+			0 0 0 var(--rui-slider-focus-ring-width, 2px) var(--rui-slider-focus-ring, var(--focus-ring));
 	}
 
 	.rui-slider__thumb[data-thumb='min'] {
@@ -47,5 +135,27 @@ rui-slider {
 
 	.rui-slider__thumb[data-thumb='max'] {
 		left: var(--rui-slider-max, 100%);
+	}
+
+	.rui-slider__thumb[data-thumb='value'] {
+		left: var(--rui-slider-value, 0%);
+	}
+
+	.rui-slider--vertical .rui-slider__thumb[data-thumb='min'],
+	.rui-slider--vertical .rui-slider__thumb[data-thumb='max'],
+	.rui-slider--vertical .rui-slider__thumb[data-thumb='value'] {
+		left: 50%;
+	}
+
+	.rui-slider--vertical .rui-slider__thumb[data-thumb='min'] {
+		top: calc(100% - var(--rui-slider-min, 0%));
+	}
+
+	.rui-slider--vertical .rui-slider__thumb[data-thumb='max'] {
+		top: calc(100% - var(--rui-slider-max, 100%));
+	}
+
+	.rui-slider--vertical .rui-slider__thumb[data-thumb='value'] {
+		top: calc(100% - var(--rui-slider-value, 0%));
 	}
 }

--- a/packages/radiant-ui/src/components/ui/slider/slider.script.tsx
+++ b/packages/radiant-ui/src/components/ui/slider/slider.script.tsx
@@ -1,10 +1,14 @@
-import { RadiantElement, customElement, event, onEvent, onUpdated, prop, query, state } from '@ecopages/radiant';
+import { RadiantElement, customElement, event, onEvent, onUpdated, prop, query } from '@ecopages/radiant';
 import type { EventEmitter } from '@ecopages/radiant/tools/event-emitter';
+import { createNumericRange, valueFromSliderKey } from '../shared/numeric-range';
 
 export type RuiSliderVariant = 'single' | 'range';
+export type RuiSliderOrientation = 'horizontal' | 'vertical';
+export type RuiSliderThumb = 'value' | 'min' | 'max';
 
 export type RuiSliderProps = {
 	variant?: RuiSliderVariant;
+	orientation?: RuiSliderOrientation;
 	value?: number;
 	rangeMin?: number;
 	rangeMax?: number;
@@ -13,23 +17,24 @@ export type RuiSliderProps = {
 	step?: number;
 	minDistance?: number;
 	disabled?: boolean;
+	readOnly?: boolean;
 	label?: string;
 	name?: string;
+	/** Shows the default value readout below the track when no `RuiSliderValue` child is provided. */
+	showValue?: boolean;
+	/** Mirrors the live value in the control `title` for hover tooltips. */
+	valueTitle?: boolean;
 };
 
 export type RuiSliderChangeDetail = { value: number } | { values: [number, number] };
 
-type RuiSliderBindings = {
-	disabled: boolean;
-	name: string;
-	label: string;
-};
+type RuiSliderBindings = Record<string, never>;
 
 /**
  * `<rui-slider>` — select a value from a continuous or discrete range.
  *
- * Single mode uses native `<input type="range">`. Range mode implements the APG
- * multi-thumb slider pattern with two `role="slider"` thumbs on one track.
+ * Single and range modes use a DOM track and `role="slider"` thumbs styled via CSS
+ * variables — no `<canvas>` rendering.
  *
  * @see https://www.w3.org/WAI/ARIA/apg/patterns/slider/
  * @see https://www.w3.org/WAI/ARIA/apg/patterns/slider-multithumb/
@@ -37,6 +42,7 @@ type RuiSliderBindings = {
  * @element rui-slider
  *
  * @attr {('single'|'range')} variant - Single-thumb or dual-thumb range. Default: `single`.
+ * @attr {('horizontal'|'vertical')} orientation - Track axis. Default: `horizontal`.
  * @attr {number} value - Selected value (single mode). Reflects to markup. Default: `50`.
  * @attr {number} range-min - Lower thumb value (range mode). Reflects to markup. Default: `25`.
  * @attr {number} range-max - Upper thumb value (range mode). Reflects to markup. Default: `75`.
@@ -45,29 +51,41 @@ type RuiSliderBindings = {
  * @attr {number} step - Arrow-key and pointer snap interval. Default: `1`.
  * @attr {number} min-distance - Minimum gap enforced between range thumbs. Default: `0`.
  * @attr {boolean} disabled - Disables interaction. Default: `false`.
+ * @attr {boolean} read-only - Blocks value changes while leaving thumbs focusable. Default: `false`.
  * @attr {string} label - Accessible name for the slider. Default: `''`.
- * @attr {string} name - Form field name (single mode native input). Default: `''`.
+ * @attr {string} name - Form field name. Range mode also writes `{name}-max`. Default: `''`.
+ * @attr {boolean} show-value - Shows the default value readout below the track. Default: `false`.
+ * @attr {boolean} value-title - Mirrors the live value in control `title` tooltips on hover. Default: `false`.
  *
- * @fires rui-change - Emitted as the value moves; `detail.value` (single) or
- *   `detail.values` `[min, max]` (range).
+ * @cssprop --rui-slider-track-size - Track thickness. Default: `0.375rem`.
+ * @cssprop --rui-slider-track-length - Track length for vertical sliders and horizontal max length. Default: `12rem`.
+ * @cssprop --rui-slider-width - Root control width. Default: `100%` (`auto` when vertical).
+ * @cssprop --rui-slider-height - Root control height. Default: `auto`.
+ * @cssprop --rui-slider-gap - Spacing between label, track, and value. Default: `--space-inline`.
+ * @cssprop --rui-slider-track-color - Range track background. Default: `--surface`.
+ * @cssprop --rui-slider-fill-color - Range selected fill. Default: `--primary`.
+ * @cssprop --rui-slider-track-radius - Track and fill corner radius. Default: `--radius-control`.
+ * @cssprop --rui-slider-thumb-size - Range thumb diameter. Default: `1.25rem`.
+ * @cssprop --rui-slider-thumb-border-width - Range thumb border width. Default: `2px`.
+ * @cssprop --rui-slider-thumb-border-color - Range thumb border color. Default: `--primary`.
+ * @cssprop --rui-slider-thumb-background - Range thumb fill. Default: `--background`.
+ * @cssprop --rui-slider-thumb-shadow - Range thumb shadow. Default: `0 2px 8px rgb(0 0 0 / 0.12)`.
+ * @cssprop --rui-slider-thumb-radius - Thumb corner radius. Default: `--radius-control`.
+ * @cssprop --rui-slider-value-color - Value readout color. Default: `--on-surface`.
+ * @cssprop --rui-slider-focus-ring - Focus ring color. Default: `--focus-ring`.
+ * @cssprop --rui-slider-focus-ring-width - Focus ring width. Default: `2px`.
+ *
+ * @fires rui-change - Emitted when the committed value changes; `detail.value` (single) or
+ *   `detail.values` `[min, max]` (range). Pointer drags emit on each distinct snap.
  *
  * @remarks
- * The composed surface is authored here — the BEM classes below live on the element,
- * not on the `RuiSlider` view (which only maps `values` to `rangeMin` / `rangeMax`).
- *
- * @cssclass rui-slider - Root; wraps the label, track, and value readout.
- * @cssclass rui-slider--range - Range-mode surface (dual-thumb track).
- * @cssclass rui-slider__label - Optional visible label.
- * @cssclass rui-slider__input - Native range input (single mode).
- * @cssclass rui-slider__value - Live numeric readout (`aria-hidden="true"`).
- * @cssclass rui-slider__range - Range-mode track wrapper.
- * @cssclass rui-slider__range-track - Track surface behind both thumbs.
- * @cssclass rui-slider__range-fill - Filled span between the thumbs.
- * @cssclass rui-slider__thumb - Range thumb (`role="slider"`).
+ * The composed surface is authored in `RuiSlider` / `RuiSliderValue`. The element
+ * queries `data-ref` targets and updates live values imperatively.
  */
 @customElement('rui-slider')
 export class RuiSlider extends RadiantElement<RuiSliderBindings> {
 	@prop({ type: String, defaultValue: 'single' }) variant: RuiSliderVariant;
+	@prop({ type: String, defaultValue: 'horizontal' }) orientation: RuiSliderOrientation;
 	@prop({ type: Number, reflect: true, defaultValue: 50 }) value: number;
 	@prop({ type: Number, reflect: true, attribute: 'range-min', defaultValue: 25 }) rangeMin: number;
 	@prop({ type: Number, reflect: true, attribute: 'range-max', defaultValue: 75 }) rangeMax: number;
@@ -76,427 +94,438 @@ export class RuiSlider extends RadiantElement<RuiSliderBindings> {
 	@prop({ type: Number, defaultValue: 1 }) step: number;
 	@prop({ type: Number, defaultValue: 0 }) minDistance: number;
 	@prop({ type: Boolean, reflect: true, defaultValue: false }) disabled: boolean;
+	@prop({ type: Boolean, attribute: 'read-only', reflect: true, defaultValue: false }) readOnly: boolean;
 	@prop({ type: String, defaultValue: '' }) label: string;
 	@prop({ type: String, defaultValue: '' }) name: string;
+	@prop({ type: Boolean, attribute: 'show-value', defaultValue: false }) showValue: boolean;
+	@prop({ type: Boolean, attribute: 'value-title', defaultValue: false }) valueTitle: boolean;
 
 	@event({ name: 'rui-change', bubbles: true, composed: true })
 	changeEvent: EventEmitter<RuiSliderChangeDetail>;
 
 	@query({ ref: 'input' }) inputTarget: HTMLInputElement;
-	@query({ ref: 'rangeFill' }) rangeFill: HTMLElement;
+	@query({ ref: 'maxInput' }) maxInputTarget: HTMLInputElement;
+	@query({ ref: 'root' }) rootTarget: HTMLElement;
+	@query({ ref: 'header' }) headerTarget: HTMLElement;
+	@query({ ref: 'label' }) labelTarget: HTMLElement;
+	@query({ ref: 'rangeTrack' }) rangeTrack: HTMLElement;
+	@query({ ref: 'value' }) valueTarget: HTMLElement;
+	@query({ ref: 'singleThumb' }) singleThumb: HTMLButtonElement;
+	@query({ ref: 'rangeMinThumb' }) rangeMinThumb: HTMLButtonElement;
+	@query({ ref: 'rangeMaxThumb' }) rangeMaxThumb: HTMLButtonElement;
 
-	private interacting = false;
-	private activeThumb: 'min' | 'max' | null = null;
-	/** Live range while dragging, rendered without committing the public props. */
-	@state private pendingRange: [number, number] | null = null;
-	@state private displayedValue: number | null = null;
+	private activeThumb: RuiSliderThumb | null = null;
+	private activePointerId: number | null = null;
+	private pending: number[] | null = null;
+	private lastEmitted = '';
 
-	/**
-	 * Live drag state is kept separate from committed public props so the
-	 * component can update the preview without changing the form value until
-	 * the interaction commits.
-	 */
-	private readonly resolvedDisabledTabindex = this.$.disabled.map((disabled) => (disabled ? -1 : 0));
-	private readonly resolvedMinLabel = this.$.label.map((label) => (label ? `${label} minimum` : 'Minimum value'));
-	private readonly resolvedMaxLabel = this.$.label.map((label) => (label ? `${label} maximum` : 'Maximum value'));
-	private readonly resolvedName = this.$.name.map((name) => name || undefined);
-
-	override connectedCallback(): void {
-		super.connectedCallback();
-		queueMicrotask(() => {
-			if (this.variant === 'single') {
-				this.syncInputFromValue();
-			} else {
-				this.syncRangeUi();
-			}
-		});
+	protected override onConnected(): void {
+		this.syncChrome();
+		this.syncValues(this.committedValues());
 	}
 
-	@onUpdated(['value', 'min', 'max', 'step', 'variant'])
-	onSinglePropsUpdated(): void {
-		if (this.variant !== 'single' || this.interacting) {
+	@onUpdated([
+		'value',
+		'rangeMin',
+		'rangeMax',
+		'min',
+		'max',
+		'step',
+		'minDistance',
+		'variant',
+		'orientation',
+		'disabled',
+		'readOnly',
+		'label',
+		'name',
+		'showValue',
+		'valueTitle',
+	])
+	onPropsUpdated(): void {
+		if (this.activeThumb) {
 			return;
 		}
 
-		this.syncInputFromValue();
+		this.syncChrome();
+		this.syncValues(this.committedValues());
 	}
 
-	@onUpdated(['rangeMin', 'rangeMax', 'min', 'max', 'step', 'minDistance', 'variant'])
-	onRangePropsUpdated(): void {
-		if (this.variant !== 'range' || this.activeThumb) {
-			return;
+	private get isRange(): boolean {
+		return this.variant === 'range';
+	}
+
+	private get isVertical(): boolean {
+		return this.orientation === 'vertical';
+	}
+
+	private get numericRange() {
+		return createNumericRange(this.min, this.max, this.step);
+	}
+
+	private get defaultValueTarget(): HTMLElement | null {
+		return this.querySelector<HTMLElement>('[data-default-value]');
+	}
+
+	private thumbFor(id: RuiSliderThumb): HTMLButtonElement | undefined {
+		if (id === 'value') {
+			return this.singleThumb;
 		}
-
-		this.syncRangeUi();
+		return id === 'min' ? this.rangeMinThumb : this.rangeMaxThumb;
 	}
 
-	private clamp(next: number): number {
-		const stepped = Math.round(next / this.step) * this.step;
-		return Math.min(this.max, Math.max(this.min, stepped));
+	private parseThumb(value: string | null): RuiSliderThumb | null {
+		if (this.isRange) {
+			return value === 'min' || value === 'max' ? value : null;
+		}
+		return value === 'value' ? value : null;
 	}
 
-	private normalizeRange(low = this.rangeMin, high = this.rangeMax): [number, number] {
-		let nextLow = this.clamp(low);
-		let nextHigh = this.clamp(high);
-
+	private constrainPair(low: number, high: number, active?: RuiSliderThumb): [number, number] {
+		const range = this.numericRange;
+		let nextLow = range.clamp(low);
+		let nextHigh = range.clamp(high);
 		if (nextLow > nextHigh) {
 			[nextLow, nextHigh] = [nextHigh, nextLow];
 		}
 
-		if (nextHigh - nextLow < this.minDistance) {
-			if (this.activeThumb === 'min') {
-				nextLow = this.clamp(nextHigh - this.minDistance);
+		const minDistance = Math.max(0, this.minDistance);
+		if (nextHigh - nextLow < minDistance) {
+			if (active === 'min') {
+				nextLow = range.clamp(nextHigh - minDistance);
 			} else {
-				nextHigh = this.clamp(nextLow + this.minDistance);
+				nextHigh = range.clamp(nextLow + minDistance);
 			}
 		}
 
 		return [nextLow, nextHigh];
 	}
 
-	private getActiveRange(): [number, number] {
-		return this.normalizeRange(...(this.pendingRange ?? [this.rangeMin, this.rangeMax]));
+	private committedValues(): number[] {
+		if (this.isRange) {
+			return this.constrainPair(this.rangeMin, this.rangeMax);
+		}
+		return [this.numericRange.clamp(this.value)];
 	}
 
-	private percentFor(value: number): number {
-		if (this.max === this.min) {
-			return 0;
+	private liveValues(): number[] {
+		return this.pending ?? this.committedValues();
+	}
+
+	private changeDetail(values: number[]): RuiSliderChangeDetail {
+		return values.length === 2 ? { values: [values[0], values[1]] } : { value: values[0] };
+	}
+
+	private emitIfChanged(values: number[]): void {
+		const key = values.join(',');
+		if (key === this.lastEmitted) {
+			return;
+		}
+		this.lastEmitted = key;
+		this.changeEvent.emit(this.changeDetail(values));
+	}
+
+	private reflectValues(values: number[]): void {
+		if (values.length === 2) {
+			if (this.rangeMin !== values[0]) {
+				this.rangeMin = values[0];
+			}
+			if (this.rangeMax !== values[1]) {
+				this.rangeMax = values[1];
+			}
+			return;
 		}
 
-		return ((value - this.min) / (this.max - this.min)) * 100;
+		if (this.value !== values[0]) {
+			this.value = values[0];
+		}
 	}
 
-	private valueFromPointer(clientX: number, track: HTMLElement): number {
+	private syncValues(values: number[]): void {
+		this.paint(values);
+		this.reflectValues(values);
+	}
+
+	private syncChrome(): void {
+		const disabled = this.disabled;
+		const range = this.isRange;
+		const tabindex = disabled ? -1 : 0;
+		const orientation = this.isVertical ? 'vertical' : 'horizontal';
+		const hasDefaultValue = Boolean(this.defaultValueTarget);
+		const hasVisibleReadout = Boolean(this.valueTarget) && (!hasDefaultValue || this.showValue);
+		const rangeBounds = this.numericRange;
+
+		this.rootTarget?.classList.toggle('rui-slider--single', !range);
+		this.rootTarget?.classList.toggle('rui-slider--range', range);
+		this.rootTarget?.classList.toggle('rui-slider--vertical', this.isVertical);
+		this.labelTarget?.toggleAttribute('hidden', !this.label);
+		if (this.labelTarget) {
+			this.labelTarget.textContent = this.label;
+		}
+		this.defaultValueTarget?.toggleAttribute('hidden', !this.showValue);
+		this.headerTarget?.toggleAttribute('hidden', !this.label && !hasVisibleReadout);
+
+		const thumbs: Array<[RuiSliderThumb, string, boolean]> = [
+			['value', this.label || 'Value', !range],
+			['min', this.label ? `${this.label} minimum` : 'Minimum value', range],
+			['max', this.label ? `${this.label} maximum` : 'Maximum value', range],
+		];
+
+		for (const [id, ariaLabel, visible] of thumbs) {
+			const thumb = this.thumbFor(id);
+			if (!thumb) {
+				continue;
+			}
+			thumb.toggleAttribute('hidden', !visible);
+			thumb.toggleAttribute('disabled', disabled || !visible);
+			thumb.setAttribute('tabindex', String(visible ? tabindex : -1));
+			thumb.setAttribute('aria-label', ariaLabel);
+			thumb.setAttribute('aria-orientation', orientation);
+			thumb.setAttribute('aria-valuemin', String(rangeBounds.lowerBound));
+			thumb.setAttribute('aria-valuemax', String(rangeBounds.upperBound));
+			thumb.setAttribute('aria-readonly', String(this.readOnly));
+		}
+	}
+
+	private paint(values: number[]): void {
+		const range = this.numericRange;
+		const start = values[0];
+		const end = values.length === 2 ? values[1] : values[0];
+		const startPercent = `${range.ratioFor(start) * 100}%`;
+		const endPercent = `${range.ratioFor(end) * 100}%`;
+		const fillSize = `${(range.ratioFor(end) - range.ratioFor(start)) * 100}%`;
+		const track = this.rangeTrack;
+
+		track?.style.setProperty('--rui-slider-fill-start', values.length === 2 ? startPercent : '0%');
+		track?.style.setProperty('--rui-slider-fill-size', values.length === 2 ? fillSize : endPercent);
+		track?.style.setProperty('--rui-slider-value', startPercent);
+		track?.style.setProperty('--rui-slider-min', startPercent);
+		track?.style.setProperty('--rui-slider-max', endPercent);
+
+		if (this.singleThumb) {
+			this.singleThumb.setAttribute('aria-valuenow', String(start));
+		}
+		if (this.rangeMinThumb) {
+			this.rangeMinThumb.setAttribute('aria-valuenow', String(start));
+			this.rangeMinThumb.setAttribute('aria-valuemax', String(end));
+		}
+		if (this.rangeMaxThumb) {
+			this.rangeMaxThumb.setAttribute('aria-valuemin', String(start));
+			this.rangeMaxThumb.setAttribute('aria-valuenow', String(end));
+		}
+
+		if (this.valueTarget) {
+			this.valueTarget.textContent = values.length === 2 ? `${start} – ${end}` : String(start);
+		}
+
+		this.syncInputs(values);
+		this.syncValueTitle(values);
+	}
+
+	private syncInputs(values: number[]): void {
+		if (this.inputTarget) {
+			this.inputTarget.disabled = this.disabled;
+			this.inputTarget.readOnly = this.readOnly;
+			this.inputTarget.value = String(values[0]);
+			if (this.name) {
+				this.inputTarget.name = this.name;
+			} else {
+				this.inputTarget.removeAttribute('name');
+			}
+		}
+
+		if (!this.maxInputTarget) {
+			return;
+		}
+
+		this.maxInputTarget.disabled = this.disabled;
+		this.maxInputTarget.readOnly = this.readOnly;
+
+		if (values.length === 2) {
+			this.maxInputTarget.value = String(values[1]);
+			if (this.name) {
+				this.maxInputTarget.name = `${this.name}-max`;
+			} else {
+				this.maxInputTarget.removeAttribute('name');
+			}
+			return;
+		}
+
+		this.maxInputTarget.value = '';
+		this.maxInputTarget.removeAttribute('name');
+	}
+
+	private syncValueTitle(values: number[]): void {
+		const thumbs = [this.singleThumb, this.rangeMinThumb, this.rangeMaxThumb];
+		if (!this.valueTitle) {
+			this.inputTarget?.removeAttribute('title');
+			this.maxInputTarget?.removeAttribute('title');
+			this.rangeTrack?.removeAttribute('title');
+			for (const thumb of thumbs) {
+				thumb?.removeAttribute('title');
+			}
+			return;
+		}
+
+		if (values.length === 1) {
+			const title = String(values[0]);
+			this.inputTarget?.setAttribute('title', title);
+			this.maxInputTarget?.removeAttribute('title');
+			this.rangeTrack?.removeAttribute('title');
+			this.singleThumb?.setAttribute('title', title);
+			this.rangeMinThumb?.removeAttribute('title');
+			this.rangeMaxThumb?.removeAttribute('title');
+			return;
+		}
+
+		const [low, high] = values;
+		this.inputTarget?.setAttribute('title', String(low));
+		this.maxInputTarget?.setAttribute('title', String(high));
+		this.rangeTrack?.setAttribute('title', `${low} – ${high}`);
+		this.singleThumb?.removeAttribute('title');
+		this.rangeMinThumb?.setAttribute('title', String(low));
+		this.rangeMaxThumb?.setAttribute('title', String(high));
+	}
+
+	private valueFromPointer(event: PointerEvent): number {
+		const track = this.rangeTrack;
+		if (!track) {
+			return this.numericRange.lowerBound;
+		}
+
 		const rect = track.getBoundingClientRect();
-		const ratio = Math.min(1, Math.max(0, (clientX - rect.left) / rect.width));
-		return this.clamp(this.min + ratio * (this.max - this.min));
+		if (rect.width === 0 || rect.height === 0) {
+			return this.numericRange.lowerBound;
+		}
+
+		const ratio = this.isVertical
+			? 1 - (event.clientY - rect.top) / rect.height
+			: (event.clientX - rect.left) / rect.width;
+		return this.numericRange.valueFromRatio(ratio);
 	}
 
-	private syncInputFromValue(): void {
-		const input = this.inputTarget;
-		if (!input) {
-			return;
+	private nearestThumb(next: number): RuiSliderThumb {
+		if (!this.isRange) {
+			return 'value';
 		}
-
-		const nextValue = String(this.value);
-		if (input.value !== nextValue) {
-			input.value = nextValue;
-		}
-
-		input.min = String(this.min);
-		input.max = String(this.max);
-		input.step = String(this.step);
-		this.updateDisplayedValue(this.value);
+		const [low, high] = this.liveValues();
+		return Math.abs(next - low) <= Math.abs(next - high) ? 'min' : 'max';
 	}
 
-	private updateDisplayedValue(next: number): void {
-		this.displayedValue = next;
-	}
-
-	private syncRangeUi(): void {
-		const [low, high] = this.getActiveRange();
-		let propsChanged = false;
-
-		if (!this.activeThumb) {
-			if (low !== this.rangeMin) {
-				this.rangeMin = low;
-				propsChanged = true;
-			}
-			if (high !== this.rangeMax) {
-				this.rangeMax = high;
-				propsChanged = true;
-			}
-		}
-
-		if (propsChanged) {
-			queueMicrotask(() => {
-				if (!this.activeThumb) {
-					this.paintRangeUi(...this.getActiveRange());
-				}
-			});
-			return;
-		}
-
-		this.paintRangeUi(low, high);
-	}
-
-	private paintRangeUi(low: number, high: number): void {
-		const lowPercent = this.percentFor(low);
-		const highPercent = this.percentFor(high);
-		const track = this.querySelector<HTMLElement>('.rui-slider__range-track');
-
-		if (track) {
-			track.style.setProperty('--rui-slider-min', `${lowPercent}%`);
-			track.style.setProperty('--rui-slider-max', `${highPercent}%`);
-		}
-
-		if (this.rangeFill) {
-			this.rangeFill.style.left = `${lowPercent}%`;
-			this.rangeFill.style.width = `${highPercent - lowPercent}%`;
-		}
-	}
-
-	private commitRange(emit = true): void {
-		const [low, high] = this.getActiveRange();
-		const changed = low !== this.rangeMin || high !== this.rangeMax;
-		this.pendingRange = null;
-		this.rangeMin = low;
-		this.rangeMax = high;
-
-		if (emit && changed) {
-			this.changeEvent.emit({ values: [low, high] });
-		}
-	}
-
-	private setRangeValue(thumb: 'min' | 'max', next: number): void {
+	private moveThumb(thumb: RuiSliderThumb, next: number): number[] {
 		this.activeThumb = thumb;
-		const [currentLow, currentHigh] = this.pendingRange ?? [this.rangeMin, this.rangeMax];
-		const [low, high] = this.normalizeRange(
-			thumb === 'min' ? next : currentLow,
-			thumb === 'max' ? next : currentHigh,
-		);
-		this.pendingRange = [low, high];
-		this.paintRangeUi(low, high);
-	}
-
-	private commitSingleValue(input: HTMLInputElement): void {
-		const next = Number(input.value);
-		this.updateDisplayedValue(next);
-
-		if (next === this.value) {
-			return;
+		if (this.isRange) {
+			const current = this.pending ?? this.committedValues();
+			this.pending = this.constrainPair(thumb === 'min' ? next : current[0], thumb === 'max' ? next : current[1], thumb);
+		} else {
+			this.pending = [this.numericRange.clamp(next)];
 		}
 
-		this.value = next;
-		this.changeEvent.emit({ value: next });
+		const values = this.pending;
+		this.paint(values);
+		this.emitIfChanged(values);
+		return values;
 	}
 
-	@onEvent({ ref: 'input', type: 'pointerdown' })
+	private commit(): void {
+		const values = this.liveValues();
+		this.pending = null;
+		this.activeThumb = null;
+		this.activePointerId = null;
+		this.syncValues(values);
+	}
+
+	private revert(): void {
+		this.pending = null;
+		this.activeThumb = null;
+		this.activePointerId = null;
+		this.lastEmitted = this.committedValues().join(',');
+		this.paint(this.committedValues());
+	}
+
+	private releasePointer(event: PointerEvent): void {
+		const track = this.rangeTrack;
+		if (track?.hasPointerCapture(event.pointerId)) {
+			track.releasePointerCapture(event.pointerId);
+		}
+	}
+
+	@onEvent({ ref: 'rangeTrack', type: 'pointerdown' })
 	onPointerDown(event: PointerEvent): void {
-		if (event.button !== 0 || this.variant !== 'single') {
-			return;
-		}
-
-		this.interacting = true;
-	}
-
-	@onEvent({ ref: 'input', type: 'pointerup' })
-	onPointerUp(event: Event): void {
-		if (!this.interacting || this.variant !== 'single') {
-			return;
-		}
-
-		this.interacting = false;
-		this.commitSingleValue(event.target as HTMLInputElement);
-	}
-
-	@onEvent({ ref: 'input', type: 'pointercancel' })
-	onPointerCancel(event: Event): void {
-		if (!this.interacting || this.variant !== 'single') {
-			return;
-		}
-
-		this.interacting = false;
-		this.commitSingleValue(event.target as HTMLInputElement);
-	}
-
-	@onEvent({ ref: 'input', type: 'input' })
-	onInput(event: Event): void {
-		if (this.variant !== 'single') {
-			return;
-		}
-
-		const input = event.target as HTMLInputElement;
-		const next = Number(input.value);
-		this.updateDisplayedValue(next);
-
-		if (this.interacting) {
-			this.changeEvent.emit({ value: next });
-			return;
-		}
-
-		this.commitSingleValue(input);
-	}
-
-	@onEvent({ ref: 'input', type: 'change' })
-	onChange(event: Event): void {
-		if (this.variant !== 'single') {
-			return;
-		}
-
-		this.interacting = false;
-		this.commitSingleValue(event.target as HTMLInputElement);
-	}
-
-	@onEvent({ selector: '[data-thumb]', type: 'pointerdown' })
-	onThumbPointerDown(event: PointerEvent): void {
-		if (event.button !== 0 || this.variant !== 'range' || this.disabled) {
+		if (event.button !== 0 || this.disabled || this.readOnly) {
 			return;
 		}
 
 		const thumbElement = (event.target as HTMLElement).closest<HTMLElement>('[data-thumb]');
-		if (!thumbElement) {
-			return;
-		}
-
-		const thumb = thumbElement.getAttribute('data-thumb') as 'min' | 'max';
+		const fromThumb = this.parseThumb(thumbElement?.getAttribute('data-thumb') ?? null);
+		const next = this.valueFromPointer(event);
+		const thumb = fromThumb ?? this.nearestThumb(next);
+		this.pending = this.committedValues();
+		this.lastEmitted = this.pending.join(',');
 		this.activeThumb = thumb;
-		this.pendingRange = [this.rangeMin, this.rangeMax];
-		thumbElement.setPointerCapture(event.pointerId);
+		this.activePointerId = event.pointerId;
+		this.rangeTrack?.setPointerCapture(event.pointerId);
+		this.thumbFor(thumb)?.focus();
+		if (!fromThumb) {
+			this.moveThumb(thumb, next);
+		}
 		event.preventDefault();
 	}
 
-	@onEvent({ selector: '[data-thumb]', type: 'pointermove' })
-	onThumbPointerMove(event: PointerEvent): void {
-		if (!this.activeThumb || this.variant !== 'range') {
+	/**
+	 * @remarks Pointermove is observed on `document` so drag still tracks when
+	 * testing-library dispatches move events off the thumb/track (no capture retarget).
+	 */
+	@onEvent({ document: true, type: 'pointermove' })
+	onPointerMove(event: PointerEvent): void {
+		if (!this.activeThumb || event.pointerId !== this.activePointerId) {
 			return;
 		}
 
-		const track = this.querySelector<HTMLElement>('.rui-slider__range-track');
-		if (!track) {
-			return;
-		}
-
-		this.setRangeValue(this.activeThumb, this.valueFromPointer(event.clientX, track));
-
-		if (this.pendingRange) {
-			this.changeEvent.emit({ values: this.pendingRange });
-		}
+		this.moveThumb(this.activeThumb, this.valueFromPointer(event));
 	}
 
-	@onEvent({ selector: '[data-thumb]', type: 'pointerup' })
-	onThumbPointerUp(): void {
-		if (!this.activeThumb || this.variant !== 'range') {
+	@onEvent({ document: true, type: 'pointerup' })
+	onPointerUp(event: PointerEvent): void {
+		if (!this.activeThumb || event.pointerId !== this.activePointerId) {
 			return;
 		}
 
-		this.commitRange();
-		this.activeThumb = null;
+		this.releasePointer(event);
+		this.commit();
 	}
 
-	@onEvent({ selector: '[data-thumb]', type: 'pointercancel' })
-	onThumbPointerCancel(): void {
-		if (!this.activeThumb || this.variant !== 'range') {
+	@onEvent({ document: true, type: 'pointercancel' })
+	onPointerCancel(event: PointerEvent): void {
+		if (!this.activeThumb || event.pointerId !== this.activePointerId) {
 			return;
 		}
 
-		this.pendingRange = null;
-		this.syncRangeUi();
-		this.activeThumb = null;
+		this.releasePointer(event);
+		this.revert();
 	}
 
 	@onEvent({ selector: '[data-thumb]', type: 'keydown' })
 	onThumbKeydown(event: KeyboardEvent): void {
-		if (this.variant !== 'range' || this.disabled) {
+		if (this.disabled || this.readOnly) {
 			return;
 		}
 
 		const thumbElement = (event.target as HTMLElement).closest<HTMLElement>('[data-thumb]');
-		if (!thumbElement) {
+		const thumb = this.parseThumb(thumbElement?.getAttribute('data-thumb') ?? null);
+		if (!thumb) {
 			return;
 		}
 
-		const thumb = thumbElement.getAttribute('data-thumb') as 'min' | 'max';
-		const current = thumb === 'min' ? this.rangeMin : this.rangeMax;
-		let next = current;
-
-		switch (event.key) {
-			case 'ArrowRight':
-			case 'ArrowUp':
-				next = this.clamp(current + this.step);
-				break;
-			case 'ArrowLeft':
-			case 'ArrowDown':
-				next = this.clamp(current - this.step);
-				break;
-			case 'Home':
-				next = this.min;
-				break;
-			case 'End':
-				next = this.max;
-				break;
-			case 'PageUp':
-				next = this.clamp(current + this.step * 10);
-				break;
-			case 'PageDown':
-				next = this.clamp(current - this.step * 10);
-				break;
-			default:
-				return;
+		const values = this.committedValues();
+		const current = thumb === 'max' ? values[values.length - 1] : values[0];
+		const next = valueFromSliderKey(this.numericRange, current, event.key);
+		if (next == null) {
+			return;
 		}
 
 		event.preventDefault();
-		this.setRangeValue(thumb, next);
-		this.commitRange(false);
-		this.changeEvent.emit({ values: [this.rangeMin, this.rangeMax] });
-		this.activeThumb = null;
-	}
-
-	override render() {
-		const [displayedRangeMin, displayedRangeMax] = this.getActiveRange();
-		const displayedSingleValue = this.displayedValue ?? this.value;
-
-		if (this.variant === 'range') {
-			return (
-				<div class="rui-slider rui-slider--range">
-					{this.label ? <span class="rui-slider__label">{this.label}</span> : null}
-					<div class="rui-slider__range">
-						<div class="rui-slider__range-track">
-							<div class="rui-slider__range-fill" data-ref="rangeFill" />
-							<button
-								type="button"
-								class="rui-slider__thumb"
-								data-ref="rangeMinThumb"
-								data-thumb="min"
-								role="slider"
-								tabindex={this.resolvedDisabledTabindex}
-								aria-label={this.resolvedMinLabel}
-								aria-valuemin={this.min}
-								aria-valuemax={displayedRangeMax}
-								aria-valuenow={displayedRangeMin}
-								disabled={this.$.disabled}
-							/>
-							<button
-								type="button"
-								class="rui-slider__thumb"
-								data-ref="rangeMaxThumb"
-								data-thumb="max"
-								role="slider"
-								tabindex={this.resolvedDisabledTabindex}
-								aria-label={this.resolvedMaxLabel}
-								aria-valuemin={displayedRangeMin}
-								aria-valuemax={this.max}
-								aria-valuenow={displayedRangeMax}
-								disabled={this.$.disabled}
-							/>
-						</div>
-					</div>
-					<span class="rui-slider__value" data-ref="value" aria-hidden="true">
-						{displayedRangeMin} – {displayedRangeMax}
-					</span>
-				</div>
-			);
-		}
-
-		return (
-			<label class="rui-slider">
-				{this.label ? <span class="rui-slider__label">{this.label}</span> : null}
-				<input
-					type="range"
-					data-ref="input"
-					data-rui-control
-					data-rui-control-type="number"
-					class="rui-slider__input"
-					disabled={this.$.disabled}
-					name={this.resolvedName}
-					aria-valuemin={this.min}
-					aria-valuemax={this.max}
-					aria-valuenow={this.value}
-				/>
-				<span class="rui-slider__value" data-ref="value" aria-hidden="true">
-					{displayedSingleValue}
-				</span>
-			</label>
-		);
+		this.lastEmitted = values.join(',');
+		this.moveThumb(thumb, next);
+		this.commit();
 	}
 }

--- a/packages/radiant-ui/src/components/ui/slider/slider.stories.tsx
+++ b/packages/radiant-ui/src/components/ui/slider/slider.stories.tsx
@@ -8,54 +8,43 @@ import { RuiSlider as RuiSliderElement } from './slider.script';
 const meta = {
 	title: 'Components/Slider',
 	component: RuiSlider,
-	parameters: { radiant: { element: RuiSliderElement, cssImports: ['./slider.css'] } },
-	args: { value: 40, min: 0, max: 100, step: 1, label: 'Volume' },
+	parameters: { radiant: { element: RuiSliderElement, cssImports: ['./slider.css', '../field/field.css'] } },
+	args: { value: 21, min: 0, max: 100, step: 1, label: 'Opacity', showValue: true },
 } satisfies Meta<typeof RuiSlider>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-const getInput = (canvasElement: HTMLElement) =>
-	canvasElement.querySelector('rui-slider input[type="range"]') as HTMLInputElement;
+const getHiddenInput = (root: HTMLElement) =>
+	root.querySelector('rui-slider input[type="hidden"]') as HTMLInputElement;
 
-const getValueLabel = (canvasElement: HTMLElement) =>
-	canvasElement.querySelector('rui-slider .rui-slider__value') as HTMLElement;
+const getSingleThumb = (root: HTMLElement) =>
+	root.querySelector('rui-slider [data-thumb="value"]') as HTMLButtonElement;
 
-const setNativeValue = (input: HTMLInputElement, value: string): void => {
-	const descriptor = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value');
-	descriptor?.set?.call(input, value);
-};
+const getValueLabel = (root: HTMLElement) =>
+	root.querySelector('rui-slider .rui-slider__value') as HTMLElement;
 
 export const Default: Story = {
-	play: async ({ canvasElement, step }) => {
-		const host = canvasElement.querySelector('rui-slider') as HTMLElement;
-		const input = getInput(canvasElement);
+	play: async ({ canvasElement: root, step }) => {
+		const host = root.querySelector('rui-slider') as HTMLElement;
+		const input = getHiddenInput(root);
+		const thumb = getSingleThumb(root);
 
 		await step('exposes the current value', async () => {
-			await expect(input).toHaveValue('40');
-			await expect(getValueLabel(canvasElement)).toHaveTextContent('40');
+			await expect(input).toHaveValue('21');
+			await expect(getValueLabel(root)).toHaveTextContent('21');
 		});
 
-		await step('changing the range emits rui-change', async () => {
-			const emissions: number[] = [];
-			host.addEventListener('rui-change', (event) =>
-				emissions.push((event as CustomEvent<{ value: number }>).detail.value),
-			);
-			setNativeValue(input, '70');
-			input.dispatchEvent(new Event('input', { bubbles: true }));
-			input.dispatchEvent(new Event('change', { bubbles: true }));
-			await expect(emissions).toEqual([70]);
-			await expect(host).toHaveAttribute('value', '70');
-			await expect(getValueLabel(canvasElement)).toHaveTextContent('70');
+		await step('keyboard nudges the thumb', async () => {
+			thumb.focus();
+			await userEvent.keyboard('{ArrowRight}');
+			await expect(host).toHaveAttribute('value', '22');
+			await expect(getValueLabel(root)).toHaveTextContent('22');
 		});
 
-		await step('pointer drag moves from a low value to a high value', async () => {
-			setNativeValue(input, '10');
-			input.dispatchEvent(new Event('input', { bubbles: true }));
-			input.dispatchEvent(new Event('change', { bubbles: true }));
-			await expect(host).toHaveAttribute('value', '10');
-
-			const rect = input.getBoundingClientRect();
+		await step('pointer drag moves the thumb', async () => {
+			const track = root.querySelector('.rui-slider__range-track') as HTMLElement;
+			const rect = track.getBoundingClientRect();
 			const midY = rect.top + rect.height / 2;
 			const startX = rect.left + rect.width * 0.1;
 			const endX = rect.left + rect.width * 0.9;
@@ -65,36 +54,33 @@ export const Default: Story = {
 				emissions.push((event as CustomEvent<{ value: number }>).detail.value),
 			);
 
-			input.dispatchEvent(
-				new PointerEvent('pointerdown', { bubbles: true, button: 0, clientX: startX, clientY: midY }),
-			);
-
-			for (const value of [25, 45, 65, 85]) {
-				setNativeValue(input, String(value));
-				input.dispatchEvent(new Event('input', { bubbles: true }));
-			}
-
-			input.dispatchEvent(
-				new PointerEvent('pointerup', { bubbles: true, button: 0, clientX: endX, clientY: midY }),
-			);
-			input.dispatchEvent(new Event('change', { bubbles: true }));
-
-			const finalValue = Number(input.value);
-			await expect(finalValue).toBeGreaterThanOrEqual(80);
-			await expect(host).toHaveAttribute('value', String(finalValue));
-			await expect(getValueLabel(canvasElement)).toHaveTextContent(String(finalValue));
-			await expect(emissions).toContain(85);
-			await expect(emissions.at(-1)).toBe(finalValue);
+			thumb.focus();
+			await expect(thumb).toHaveFocus();
 
 			await userEvent.pointer([
-				{ keys: '[MouseLeft>]', target: input, coords: { clientX: startX, clientY: midY } },
+				{ keys: '[MouseLeft>]', target: thumb, coords: { clientX: startX, clientY: midY } },
 				{ coords: { clientX: endX, clientY: midY } },
 				{ keys: '[/MouseLeft]' },
 			]);
 
-			const pointerValue = Number(input.value);
-			await expect(pointerValue).toBeGreaterThanOrEqual(70);
-			await expect(host).toHaveAttribute('value', String(pointerValue));
+			await expect(thumb).toHaveFocus();
+			await expect(Number(host.getAttribute('value'))).toBeGreaterThan(22);
+			await expect(emissions.length).toBeGreaterThan(0);
+		});
+
+		await step('switches between single and range presentation without replacing its view', async () => {
+			const slider = host as unknown as RuiSliderElement;
+			slider.showValue = false;
+			await expect(getValueLabel(root)).toHaveAttribute('hidden');
+			slider.showValue = true;
+			await expect(getValueLabel(root)).not.toHaveAttribute('hidden');
+
+			slider.variant = 'range';
+			const [minThumb, maxThumb] = getRangeThumbs(root);
+
+			await expect(getSingleThumb(root)).toHaveAttribute('hidden');
+			await expect(minThumb).not.toHaveAttribute('hidden');
+			await expect(maxThumb).not.toHaveAttribute('hidden');
 		});
 	},
 };
@@ -103,8 +89,48 @@ export const Disabled: Story = {
 	args: { disabled: true },
 };
 
-const getRangeThumbs = (canvasElement: HTMLElement) =>
-	Array.from(canvasElement.querySelectorAll('rui-slider [data-thumb]')) as HTMLButtonElement[];
+export const Vertical: Story = {
+	args: {
+		orientation: 'vertical',
+		value: 40,
+		label: 'Volume',
+		showValue: true,
+	},
+	render: (args) => (
+		<div style={{ height: '12rem' }}>
+			<RuiSlider {...args} />
+		</div>
+	),
+	play: async ({ canvasElement: root, step }) => {
+		const host = root.querySelector('rui-slider') as HTMLElement;
+		const thumb = getSingleThumb(root);
+
+		await step('renders a vertical track', async () => {
+			await expect(host.querySelector('.rui-slider--vertical')).toBeTruthy();
+			await expect(thumb).toHaveAttribute('aria-orientation', 'vertical');
+		});
+
+		await step('pointer drag moves the value upward', async () => {
+			const track = root.querySelector('.rui-slider__range-track') as HTMLElement;
+			const rect = track.getBoundingClientRect();
+			const midX = rect.left + rect.width / 2;
+			const startY = rect.bottom - rect.height * 0.1;
+			const endY = rect.top + rect.height * 0.1;
+
+			thumb.focus();
+			await userEvent.pointer([
+				{ keys: '[MouseLeft>]', target: thumb, coords: { clientX: midX, clientY: startY } },
+				{ coords: { clientX: midX, clientY: endY } },
+				{ keys: '[/MouseLeft]' },
+			]);
+
+			await expect(Number(host.getAttribute('value'))).toBeGreaterThan(40);
+		});
+	},
+};
+
+const getRangeThumbs = (root: HTMLElement) =>
+	Array.from(root.querySelectorAll('rui-slider [data-thumb="min"], rui-slider [data-thumb="max"]')) as HTMLButtonElement[];
 
 export const Range: Story = {
 	args: {
@@ -114,15 +140,18 @@ export const Range: Story = {
 		max: 100,
 		step: 1,
 		values: [20, 80],
+		showValue: true,
 	},
-	play: async ({ canvasElement, step }) => {
-		const host = canvasElement.querySelector('rui-slider') as HTMLElement;
-		const [minThumb, maxThumb] = getRangeThumbs(canvasElement);
+	play: async ({ canvasElement: root, step }) => {
+		const host = root.querySelector('rui-slider') as HTMLElement;
+		const [minThumb, maxThumb] = getRangeThumbs(root);
 
 		await step('shows the current range', async () => {
 			await expect(host).toHaveAttribute('range-min', '20');
 			await expect(host).toHaveAttribute('range-max', '80');
-			await expect(getValueLabel(canvasElement)).toHaveTextContent('20 – 80');
+			await expect(getValueLabel(root)).toHaveTextContent('20 – 80');
+			await expect(root.querySelector('rui-slider [data-ref="input"]')).toHaveValue('20');
+			await expect(root.querySelector('rui-slider [data-ref="maxInput"]')).toHaveValue('80');
 		});
 
 		await step('keyboard nudges the minimum thumb', async () => {
@@ -138,11 +167,14 @@ export const Range: Story = {
 		});
 
 		await step('pointer drag moves the minimum thumb', async () => {
-			const track = canvasElement.querySelector('.rui-slider__range-track') as HTMLElement;
+			const track = root.querySelector('.rui-slider__range-track') as HTMLElement;
 			const rect = track.getBoundingClientRect();
 			const midY = rect.top + rect.height / 2;
 			const startX = rect.left + rect.width * 0.2;
 			const endX = rect.left + rect.width * 0.35;
+
+			minThumb.focus();
+			await expect(minThumb).toHaveFocus();
 
 			await userEvent.pointer([
 				{ keys: '[MouseLeft>]', target: minThumb, coords: { clientX: startX, clientY: midY } },
@@ -150,7 +182,82 @@ export const Range: Story = {
 				{ keys: '[/MouseLeft]' },
 			]);
 
+			await expect(minThumb).toHaveFocus();
 			await expect(Number(host.getAttribute('range-min'))).toBeGreaterThan(21);
+		});
+	},
+};
+
+export const VerticalRange: Story = {
+	args: {
+		variant: 'range',
+		orientation: 'vertical',
+		label: 'Price',
+		min: 0,
+		max: 100,
+		step: 1,
+		values: [20, 80],
+		showValue: true,
+	},
+	render: (args) => (
+		<div style={{ height: '12rem' }}>
+			<RuiSlider {...args} />
+		</div>
+	),
+	play: async ({ canvasElement: root, step }) => {
+		const host = root.querySelector('rui-slider') as HTMLElement;
+		const [minThumb] = getRangeThumbs(root);
+
+		await step('renders a vertical range track', async () => {
+			await expect(host.querySelector('.rui-slider--vertical')).toBeTruthy();
+		});
+
+		await step('pointer drag moves the minimum thumb upward', async () => {
+			const track = root.querySelector('.rui-slider__range-track') as HTMLElement;
+			const rect = track.getBoundingClientRect();
+			const midX = rect.left + rect.width / 2;
+			const startY = rect.bottom - rect.height * 0.2;
+			const endY = rect.top + rect.height * 0.35;
+
+			minThumb.focus();
+			await userEvent.pointer([
+				{ keys: '[MouseLeft>]', target: minThumb, coords: { clientX: midX, clientY: startY } },
+				{ coords: { clientX: midX, clientY: endY } },
+				{ keys: '[/MouseLeft]' },
+			]);
+
+			await expect(Number(host.getAttribute('range-min'))).toBeGreaterThan(20);
+		});
+	},
+};
+
+export const Customized: Story = {
+	parameters: {
+		radiant: {
+			element: RuiSliderElement,
+			cssImports: ['./slider.css', '../../../stories/fixtures/slider-custom.css'],
+		},
+	},
+	render: () => (
+		<div class="slider-shape-demo">
+			<RuiSlider variant="range" min={0} max={100} values={[28, 72]} showValue valueTitle />
+		</div>
+	),
+	play: async ({ canvasElement: root, step }) => {
+		await step('styles track and thumb via slider css variables', async () => {
+			const track = root.querySelector('.slider-shape-demo .rui-slider__range-track') as HTMLElement;
+			const thumb = root.querySelector('.slider-shape-demo .rui-slider__thumb') as HTMLElement;
+
+			await expect(track).toBeTruthy();
+			await expect(thumb).toBeTruthy();
+			await expect(track.getBoundingClientRect().height).toBeGreaterThan(thumb.getBoundingClientRect().height);
+			await expect(getComputedStyle(track).borderRadius).not.toBe('');
+			await expect(getComputedStyle(thumb).borderRadius).not.toBe('');
+		});
+
+		await step('exposes live value in the control title tooltip', async () => {
+			const thumb = root.querySelector('.slider-shape-demo [data-thumb="min"]') as HTMLElement;
+			await expect(thumb).toHaveAttribute('title');
 		});
 	},
 };
@@ -165,9 +272,9 @@ export const RangeMinDistance: Story = {
 		minDistance: 20,
 		values: [30, 60],
 	},
-	play: async ({ canvasElement, step }) => {
-		const host = canvasElement.querySelector('rui-slider') as HTMLElement;
-		const [minThumb] = getRangeThumbs(canvasElement);
+	play: async ({ canvasElement: root, step }) => {
+		const host = root.querySelector('rui-slider') as HTMLElement;
+		const [minThumb] = getRangeThumbs(root);
 
 		await step('thumbs cannot move closer than minDistance', async () => {
 			minThumb.focus();
@@ -190,4 +297,12 @@ export const AsField: Story = {
 			<RuiFieldError />
 		</RuiField>
 	),
+	play: async ({ canvasElement: root, step }) => {
+		await step('connects the field label to the focusable slider thumb', async () => {
+			const label = root.querySelector('.rui-label') as HTMLLabelElement;
+			const thumb = getSingleThumb(root);
+
+			await expect(label).toHaveAttribute('for', thumb.id);
+		});
+	},
 };

--- a/packages/radiant-ui/src/components/ui/slider/slider.tsx
+++ b/packages/radiant-ui/src/components/ui/slider/slider.tsx
@@ -1,6 +1,23 @@
-import type { JsxCustomElementAttributes } from '@ecopages/jsx';
+import type { JsxCustomElementAttributes, JsxElementProps } from '@ecopages/jsx';
+import { cx } from '@/lib/cx';
 import type { RuiSlider as RuiSliderElement, RuiSliderProps } from './slider.script';
 import './slider.script';
+
+export type RuiSliderValueProps = JsxElementProps<HTMLSpanElement>;
+
+/**
+ * Live value readout for `RuiSlider`. The element keeps this node in sync
+ * imperatively while dragging.
+ *
+ * @cssclass rui-slider__value - Numeric readout (`aria-hidden="true"`).
+ */
+export function RuiSliderValue({ children, class: className, ...props }: RuiSliderValueProps) {
+	return (
+		<span {...props} class={cx('rui-slider__value', className)} data-ref="value" aria-hidden="true">
+			{children}
+		</span>
+	);
+}
 
 export type RuiSliderViewProps = JsxCustomElementAttributes<
 	RuiSliderElement,
@@ -9,6 +26,109 @@ export type RuiSliderViewProps = JsxCustomElementAttributes<
 	}
 >;
 
-export function RuiSlider({ values, ...props }: RuiSliderViewProps) {
-	return <rui-slider {...props} rangeMin={values?.[0]} rangeMax={values?.[1]} />;
+function SliderTrack({ disabled, min, max, label, variant }: Omit<RuiSliderProps, 'value'>) {
+	const single = variant !== 'range';
+	const thumbLabel = label || 'Value';
+
+	return (
+		<div class="rui-slider__range">
+			<div class="rui-slider__range-track" data-ref="rangeTrack">
+				<div class="rui-slider__range-fill" data-ref="rangeFill" />
+				<button
+					type="button"
+					class="rui-slider__thumb"
+					data-ref="singleThumb"
+					data-thumb="value"
+					role="slider"
+					tabindex={disabled || !single ? -1 : 0}
+					aria-label={thumbLabel}
+					aria-valuemin={min}
+					aria-valuemax={max}
+					disabled={disabled || !single}
+					hidden={!single}
+				/>
+				<button
+					type="button"
+					class="rui-slider__thumb"
+					data-ref="rangeMinThumb"
+					data-thumb="min"
+					role="slider"
+					tabindex={disabled || single ? -1 : 0}
+					aria-label={label ? `${label} minimum` : 'Minimum value'}
+					aria-valuemin={min}
+					aria-valuemax={max}
+					disabled={disabled || single}
+					hidden={single}
+				/>
+				<button
+					type="button"
+					class="rui-slider__thumb"
+					data-ref="rangeMaxThumb"
+					data-thumb="max"
+					role="slider"
+					tabindex={disabled || single ? -1 : 0}
+					aria-label={label ? `${label} maximum` : 'Maximum value'}
+					aria-valuemin={min}
+					aria-valuemax={max}
+					disabled={disabled || single}
+					hidden={single}
+				/>
+			</div>
+		</div>
+	);
+}
+
+/**
+ * Single- or dual-thumb slider styled with CSS variables on the track and thumbs.
+ * When `children` is omitted, the view supplies a default `RuiSliderValue` that
+ * the element shows or hides through `showValue`.
+ */
+export function RuiSlider({
+	values,
+	variant = 'single',
+	orientation = 'horizontal',
+	label,
+	showValue = false,
+	valueTitle = false,
+	disabled,
+	name,
+	min,
+	max,
+	children,
+	...props
+}: RuiSliderViewProps) {
+	const valueReadout = children ?? <RuiSliderValue data-default-value hidden={!showValue} />;
+	const hasVisibleReadout = Boolean(children) || showValue;
+
+	return (
+		<rui-slider
+			{...props}
+			variant={variant}
+			orientation={orientation}
+			label={label}
+			showValue={showValue}
+			valueTitle={valueTitle}
+			disabled={disabled}
+			name={name}
+			min={min}
+			max={max}
+			rangeMin={values?.[0]}
+			rangeMax={values?.[1]}
+		>
+			<div
+				class={cx('rui-slider', variant === 'range' ? 'rui-slider--range' : 'rui-slider--single', orientation === 'vertical' && 'rui-slider--vertical')}
+				data-ref="root"
+			>
+				<div class="rui-slider__header" data-ref="header" hidden={!label && !hasVisibleReadout}>
+					<span class="rui-slider__label" data-ref="label" hidden={!label}>
+						{label}
+					</span>
+					{valueReadout}
+				</div>
+				<SliderTrack disabled={disabled} min={min} max={max} label={label} variant={variant} />
+				<input type="hidden" data-ref="input" name={name || undefined} />
+				<input type="hidden" data-ref="maxInput" />
+			</div>
+		</rui-slider>
+	);
 }

--- a/packages/radiant-ui/src/stories/fixtures/slider-custom.css
+++ b/packages/radiant-ui/src/stories/fixtures/slider-custom.css
@@ -1,0 +1,13 @@
+@reference '../../styles/radiant-ui.css';
+
+.slider-shape-demo {
+	@apply flex justify-center p-6;
+}
+
+.slider-shape-demo rui-slider {
+	--rui-slider-track-size: 1.25rem;
+	--rui-slider-thumb-size: 0.875rem;
+	--rui-slider-thumb-border-width: 2px;
+	--rui-slider-thumb-radius: 0;
+	--rui-slider-track-radius: var(--radius-container);
+}


### PR DESCRIPTION
Rewrite slider with view-owned markup, vertical orientation, and shared
numeric-range keyboard model.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>