### PR TITLE
feat(radiant-ui): add hover-card preview primitive

### DIFF
--- a/.changeset/radiant-ui-hover-card.md
+++ b/.changeset/radiant-ui-hover-card.md
@@ -1,0 +1,5 @@
+---
+'@ecopages/radiant-ui': minor
+---
+
+Add `RuiHoverCard` for rich hover previews with composable trigger and content.

--- a/apps/radiant-ui/src/content/components/hover-card.mdx
+++ b/apps/radiant-ui/src/content/components/hover-card.mdx
@@ -1,0 +1,113 @@
+---
+title: Hover Card
+description: Hover cards preview rich content behind a link or control on hover or focus.
+category: Overlays
+---
+
+import { meta as HoverCardMeta, Default } from '@/content/stories/hover-card';
+import Canvas from '@/components/component-docs/canvas';
+import Demo from '@/components/component-docs/demo';
+
+export const config = {
+	dependencies: {
+		components: [Canvas, Demo],
+		scripts: [
+			'../../components/component-docs/demo.script.tsx',
+			'../../components/component-docs/canvas.script.tsx',
+			'../../components/component-docs/controls.script.tsx',
+		],
+	},
+};
+
+
+# Hover Card
+
+<p class="docs-lede">Hover cards preview rich content behind a link or control on hover or focus — profiles, link previews, and other supplementary detail.</p>
+
+## Try it
+
+<Demo of={Default} meta={HoverCardMeta} />
+
+## Usage
+
+Compose a trigger and content surface. Tune `delay` and `closeDelay` so pointer movement can reach interactive content inside the card.
+
+```tsx
+import {
+  RuiHoverCard,
+  RuiHoverCardContent,
+  RuiHoverCardTrigger,
+} from '@ecopages/radiant-ui/hover-card';
+import { RuiAvatar } from '@ecopages/radiant-ui/avatar';
+import { RuiButton } from '@ecopages/radiant-ui/button';
+
+<RuiHoverCard delay={600} closeDelay={200} placement="bottom-start">
+  <RuiHoverCardTrigger>
+    <RuiButton variant="link">Jane Cooper</RuiButton>
+  </RuiHoverCardTrigger>
+  <RuiHoverCardContent>
+    <div class="flex gap-3">
+      <RuiAvatar fallback="JC" alt="Jane Cooper" />
+      <div class="flex flex-col gap-1">
+        <p class="font-medium text-sm">Jane Cooper</p>
+        <p class="text-on-surface text-xs opacity-80">Product designer on the Radiant team.</p>
+      </div>
+    </div>
+  </RuiHoverCardContent>
+</RuiHoverCard>
+```
+
+## Hover card vs tooltip
+
+<p>Use `RuiTooltip` for short, non-interactive descriptions. Use `RuiHoverCard` when the preview includes links, avatars, or other focusable content.</p>
+
+## Theming
+
+| Part | CSS roles |
+| --- | --- |
+| Content (`rui-hover-card__content`) | `background`, `on-background`, `border`, `rounded-container`, `shadow-overlay` |
+| Z-order | `overlay` |
+
+## Accessibility
+
+- The same information should remain available without hover (for example via navigation to a full profile page).
+- The preview dialog has a default accessible name (`Preview`). Override with `content-label` when needed.
+- Keyboard users can Tab into card content while it is open.
+- Press Escape to dismiss.
+
+## API
+
+`RuiHoverCard` is a custom element (`<rui-hover-card>`) that shows a floating preview on hover or focus of its trigger.
+
+### Attributes (`<rui-hover-card>`)
+
+| Attribute | Type | Default | Description |
+| --- | --- | --- | --- |
+| `open` | `boolean` | `false` | Whether the card is open (controlled). |
+| `placement` | `RuiPlacement` | `bottom-start` | Placement relative to the anchor. |
+| `delay` | `number` | `600` | Show delay in ms. |
+| `close-delay` | `number` | `200` | Hide delay in ms after pointer/focus leaves. |
+| `portal` | `boolean` | `true` | Teleport the surface to `document.body`. |
+| `disabled` | `boolean` | `false` | Suppress hover/focus preview interactions. |
+| `content-label` | `string` | `Preview` | Accessible name for the preview dialog. |
+
+### Composition
+
+| Piece | Description |
+| --- | --- |
+| `trigger` | Anchor element (link, button, or other focusable control). |
+| `content` | Rich preview content in the floating surface. |
+
+### Events
+
+| Event | Detail | Description |
+| --- | --- | --- |
+| `rui-open-change` | `{ open: boolean }` | Emitted when open state changes. |
+
+### CSS classes
+
+| Class | Description |
+| --- | --- |
+| `.rui-hover-card` | Root wrapper. |
+| `.rui-hover-card__trigger` | Trigger wrapper. |
+| `.rui-hover-card__content` | Floating preview surface. |

--- a/apps/radiant-ui/src/content/stories/hover-card.tsx
+++ b/apps/radiant-ui/src/content/stories/hover-card.tsx
@@ -1,0 +1,52 @@
+import { RuiAvatar } from '@ecopages/radiant-ui/avatar';
+import { RuiButton } from '@ecopages/radiant-ui/button';
+import { RuiHoverCard, RuiHoverCardContent, RuiHoverCardTrigger } from '@ecopages/radiant-ui/hover-card';
+import { docsStory, type DocsMeta, type DocsStory } from '@/lib/docs-stories';
+
+export type HoverCardArgs = {
+	placement: 'top' | 'bottom' | 'left' | 'right' | 'bottom-start';
+	delay: number;
+	closeDelay: number;
+};
+
+export const meta = {
+	args: {
+		placement: 'bottom-start',
+		delay: 600,
+		closeDelay: 200,
+	},
+	argTypes: {
+		placement: {
+			control: { type: 'select' },
+			options: [
+				'top',
+				'bottom',
+				'left',
+				'right',
+				'bottom-start',
+			] as const satisfies readonly HoverCardArgs['placement'][],
+		},
+		delay: { control: { type: 'number' } },
+		closeDelay: { control: { type: 'number' } },
+	},
+	render: (args) => (
+		<RuiHoverCard placement={args.placement} delay={args.delay} closeDelay={args.closeDelay}>
+			<RuiHoverCardTrigger>
+				<RuiButton variant="link">Jane Cooper</RuiButton>
+			</RuiHoverCardTrigger>
+			<RuiHoverCardContent>
+				<div class="flex gap-3">
+					<RuiAvatar fallback="JC" alt="Jane Cooper" />
+					<div class="flex flex-col gap-1">
+						<p class="font-medium text-sm">Jane Cooper</p>
+						<p class="text-on-surface text-xs opacity-80">Product designer on the Radiant team.</p>
+					</div>
+				</div>
+			</RuiHoverCardContent>
+		</RuiHoverCard>
+	),
+} satisfies DocsMeta<HoverCardArgs>;
+
+type Story = DocsStory<HoverCardArgs>;
+
+export const Default: Story = docsStory(meta, { parameters: { docs: { id: 'hover-card/default' } } });

--- a/apps/radiant-ui/src/content/stories/index.ts
+++ b/apps/radiant-ui/src/content/stories/index.ts
@@ -48,3 +48,4 @@ import './tooltip';
 import './tree';
 import './treegrid';
 import './window-splitter';
+import './hover-card'

--- a/packages/radiant-ui/package.json
+++ b/packages/radiant-ui/package.json
@@ -336,6 +336,13 @@
 		"./headline/styles.css": {
 			"default": "./dist/components/ui/headline/headline.css"
 		},
+		"./hover-card": {
+			"types": "./dist/components/ui/hover-card/index.d.ts",
+			"import": "./dist/components/ui/hover-card/index.js"
+		},
+		"./hover-card/styles.css": {
+			"default": "./dist/components/ui/hover-card/hover-card.css"
+		},
 		"./input": {
 			"types": "./dist/components/ui/input/index.d.ts",
 			"import": "./dist/components/ui/input/index.js"

--- a/packages/radiant-ui/src/components/ui/hover-card/hover-card.css
+++ b/packages/radiant-ui/src/components/ui/hover-card/hover-card.css
@@ -1,0 +1,23 @@
+@reference '../../../styles/radiant-ui.css';
+
+rui-hover-card {
+	@apply inline-flex;
+}
+
+@layer components {
+	.rui-hover-card {
+		@apply relative inline-flex;
+	}
+
+	.rui-hover-card__trigger {
+		@apply inline-flex;
+	}
+
+	.rui-hover-card__content {
+		@apply z-overlay w-80 rounded-container border border-border bg-background p-4 text-on-background shadow-overlay;
+	}
+
+	.rui-hover-card__content[hidden] {
+		display: none;
+	}
+}

--- a/packages/radiant-ui/src/components/ui/hover-card/hover-card.script.tsx
+++ b/packages/radiant-ui/src/components/ui/hover-card/hover-card.script.tsx
@@ -1,0 +1,316 @@
+import { RadiantElement, bound, customElement, event, onEvent, onUpdated, prop, query } from '@ecopages/radiant';
+import type { EventEmitter } from '@ecopages/radiant/tools/event-emitter';
+import { findFirstFocusableCandidate } from '@/lib/focusable-elements';
+import { notePreviewClosed, notePreviewOpened, resolvePreviewOpenDelay } from '../shared/preview-timing';
+import { PopoverController, shouldDismissPopoverFocus } from '../shared/popover-controller';
+import type { RuiPlacement } from '../shared/placement';
+
+export type RuiHoverCardOpenChangeDetail = {
+	open: boolean;
+};
+
+export type RuiHoverCardProps = {
+	/** Whether the card is open (controlled). */
+	open?: boolean;
+	/** Placement of the card relative to its anchor. Default: `bottom-start`. */
+	placement?: RuiPlacement;
+	/** Delay in ms before showing on hover/focus. Default: `600`. */
+	delay?: number;
+	/** Delay in ms before hiding after pointer/focus leaves. Default: `200`. */
+	closeDelay?: number;
+	/** Teleport the surface to `document.body`. Default: `true`. */
+	portal?: boolean;
+	/** Suppress hover/focus preview interactions. */
+	disabled?: boolean;
+	/** Accessible name for the preview dialog. Default: `Preview`. */
+	contentLabel?: string;
+};
+
+/**
+ * Default accessible name for the preview dialog.
+ *
+ * @remarks Must match the host `@prop` default: the SSR view seeds
+ * `content-label` with it so the dialog is named before hydration.
+ */
+export const HOVER_CARD_DEFAULT_CONTENT_LABEL = 'Preview';
+
+const HOVER_CARD_GAP = 8;
+const LONG_PRESS_MS = 500;
+
+/**
+ * `<rui-hover-card>` — a floating preview surfaced on hover or focus.
+ *
+ * Unlike `rui-tooltip`, the card can hold rich, interactive content (links,
+ * avatars, buttons). It is not an APG tooltip: the panel does not use
+ * `role="tooltip"` and may receive pointer and keyboard focus while open.
+ *
+ * Preview timing uses a shared warmup/cooldown model shared with `rui-tooltip`: the first
+ * preview waits for `delay`, then subsequent previews open immediately until the post-close
+ * cooldown elapses. Touch pointers open on long press.
+ *
+ * @element rui-hover-card
+ * @attr {boolean} disabled - Suppress hover/focus preview interactions. Default: `false`.
+ * @attr {string} content-label - Accessible name for the preview dialog. Default: `Preview`.
+ * @fires rui-open-change - Emitted when open state changes; `detail.open`.
+ * @cssclass rui-hover-card - Root wrapper.
+ * @cssclass rui-hover-card__trigger - Host wrapper for the trigger.
+ * @cssclass rui-hover-card__content - Floating preview surface.
+ */
+@customElement('rui-hover-card')
+export class RuiHoverCard extends RadiantElement {
+	@prop({ type: Boolean, reflect: true, defaultValue: false }) open: boolean;
+	@prop({ type: String, defaultValue: 'bottom-start' }) placement: RuiPlacement;
+	@prop({ type: Number, defaultValue: 600 }) delay: number;
+	@prop({ type: Number, defaultValue: 200 }) closeDelay: number;
+	@prop({ type: Boolean, defaultValue: true }) portal: boolean;
+	@prop({ type: Boolean, reflect: true, defaultValue: false }) disabled: boolean;
+	@prop({ type: String, attribute: 'content-label', reflect: true, defaultValue: HOVER_CARD_DEFAULT_CONTENT_LABEL })
+	contentLabel: string;
+
+	@query({ ref: 'content' }) contentTarget: HTMLElement;
+
+	@event({ name: 'rui-open-change', bubbles: true, composed: true })
+	openChangeEvent: EventEmitter<RuiHoverCardOpenChangeDetail>;
+
+	private readonly contentId = `rui-hover-card-${Math.random().toString(36).slice(2, 9)}`;
+	private controller: PopoverController | null = null;
+	private showTimer: ReturnType<typeof setTimeout> | null = null;
+	private hideTimer: ReturnType<typeof setTimeout> | null = null;
+	private longPressTimer: ReturnType<typeof setTimeout> | null = null;
+	private openedByKeyboard = false;
+
+	override connectedCallback(): void {
+		super.connectedCallback();
+		this.addEventListener('pointerenter', this.onPointerEnter);
+		this.addEventListener('pointerleave', this.onPointerLeave);
+		this.addEventListener('pointerdown', this.onPointerDown);
+		this.addEventListener('pointerup', this.onPointerUp);
+		this.addEventListener('pointercancel', this.onPointerUp);
+	}
+
+	protected override onConnected(): void {
+		this.syncCard();
+	}
+
+	override disconnectedCallback(): void {
+		this.clearTimers();
+		if (this.open) {
+			notePreviewClosed();
+		}
+		this.controller?.destroy();
+		this.controller = null;
+		this.removeEventListener('pointerenter', this.onPointerEnter);
+		this.removeEventListener('pointerleave', this.onPointerLeave);
+		this.removeEventListener('pointerdown', this.onPointerDown);
+		this.removeEventListener('pointerup', this.onPointerUp);
+		this.removeEventListener('pointercancel', this.onPointerUp);
+		super.disconnectedCallback();
+	}
+
+	private clearTimers(): void {
+		if (this.showTimer) clearTimeout(this.showTimer);
+		if (this.hideTimer) clearTimeout(this.hideTimer);
+		if (this.longPressTimer) clearTimeout(this.longPressTimer);
+		this.showTimer = null;
+		this.hideTimer = null;
+		this.longPressTimer = null;
+	}
+
+	private getAnchor(): HTMLElement | null {
+		const trigger = this.querySelector<HTMLElement>('[data-hover-card-trigger]');
+		if (trigger instanceof HTMLElement) {
+			return findFirstFocusableCandidate(trigger) ?? trigger;
+		}
+		return findFirstFocusableCandidate(this) ?? this;
+	}
+
+	private getFloatingElement(): HTMLElement | null {
+		return this.controller?.getFloatingElement() ?? this.contentTarget;
+	}
+
+	private ensureController(): PopoverController {
+		if (!this.controller) {
+			this.controller = new PopoverController({
+				getAnchor: () => this.getAnchor(),
+				getFloating: () => this.contentTarget,
+				getOpen: () => this.open,
+				getPlacement: () => this.placement,
+				gap: HOVER_CARD_GAP,
+				portal: this.portal,
+			});
+		}
+		return this.controller;
+	}
+
+	@bound
+	@onUpdated(['open', 'placement', 'portal', 'disabled', 'contentLabel'])
+	syncCard(): void {
+		const anchor = this.getAnchor();
+		const surface = this.contentTarget;
+
+		if (surface) {
+			surface.id = this.contentId;
+			surface.setAttribute('aria-label', this.contentLabel);
+		}
+		if (anchor) {
+			anchor.setAttribute('aria-controls', this.contentId);
+			anchor.setAttribute('aria-expanded', String(this.open));
+		}
+
+		const controller = this.ensureController();
+		controller.updateConfig({
+			getAnchor: () => this.getAnchor(),
+			getFloating: () => this.contentTarget,
+			getOpen: () => this.open,
+			getPlacement: () => this.placement,
+			gap: HOVER_CARD_GAP,
+			portal: this.portal,
+		});
+		controller.sync();
+		this.syncContentPointerBridge();
+	}
+
+	private syncContentPointerBridge(): void {
+		const surface = this.getFloatingElement();
+		if (!surface) {
+			return;
+		}
+
+		surface.removeEventListener('pointerenter', this.onPointerEnter);
+		surface.removeEventListener('pointerleave', this.onPointerLeave);
+
+		if (this.open) {
+			surface.addEventListener('pointerenter', this.onPointerEnter);
+			surface.addEventListener('pointerleave', this.onPointerLeave);
+		}
+	}
+
+	setOpen(next: boolean, emit = true): void {
+		if (this.disabled && next) {
+			return;
+		}
+		if (this.open === next) {
+			this.syncCard();
+			return;
+		}
+
+		const wasOpen = this.open;
+		this.open = next;
+
+		if (next) {
+			notePreviewOpened();
+		} else if (wasOpen) {
+			notePreviewClosed();
+		}
+
+		if (emit) {
+			this.openChangeEvent.emit({ open: next });
+		}
+		this.syncCard();
+	}
+
+	private scheduleShow(fromKeyboard = false): void {
+		if (this.disabled || this.open) {
+			return;
+		}
+
+		this.clearTimers();
+		this.openedByKeyboard = fromKeyboard;
+		const effectiveDelay = resolvePreviewOpenDelay(this.delay);
+		if (effectiveDelay <= 0) {
+			this.setOpen(true);
+			return;
+		}
+		this.showTimer = setTimeout(() => this.setOpen(true), effectiveDelay);
+	}
+
+	private scheduleHide(): void {
+		this.clearTimers();
+		const delay = this.closeDelay > 0 ? this.closeDelay : 0;
+		if (delay <= 0) {
+			this.setOpen(false);
+			return;
+		}
+		this.hideTimer = setTimeout(() => this.setOpen(false), delay);
+	}
+
+	private isTouchPointer(event: PointerEvent): boolean {
+		return event.pointerType === 'touch';
+	}
+
+	@onEvent({ document: true, type: 'keydown' })
+	onDocumentKeydown(event: KeyboardEvent): void {
+		if (!this.open || event.key !== 'Escape') {
+			return;
+		}
+		event.preventDefault();
+		this.setOpen(false);
+		this.getAnchor()?.focus();
+	}
+
+	@onEvent({ type: 'focusin', selector: '.rui-hover-card__trigger' })
+	onFocusIn(): void {
+		this.scheduleShow(true);
+	}
+
+	@onEvent({ type: 'focusout', selector: '.rui-hover-card__trigger' })
+	onFocusOut(event: FocusEvent): void {
+		if (!shouldDismissPopoverFocus(this.getAnchor(), this.getFloatingElement(), event.relatedTarget)) {
+			return;
+		}
+		this.scheduleHide();
+	}
+
+	@onEvent({ type: 'keydown', selector: '.rui-hover-card__trigger' })
+	onHostKeydown(event: KeyboardEvent): void {
+		if (!this.open || event.key !== 'Tab' || event.shiftKey || !this.openedByKeyboard) {
+			return;
+		}
+		const floating = this.getFloatingElement();
+		if (!floating) {
+			return;
+		}
+		const first = findFirstFocusableCandidate(floating);
+		if (!first) {
+			return;
+		}
+		event.preventDefault();
+		first.focus();
+	}
+
+	@bound
+	onPointerEnter(event: PointerEvent): void {
+		if (this.isTouchPointer(event)) {
+			return;
+		}
+		this.scheduleShow();
+	}
+
+	@bound
+	onPointerLeave(event: PointerEvent): void {
+		if (this.isTouchPointer(event)) {
+			return;
+		}
+		this.scheduleHide();
+	}
+
+	@bound
+	onPointerDown(event: PointerEvent): void {
+		if (this.disabled || !this.isTouchPointer(event)) {
+			return;
+		}
+		this.clearTimers();
+		this.longPressTimer = setTimeout(() => {
+			this.openedByKeyboard = false;
+			this.setOpen(true);
+		}, LONG_PRESS_MS);
+	}
+
+	@bound
+	onPointerUp(): void {
+		if (this.longPressTimer) {
+			clearTimeout(this.longPressTimer);
+			this.longPressTimer = null;
+		}
+	}
+}

--- a/packages/radiant-ui/src/components/ui/hover-card/hover-card.ssr.test.tsx
+++ b/packages/radiant-ui/src/components/ui/hover-card/hover-card.ssr.test.tsx
@@ -1,0 +1,24 @@
+import { renderToString } from '@ecopages/jsx/server';
+import { describe, expect, it } from 'vitest';
+import { RuiHoverCard, RuiHoverCardContent, RuiHoverCardTrigger } from './hover-card';
+
+describe('RuiHoverCard SSR', () => {
+	it('renders the view-owned trigger and preview shell', () => {
+		const html = renderToString(
+			<RuiHoverCard contentLabel="Preview" placement="bottom-start">
+				<RuiHoverCardTrigger>
+					<button type="button">Jane Cooper</button>
+				</RuiHoverCardTrigger>
+				<RuiHoverCardContent>
+					<p>Preview body</p>
+				</RuiHoverCardContent>
+			</RuiHoverCard>,
+		);
+
+		expect(html).toContain('<rui-hover-card');
+		expect(html).toContain('data-hover-card-trigger');
+		expect(html).toContain('data-ref="content"');
+		expect(html).toContain('Preview body');
+		expect(html).not.toContain('slot=');
+	});
+});

--- a/packages/radiant-ui/src/components/ui/hover-card/hover-card.stories.tsx
+++ b/packages/radiant-ui/src/components/ui/hover-card/hover-card.stories.tsx
@@ -1,0 +1,114 @@
+import type { Meta, StoryObj } from '@ecopages/storybook-radiant-vite';
+import { expect, userEvent } from 'storybook/test';
+import { RuiAvatar } from '../avatar';
+import { RuiButton } from '../button';
+import { RuiHoverCard, RuiHoverCardContent, RuiHoverCardTrigger } from './hover-card';
+import { RuiHoverCard as RuiHoverCardElement } from './hover-card.script';
+
+const meta = {
+	title: 'Components/Hover Card',
+	component: RuiHoverCard,
+	parameters: {
+		radiant: {
+			element: RuiHoverCardElement,
+			cssImports: [
+				'../../../styles/primitives.css',
+				'./hover-card.css',
+				'../avatar/avatar.css',
+				'../button/button.css',
+			],
+		},
+	},
+	args: {
+		delay: 0,
+		closeDelay: 0,
+		placement: 'bottom-start',
+	},
+} satisfies Meta<typeof RuiHoverCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const getContent = (canvasElement: HTMLElement) =>
+	canvasElement.querySelector('rui-hover-card .rui-hover-card__content') as HTMLElement;
+
+export const Default: Story = {
+	render: (args) => (
+		<RuiHoverCard {...args}>
+			<RuiHoverCardTrigger>
+				<RuiButton variant="link">Jane Cooper</RuiButton>
+			</RuiHoverCardTrigger>
+			<RuiHoverCardContent>
+				<div class="flex gap-3">
+					<RuiAvatar fallback="JC" alt="Jane Cooper" />
+					<div class="flex flex-col gap-1">
+						<p class="font-medium text-sm">Jane Cooper</p>
+						<p class="text-on-surface text-xs opacity-80">Product designer on the Radiant team.</p>
+						<p class="text-on-surface text-xs opacity-60">Joined March 2024</p>
+					</div>
+				</div>
+			</RuiHoverCardContent>
+		</RuiHoverCard>
+	),
+	play: async ({ canvasElement, step }) => {
+		const host = canvasElement.querySelector('rui-hover-card') as HTMLElement;
+		const content = getContent(canvasElement);
+		const trigger = host.querySelector('[data-hover-card-trigger] button') as HTMLButtonElement;
+
+		await step('card starts hidden', async () => {
+			await expect(content.hidden).toBe(true);
+		});
+
+		await step('pointer enter shows interactive content', async () => {
+			host.dispatchEvent(new PointerEvent('pointerenter', { bubbles: true, pointerType: 'mouse' }));
+			await expect(content.hidden).toBe(false);
+			await expect(content).toHaveAttribute('aria-label', 'Preview');
+			await expect(content).toHaveTextContent('Jane Cooper');
+		});
+
+		await step('Escape dismisses the card', async () => {
+			trigger.focus();
+			await userEvent.keyboard('{Escape}');
+			await expect(content.hidden).toBe(true);
+		});
+	},
+};
+
+export const Placements: Story = {
+	render: (args) => (
+		<div class="flex flex-wrap gap-8 p-24">
+			<RuiHoverCard {...args} placement="top">
+				<RuiHoverCardTrigger>
+					<RuiButton variant="outline">top</RuiButton>
+				</RuiHoverCardTrigger>
+				<RuiHoverCardContent>
+					<p class="text-sm">Placement: top</p>
+				</RuiHoverCardContent>
+			</RuiHoverCard>
+			<RuiHoverCard {...args} placement="right">
+				<RuiHoverCardTrigger>
+					<RuiButton variant="outline">right</RuiButton>
+				</RuiHoverCardTrigger>
+				<RuiHoverCardContent>
+					<p class="text-sm">Placement: right</p>
+				</RuiHoverCardContent>
+			</RuiHoverCard>
+			<RuiHoverCard {...args} placement="bottom">
+				<RuiHoverCardTrigger>
+					<RuiButton variant="outline">bottom</RuiButton>
+				</RuiHoverCardTrigger>
+				<RuiHoverCardContent>
+					<p class="text-sm">Placement: bottom</p>
+				</RuiHoverCardContent>
+			</RuiHoverCard>
+			<RuiHoverCard {...args} placement="left">
+				<RuiHoverCardTrigger>
+					<RuiButton variant="outline">left</RuiButton>
+				</RuiHoverCardTrigger>
+				<RuiHoverCardContent>
+					<p class="text-sm">Placement: left</p>
+				</RuiHoverCardContent>
+			</RuiHoverCard>
+		</div>
+	),
+};

--- a/packages/radiant-ui/src/components/ui/hover-card/hover-card.test.tsx
+++ b/packages/radiant-ui/src/components/ui/hover-card/hover-card.test.tsx
@@ -1,0 +1,186 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { createRoot, type JsxRenderable } from '@ecopages/jsx';
+import { resetPreviewTimingForTests, resolvePreviewOpenDelay } from '../shared/preview-timing';
+import { RuiHoverCard, RuiHoverCardContent, RuiHoverCardTrigger } from './hover-card';
+import type { RuiHoverCard as RuiHoverCardElement } from './hover-card.script';
+import './hover-card.script';
+
+function mount(element: JsxRenderable): { host: HTMLElement; cleanup: () => void } {
+	const host = document.createElement('div');
+	document.body.appendChild(host);
+	const root = createRoot(host);
+	root.render(element);
+	return {
+		host,
+		cleanup: () => {
+			root.unmount();
+			host.remove();
+		},
+	};
+}
+
+async function settled(): Promise<void> {
+	await Promise.resolve();
+	await new Promise((resolve) => setTimeout(resolve, 0));
+	await customElements.whenDefined('rui-hover-card');
+	await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve(undefined))));
+}
+
+function getCard(host: ParentNode): RuiHoverCardElement {
+	const card = host.querySelector('rui-hover-card');
+	if (!(card instanceof HTMLElement)) {
+		throw new Error('Expected rui-hover-card');
+	}
+	return card as RuiHoverCardElement;
+}
+
+function getContent(host: ParentNode): HTMLElement {
+	const content = host.querySelector('.rui-hover-card__content');
+	if (!(content instanceof HTMLElement)) {
+		throw new Error('Expected hover card content');
+	}
+	return content;
+}
+
+function getTriggerButton(host: ParentNode): HTMLButtonElement {
+	const button = host.querySelector('[data-hover-card-trigger] button');
+	if (!(button instanceof HTMLButtonElement)) {
+		throw new Error('Expected trigger button');
+	}
+	return button;
+}
+
+describe('RuiHoverCard', () => {
+	afterEach(() => {
+		document.body.innerHTML = '';
+		resetPreviewTimingForTests();
+	});
+
+	it('opens on pointer enter and closes on escape with focus return', async () => {
+		const { host, cleanup } = mount(
+			<RuiHoverCard delay={0} closeDelay={0}>
+				<RuiHoverCardTrigger>
+					<button type="button">Trigger</button>
+				</RuiHoverCardTrigger>
+				<RuiHoverCardContent>Preview</RuiHoverCardContent>
+			</RuiHoverCard>,
+		);
+		await settled();
+
+		const card = getCard(host);
+		const content = getContent(host);
+		const trigger = getTriggerButton(host);
+
+		expect(content.hidden).toBe(true);
+		expect(trigger.getAttribute('aria-expanded')).toBe('false');
+
+		card.dispatchEvent(new PointerEvent('pointerenter', { bubbles: true, pointerType: 'mouse' }));
+		await settled();
+
+		expect(content.hidden).toBe(false);
+		expect(trigger.getAttribute('aria-expanded')).toBe('true');
+		expect(trigger.getAttribute('aria-controls')).toBe(content.id);
+		expect(content.getAttribute('aria-label')).toBe('Preview');
+
+		trigger.focus();
+		document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+		await settled();
+
+		expect(content.hidden).toBe(true);
+		expect(document.activeElement).toBe(trigger);
+
+		cleanup();
+	});
+
+	it('respects open delay before showing', async () => {
+		const { host, cleanup } = mount(
+			<RuiHoverCard delay={50} closeDelay={0}>
+				<RuiHoverCardTrigger>
+					<button type="button">Trigger</button>
+				</RuiHoverCardTrigger>
+				<RuiHoverCardContent>Preview</RuiHoverCardContent>
+			</RuiHoverCard>,
+		);
+		await settled();
+
+		const card = getCard(host);
+		const content = getContent(host);
+
+		card.dispatchEvent(new PointerEvent('pointerenter', { bubbles: true, pointerType: 'mouse' }));
+		expect(content.hidden).toBe(true);
+
+		await new Promise((resolve) => setTimeout(resolve, 80));
+		await settled();
+		expect(content.hidden).toBe(false);
+
+		cleanup();
+	});
+
+	it('does not open when disabled', async () => {
+		const { host, cleanup } = mount(
+			<RuiHoverCard disabled delay={0} closeDelay={0}>
+				<RuiHoverCardTrigger>
+					<button type="button">Trigger</button>
+				</RuiHoverCardTrigger>
+				<RuiHoverCardContent>Preview</RuiHoverCardContent>
+			</RuiHoverCard>,
+		);
+		await settled();
+
+		const card = getCard(host);
+		const content = getContent(host);
+
+		card.dispatchEvent(new PointerEvent('pointerenter', { bubbles: true, pointerType: 'mouse' }));
+		await settled();
+
+		expect(content.hidden).toBe(true);
+
+		cleanup();
+	});
+
+	it('emits rui-open-change when visibility changes', async () => {
+		const { host, cleanup } = mount(
+			<RuiHoverCard delay={0} closeDelay={0}>
+				<RuiHoverCardTrigger>
+					<button type="button">Trigger</button>
+				</RuiHoverCardTrigger>
+				<RuiHoverCardContent>Preview</RuiHoverCardContent>
+			</RuiHoverCard>,
+		);
+		await settled();
+
+		const card = getCard(host);
+		const events: boolean[] = [];
+		card.addEventListener('rui-open-change', (event) => {
+			events.push((event as CustomEvent<{ open: boolean }>).detail.open);
+		});
+
+		card.dispatchEvent(new PointerEvent('pointerenter', { bubbles: true, pointerType: 'mouse' }));
+		await settled();
+		card.dispatchEvent(new PointerEvent('pointerleave', { bubbles: true, pointerType: 'mouse' }));
+		await settled();
+
+		expect(events).toEqual([true, false]);
+
+		cleanup();
+	});
+
+	it('does not leak preview warmup after an open card unmounts', async () => {
+		const { host, cleanup } = mount(
+			<RuiHoverCard delay={0} closeDelay={0}>
+				<RuiHoverCardTrigger>
+					<button type="button">Trigger</button>
+				</RuiHoverCardTrigger>
+				<RuiHoverCardContent>Preview</RuiHoverCardContent>
+			</RuiHoverCard>,
+		);
+		await settled();
+
+		getCard(host).dispatchEvent(new PointerEvent('pointerenter', { bubbles: true, pointerType: 'mouse' }));
+		await settled();
+		expect(getContent(document).hidden).toBe(false);
+
+		cleanup();
+		expect(resolvePreviewOpenDelay(600, Date.now() + 1_000)).toBe(600);
+	});
+});

--- a/packages/radiant-ui/src/components/ui/hover-card/hover-card.tsx
+++ b/packages/radiant-ui/src/components/ui/hover-card/hover-card.tsx
@@ -1,0 +1,49 @@
+import type { JsxCustomElementAttributes, JsxElementProps } from '@ecopages/jsx';
+import { cx } from '@/lib/cx';
+import {
+	HOVER_CARD_DEFAULT_CONTENT_LABEL,
+	type RuiHoverCard as RuiHoverCardElement,
+	type RuiHoverCardProps,
+} from './hover-card.script';
+import './hover-card.script';
+
+export type RuiHoverCardTriggerProps = JsxElementProps<HTMLSpanElement>;
+
+/** Anchor for the hover card preview. */
+export function RuiHoverCardTrigger({ children, class: className, ...props }: RuiHoverCardTriggerProps) {
+	return (
+		<span class="rui-hover-card__trigger">
+			<span {...props} data-hover-card-trigger class={cx(className)}>
+				{children}
+			</span>
+		</span>
+	);
+}
+
+export type RuiHoverCardContentProps = JsxElementProps<HTMLDivElement>;
+
+/** Rich preview content rendered in the floating surface. */
+export function RuiHoverCardContent({ children, class: className, ...props }: RuiHoverCardContentProps) {
+	return (
+		<div
+			{...props}
+			data-ref="content"
+			class={cx('rui-hover-card__content', 'rui-floating', className)}
+			role="dialog"
+		>
+			{children}
+		</div>
+	);
+}
+
+export function RuiHoverCard({
+	children,
+	contentLabel = HOVER_CARD_DEFAULT_CONTENT_LABEL,
+	...props
+}: JsxCustomElementAttributes<RuiHoverCardElement, RuiHoverCardProps>) {
+	return (
+		<rui-hover-card contentLabel={contentLabel} {...props}>
+			<span class="rui-hover-card">{children}</span>
+		</rui-hover-card>
+	);
+}

--- a/packages/radiant-ui/src/components/ui/hover-card/index.ts
+++ b/packages/radiant-ui/src/components/ui/hover-card/index.ts
@@ -1,0 +1,7 @@
+export { RuiHoverCard, RuiHoverCardContent, RuiHoverCardTrigger } from './hover-card';
+export type { RuiHoverCardContentProps, RuiHoverCardTriggerProps } from './hover-card';
+export {
+	RuiHoverCard as RuiHoverCardElement,
+	type RuiHoverCardOpenChangeDetail,
+	type RuiHoverCardProps,
+} from './hover-card.script';

--- a/packages/radiant-ui/src/index.ts
+++ b/packages/radiant-ui/src/index.ts
@@ -28,6 +28,7 @@ export * from './components/ui/form';
 export * from './components/ui/grid';
 export * from './components/ui/heading';
 export * from './components/ui/headline';
+export * from './components/ui/hover-card';
 export * from './components/ui/input';
 export * from './components/ui/input-group';
 export * from './components/ui/knob';

--- a/packages/radiant-ui/src/jsx-custom-elements.d.ts
+++ b/packages/radiant-ui/src/jsx-custom-elements.d.ts
@@ -10,6 +10,7 @@ import type { RuiDisclosureGroup, RuiDisclosureGroupProps } from './components/u
 import type { RuiDisclosure, RuiDisclosureProps } from './components/ui/disclosure/disclosure.script';
 import type { RuiField, RuiFieldProps } from './components/ui/field/field.script';
 import type { RuiForm, RuiFormProps } from './components/ui/form/form.script';
+import type { RuiHoverCard, RuiHoverCardProps } from './components/ui/hover-card/hover-card.script';
 import type { RuiGrid, RuiGridProps } from './components/ui/grid/grid.script';
 import type { RuiListbox, RuiListboxProps } from './components/ui/listbox/listbox.script';
 import type { RuiMenuButton, RuiMenuButtonProps } from './components/ui/menu-button/menu-button.script';
@@ -49,6 +50,7 @@ declare module '@ecopages/jsx/jsx-runtime' {
 		'rui-disclosure-group': JsxCustomElementAttributes<RuiDisclosureGroup, RuiDisclosureGroupProps>;
 		'rui-field': JsxCustomElementAttributes<RuiField, RuiFieldProps>;
 		'rui-form': JsxCustomElementAttributes<RuiForm, RuiFormProps>;
+		'rui-hover-card': JsxCustomElementAttributes<RuiHoverCard, RuiHoverCardProps>;
 		'rui-grid': JsxCustomElementAttributes<RuiGrid, RuiGridProps>;
 		'rui-listbox': JsxCustomElementAttributes<RuiListbox, RuiListboxProps>;
 		'rui-menu-button': JsxCustomElementAttributes<RuiMenuButton, RuiMenuButtonProps>;

--- a/packages/radiant-ui/src/styles/style-dependencies.json
+++ b/packages/radiant-ui/src/styles/style-dependencies.json
@@ -173,6 +173,15 @@
 				"@ecopages/radiant-ui/headline/styles.css"
 			]
 		},
+		"hover-card": {
+			"direct": [
+				"primitives"
+			],
+			"styles": [
+				"@ecopages/radiant-ui/primitives.css",
+				"@ecopages/radiant-ui/hover-card/styles.css"
+			]
+		},
 		"input": {
 			"direct": [],
 			"styles": [

--- a/packages/radiant-ui/src/styles/styles.css
+++ b/packages/radiant-ui/src/styles/styles.css
@@ -28,6 +28,7 @@
 @import '../components/ui/grid/grid.css';
 @import '../components/ui/heading/heading.css';
 @import '../components/ui/headline/headline.css';
+@import '../components/ui/hover-card/hover-card.css';
 @import '../components/ui/input/input.css';
 @import '../components/ui/input-group/input-group.css';
 @import '../components/ui/knob/knob.css';


### PR DESCRIPTION
Add RuiHoverCard with focusable content and preview timing integration.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>