### PR TITLE
Publish the Storybook Vite framework with the Radiant plugin

### DIFF
--- a/.agents/skills/changesets/references/project.md
+++ b/.agents/skills/changesets/references/project.md
@@ -10,8 +10,7 @@ Source of truth: `.changeset/config.json`. Prerelease channel: `.changeset/pre.j
 | ------------------ | --------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
 | Platform (`fixed`) | `@ecopages/jsx`, `@ecopages/signals`, `@ecopages/radiant` | List only those with a user-visible change. `fixed` bumps all three to the same version regardless.               |
 | Design system      | `@ecopages/radiant-ui`                                    | List when components, tokens, themes, or public exports change. Versions independently — never add it to `fixed`. |
-| Vite integration   | `@ecopages/vite-plugin-radiant`                           | List for its own public API, Vite, or Nitro contract changes. Not in `fixed`.                                     |
-| Ignored tooling    | `@ecopages/storybook-radiant-vite`                        | Never list. Private and in `ignore`.                                                                              |
+| Vite integration (`fixed`) | `@ecopages/vite-plugin-radiant`, `@ecopages/storybook-radiant-vite` | List when either public API changes. `fixed` bumps both to the same version. Not in the platform group. |
 | Private            | `apps/*`, `playground/*`                                  | Never list, never publish.                                                                                        |
 
 Do not invent a `packages/core/` layout to co-version the platform trio — `fixed` already does that.
@@ -22,7 +21,7 @@ Do not invent a `packages/core/` layout to co-version the platform trio — `fix
 pnpm run prerelease   # typecheck + build:all + test:all
 ```
 
-`build:all` covers all five publishable packages, including `@ecopages/radiant-ui`.
+`build:all` covers all six publishable packages, including `@ecopages/radiant-ui` and `@ecopages/storybook-radiant-vite`.
 
 ## Versioning needs a token
 
@@ -44,7 +43,7 @@ GITHUB_TOKEN="$(gh auth token)" pnpm changeset version
 
 ## Publish layout
 
-`@ecopages/jsx`, `@ecopages/radiant`, and `@ecopages/signals` set `publishConfig.directory: "dist"`. `@ecopages/radiant-ui` and `@ecopages/vite-plugin-radiant` publish from the package root.
+`@ecopages/jsx`, `@ecopages/radiant`, and `@ecopages/signals` set `publishConfig.directory: "dist"`. `@ecopages/radiant-ui`, `@ecopages/vite-plugin-radiant`, and `@ecopages/storybook-radiant-vite` publish from the package root.
 
 ## Verify a release
 
@@ -54,4 +53,5 @@ npm view @ecopages/jsx dist-tags --json
 npm view @ecopages/signals dist-tags --json
 npm view @ecopages/radiant-ui dist-tags --json
 npm view @ecopages/vite-plugin-radiant dist-tags --json
+npm view @ecopages/storybook-radiant-vite dist-tags --json
 ```

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,10 +2,12 @@
 	"$schema": "https://unpkg.com/@changesets/config@4.0.0/schema.json",
 	"changelog": ["@changesets/changelog-github", { "repo": "ecopages/radiant" }],
 	"commit": false,
-	"fixed": [["@ecopages/jsx", "@ecopages/signals", "@ecopages/radiant"]],
+	"fixed": [
+		["@ecopages/jsx", "@ecopages/signals", "@ecopages/radiant"],
+		["@ecopages/storybook-radiant-vite", "@ecopages/vite-plugin-radiant"]
+	],
 	"linked": [],
 	"access": "public",
 	"baseBranch": "release/v0.3.0",
-	"updateInternalDependencies": "patch",
-	"ignore": ["@ecopages/storybook-radiant-vite"]
+	"updateInternalDependencies": "patch"
 }

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ For more details, [see the docs page](https://radiant.ecopages.app/).
 - [@ecopages/signals](./packages/signals/README.md)
 - [@ecopages/radiant-ui](./packages/radiant-ui/README.md)
 - [@ecopages/vite-plugin-radiant](./packages/vite-plugin-radiant/README.md)
+- [@ecopages/storybook-radiant-vite](./packages/storybook-radiant-vite/README.md)
 
 The JSX package README is the source of truth for entrypoint boundaries. In particular, [packages/jsx/README.md](./packages/jsx/README.md) documents when to use `@ecopages/jsx/server` directly, including the SSR hydration binding scope helpers intended for framework integrations that compose one page from multiple server renders.
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"typecheck": "pnpm run typecheck:packages && tsc --noEmit -p apps/docs/tsconfig.json && tsc --noEmit -p apps/radiant-ui/tsconfig.json",
 		"typecheck:packages": "tsc --noEmit -p packages/jsx/tsconfig.json && tsc --noEmit -p packages/signals/tsconfig.json && tsc --noEmit -p packages/radiant/tsconfig.json && tsc --noEmit -p packages/vite-plugin-radiant/tsconfig.json && tsc --noEmit -p packages/storybook-radiant-vite/tsconfig.json && tsc --noEmit -p packages/radiant-ui/tsconfig.app.json && tsc --noEmit -p playground/vite/tsconfig.json && tsc --noEmit -p playground/vite-nitro/tsconfig.json",
 		"prepare:husky": "husky",
-		"build:all": "pnpm --filter @ecopages/signals build:lib && pnpm --filter @ecopages/jsx build:lib && pnpm --filter @ecopages/radiant build:lib && pnpm --filter @ecopages/vite-plugin-radiant build:lib && pnpm --filter @ecopages/radiant-ui build:lib",
+		"build:all": "pnpm --filter @ecopages/signals build:lib && pnpm --filter @ecopages/jsx build:lib && pnpm --filter @ecopages/radiant build:lib && pnpm --filter @ecopages/vite-plugin-radiant build:lib && pnpm --filter @ecopages/storybook-radiant-vite build && pnpm --filter @ecopages/radiant-ui build:lib",
 		"test:all": "pnpm -r --sequential test:all",
 		"size:check": "pnpm -r --filter \"@ecopages/jsx\" --filter \"@ecopages/signals\" --filter \"@ecopages/radiant\" run size:check",
 		"size:report": "pnpm -r --filter \"@ecopages/jsx\" --filter \"@ecopages/signals\" --filter \"@ecopages/radiant\" run size:report",

--- a/packages/storybook-radiant-vite/CHANGELOG.md
+++ b/packages/storybook-radiant-vite/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @ecopages/storybook-radiant-vite
+
+## 0.1.0-rc.0
+
+### Minor Changes
+
+- First publish of the Storybook Vite framework for Radiant (client + SSR → hydrate story modes).

--- a/packages/storybook-radiant-vite/README.md
+++ b/packages/storybook-radiant-vite/README.md
@@ -372,15 +372,11 @@ Controller SSR (`renderController`) is not wired in v1 — use client mode for c
 - **Storybook UI still depends on React transitively** (`storybook` → `use-sync-external-store` → `react`, and `@storybook/addon-docs` → `react` / `@mdx-js/react`). That is Storybook’s manager/docs stack. Your stories do **not** import or render through React.
 - **Tag collisions** — two modules registering the same custom element tag will conflict if both load in one session.
 
-## Extracting / publishing
+## Publishing
 
 This package depends on `@ecopages/vite-plugin-radiant` for shared Vite primitives (JSX, decorators, SSR externals). Storybook-only code stays here: CSF types, SSR middleware, script-module stamps, and framework HMR.
 
-To ship:
-
-1. Copy or publish `packages/storybook-radiant-vite/`
-2. Resolve peers from npm (`@ecopages/vite-plugin-radiant`, `@ecopages/radiant`, …)
-3. `npm publish` (or Changesets)
+It is published from this repo through Changesets. It shares a `fixed` version group with `@ecopages/vite-plugin-radiant`, so a bump to either package bumps both.
 
 ## License
 

--- a/packages/storybook-radiant-vite/package.json
+++ b/packages/storybook-radiant-vite/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@ecopages/storybook-radiant-vite",
-	"version": "0.1.0-beta.0",
-	"private": true,
+	"version": "0.1.0-rc.0",
 	"description": "Storybook framework for @ecopages/radiant — Vite builder, Radiant JSX renderer, and SSR story modes",
 	"keywords": [
 		"storybook",
@@ -12,6 +11,11 @@
 		"vite",
 		"ssr"
 	],
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/ecopages/radiant.git",
+		"directory": "packages/storybook-radiant-vite"
+	},
 	"license": "MIT",
 	"type": "module",
 	"publishConfig": {


### PR DESCRIPTION
## Summary
- Make `@ecopages/storybook-radiant-vite` public and ship it at `0.1.0-rc.0` through Changesets.
- Co-version it with `@ecopages/vite-plugin-radiant` via a second `fixed` group, and include it in `build:all`.

## Test plan
- [x] Confirm `changeset status` lists `@ecopages/storybook-radiant-vite` (no longer ignored/private).
- [x] Confirm a bump to either plugin would bump both.
- [x] After merge/release, `npm view @ecopages/storybook-radiant-vite dist-tags` shows `rc`.