### PR TITLE
refactor(quality): enforce complexity limit

### DIFF
--- a/.changeset/css-escape-ssr-polyfill.md
+++ b/.changeset/css-escape-ssr-polyfill.md
@@ -1,0 +1,5 @@
+---
+'@ecopages/radiant': patch
+---
+
+Stop the SSR light-DOM shim from recursing through `CSS.escape`, and make delegated `subscribeEvent(...)` matching ancestor-aware like `@onEvent`. Client ref selectors use native `CSS.escape`.

--- a/packages/jsx/src/dom-render/bindings.ts
+++ b/packages/jsx/src/dom-render/bindings.ts
@@ -36,89 +36,103 @@ export function applyBindingToElement(
 
 	switch (binding.kind) {
 		case 'attr':
-			if (resolvedValue === undefined || resolvedValue === null) {
-				removeElementAttribute(element, binding.name);
-				if (livePart) livePart.previousValue = resolvedValue;
-				return;
-			}
-
-			{
-				const isStyleBinding = binding.name.toLowerCase() === 'style';
-				const nextValue = isStyleBinding ? serializeStyleSnapshot(resolvedValue) : String(resolvedValue);
-				const cachedValue = isStyleBinding ? nextValue : resolvedValue;
-
-				if (
-					!livePart ||
-					livePart.previousValue !== cachedValue ||
-					getElementAttributeValue(element, binding.name) !== nextValue
-				) {
-					setElementAttributeValue(element, binding.name, nextValue);
-				}
-
-				if (livePart) livePart.previousValue = cachedValue;
-			}
+			applyAttributeBinding(element, binding.name, resolvedValue, livePart);
 			return;
 
 		case 'bool':
-			if (resolvedValue) {
-				element.setAttribute(binding.name, '');
-			} else {
-				element.removeAttribute(binding.name);
-			}
-
-			if (livePart) livePart.previousValue = resolvedValue;
+			applyBooleanBinding(element, binding.name, resolvedValue, livePart);
 			return;
 
 		case 'event': {
-			const nextListener = asEventBindingListener(resolvedValue);
-			const previousListener = livePart ? asEventBindingListener(livePart.previousValue) : null;
-
-			if (livePart?.previousValue === resolvedValue) {
-				return;
-			}
-
-			if (previousListener) {
-				detachEventBindingListener(options.rootTarget, element, binding.name, previousListener);
-			}
-
-			if (nextListener) {
-				attachEventBindingListener(options.rootTarget, element, binding.name, nextListener);
-			}
-
-			if (livePart) livePart.previousValue = resolvedValue;
+			applyDelegatedEventBinding(element, binding.name, resolvedValue, options.rootTarget, livePart);
 			return;
 		}
 
 		case 'native-event': {
-			const nextListener = asEventBindingListener(resolvedValue);
-			const previousListener = livePart ? asEventBindingListener(livePart.previousValue) : null;
-
-			if (livePart?.previousValue === resolvedValue) {
-				return;
-			}
-
-			if (previousListener) {
-				element.removeEventListener(binding.name, previousListener);
-			}
-
-			if (nextListener) {
-				element.addEventListener(binding.name, nextListener);
-			}
-
-			if (livePart) livePart.previousValue = resolvedValue;
+			applyNativeEventBinding(element, binding.name, resolvedValue, livePart);
 			return;
 		}
 
 		case 'prop':
-			options.deferredProperties.push({
-				element,
-				name: binding.name,
-				value: resolvedValue,
-			});
-
-			if (livePart) livePart.previousValue = resolvedValue;
+			applyDeferredPropertyBinding(element, binding.name, resolvedValue, options.deferredProperties, livePart);
 			return;
 	}
+}
+
+function applyAttributeBinding(
+	element: Element,
+	name: string,
+	value: unknown,
+	livePart: LiveAttributePart | undefined,
+): void {
+	if (value === undefined || value === null) {
+		removeElementAttribute(element, name);
+		updatePreviousValue(livePart, value);
+		return;
+	}
+
+	const isStyleBinding = name.toLowerCase() === 'style';
+	const nextValue = isStyleBinding ? serializeStyleSnapshot(value) : String(value);
+	const cachedValue = isStyleBinding ? nextValue : value;
+	if (!livePart || livePart.previousValue !== cachedValue || getElementAttributeValue(element, name) !== nextValue) {
+		setElementAttributeValue(element, name, nextValue);
+	}
+	updatePreviousValue(livePart, cachedValue);
+}
+
+function applyBooleanBinding(
+	element: Element,
+	name: string,
+	value: unknown,
+	livePart: LiveAttributePart | undefined,
+): void {
+	if (value) element.setAttribute(name, '');
+	else element.removeAttribute(name);
+	updatePreviousValue(livePart, value);
+}
+
+function applyDelegatedEventBinding(
+	element: Element,
+	name: string,
+	value: unknown,
+	rootTarget: HTMLElement,
+	livePart: LiveAttributePart | undefined,
+): void {
+	if (livePart?.previousValue === value) return;
+	const previousListener = livePart ? asEventBindingListener(livePart.previousValue) : null;
+	if (previousListener) detachEventBindingListener(rootTarget, element, name, previousListener);
+	const nextListener = asEventBindingListener(value);
+	if (nextListener) attachEventBindingListener(rootTarget, element, name, nextListener);
+	updatePreviousValue(livePart, value);
+}
+
+function applyNativeEventBinding(
+	element: Element,
+	name: string,
+	value: unknown,
+	livePart: LiveAttributePart | undefined,
+): void {
+	if (livePart?.previousValue === value) return;
+	const previousListener = livePart ? asEventBindingListener(livePart.previousValue) : null;
+	if (previousListener) element.removeEventListener(name, previousListener);
+	const nextListener = asEventBindingListener(value);
+	if (nextListener) element.addEventListener(name, nextListener);
+	updatePreviousValue(livePart, value);
+}
+
+function applyDeferredPropertyBinding(
+	element: Element,
+	name: string,
+	value: unknown,
+	deferredProperties: DeferredPropertyBinding[],
+	livePart: LiveAttributePart | undefined,
+): void {
+	deferredProperties.push({ element, name, value });
+	updatePreviousValue(livePart, value);
+}
+
+function updatePreviousValue(livePart: LiveAttributePart | undefined, value: unknown): void {
+	if (livePart) livePart.previousValue = value;
 }
 
 function asEventBindingListener(value: unknown): EventListenerOrEventListenerObject | null {

--- a/packages/jsx/src/dom-render/child-range-update.ts
+++ b/packages/jsx/src/dom-render/child-range-update.ts
@@ -42,16 +42,9 @@ export function updateRangeContent(
 	deferredProperties: DeferredPropertyBinding[],
 ): MountedRangeContent {
 	const nextValue = unwrapKeyedValue(value);
-	let currentContent = current;
-
-	if (currentContent.kind === 'subscription') {
-		if (isReactiveChildSource(nextValue) && currentContent.source === nextValue) {
-			return currentContent;
-		}
-
-		currentContent = releaseMountedSubscription(currentContent);
-	}
-
+	if (current.kind === 'subscription' && isReactiveChildSource(nextValue) && current.source === nextValue)
+		return current;
+	const currentContent = current.kind === 'subscription' ? releaseMountedSubscription(current) : current;
 	if (isReactiveChildSource(nextValue)) {
 		return mountReactiveChildSource(
 			startMarker,
@@ -62,12 +55,11 @@ export function updateRangeContent(
 			deferredProperties,
 		);
 	}
+	const nextKind = classifyChildValue(nextValue);
 
-	const iterableChildren = getIterableChildren(nextValue);
-
-	if (iterableChildren) {
+	if (nextKind === 'iterable') {
+		const iterableChildren = getIterableChildren(nextValue)!;
 		const keyedChildren = getKeyedChildren(iterableChildren);
-
 		if (keyedChildren) {
 			return updateKeyedChildren(
 				startMarker,
@@ -89,7 +81,27 @@ export function updateRangeContent(
 		);
 	}
 
-	if (isTemplateResultLike(nextValue)) {
+	return updateSingleChildContent(
+		startMarker,
+		endMarker,
+		nextValue,
+		nextKind,
+		currentContent,
+		rootTarget,
+		deferredProperties,
+	);
+}
+
+function updateSingleChildContent(
+	startMarker: Text,
+	endMarker: Text,
+	nextValue: unknown,
+	nextKind: 'empty' | 'nodes' | 'template' | 'text',
+	currentContent: MountedRangeContent,
+	rootTarget: HTMLElement,
+	deferredProperties: DeferredPropertyBinding[],
+): MountedRangeContent {
+	if (nextKind === 'template' && isTemplateResultLike(nextValue)) {
 		if (currentContent.kind === 'template' && currentContent.instance.compiled === getCompiledTemplate(nextValue)) {
 			currentContent.instance.update(nextValue.values, deferredProperties);
 			return currentContent;
@@ -99,11 +111,11 @@ export function updateRangeContent(
 		return replaceMountedRangeWithTemplate(startMarker, endMarker, currentContent, instance);
 	}
 
-	if (nextValue === undefined || nextValue === null || nextValue === false || nextValue === true) {
+	if (nextKind === 'empty') {
 		return replaceMountedRangeWithEmpty(startMarker, endMarker, currentContent);
 	}
 
-	if (currentContent.kind === 'text' && canRenderAsTextNode(nextValue)) {
+	if (nextKind === 'text' && currentContent.kind === 'text') {
 		const nextText = String(nextValue);
 
 		if (currentContent.node.data !== nextText) {
@@ -113,7 +125,7 @@ export function updateRangeContent(
 		return currentContent;
 	}
 
-	if (canRenderAsTextNode(nextValue)) {
+	if (nextKind === 'text') {
 		const textNode = document.createTextNode(String(nextValue));
 		return replaceMountedRangeWithText(startMarker, endMarker, currentContent, textNode);
 	}
@@ -126,6 +138,13 @@ export function updateRangeContent(
 		endMarker.parentNode,
 	);
 	return replaceMountedRangeWithNodes(startMarker, endMarker, currentContent, nodes);
+}
+
+function classifyChildValue(value: unknown): 'empty' | 'iterable' | 'template' | 'text' | 'nodes' {
+	if (getIterableChildren(value)) return 'iterable';
+	if (isTemplateResultLike(value)) return 'template';
+	if (value === undefined || value === null || value === false || value === true) return 'empty';
+	return canRenderAsTextNode(value) ? 'text' : 'nodes';
 }
 
 function replaceMountedRangeWithEmpty(

--- a/packages/jsx/src/dom-render/template-compiler.ts
+++ b/packages/jsx/src/dom-render/template-compiler.ts
@@ -145,6 +145,13 @@ function collectTemplateParts(
 	fragment: DocumentFragment,
 	bindings: ReadonlyMap<number, BindingDescriptor>,
 ): TemplatePart[] {
+	return [...collectAttributeParts(fragment, bindings), ...collectChildParts(fragment, bindings)];
+}
+
+function collectAttributeParts(
+	fragment: DocumentFragment,
+	bindings: ReadonlyMap<number, BindingDescriptor>,
+): TemplatePart[] {
 	const parts: TemplatePart[] = [];
 	const walker = document.createTreeWalker(fragment, NodeFilter.SHOW_ELEMENT);
 	let currentNode = walker.nextNode();
@@ -177,6 +184,13 @@ function collectTemplateParts(
 		currentNode = walker.nextNode();
 	}
 
+	return parts;
+}
+
+function collectChildParts(
+	fragment: DocumentFragment,
+	bindings: ReadonlyMap<number, BindingDescriptor>,
+): TemplatePart[] {
 	const childMarkers = new Map<number, Partial<ChildTemplatePart>>();
 	const commentWalker = document.createTreeWalker(fragment, NodeFilter.SHOW_COMMENT);
 	let commentNode = commentWalker.nextNode();
@@ -201,6 +215,7 @@ function collectTemplateParts(
 		commentNode = commentWalker.nextNode();
 	}
 
+	const parts: TemplatePart[] = [];
 	for (const [index, marker] of childMarkers) {
 		const binding = bindings.get(index);
 

--- a/packages/jsx/src/ssr/serialize-renderable.ts
+++ b/packages/jsx/src/ssr/serialize-renderable.ts
@@ -98,44 +98,38 @@ function serializeTemplateResult(template: TemplateResultLike, options: Serializ
 	let html = '';
 
 	for (let index = 0; index < template.values.length; index += 1) {
-		const part = template.parts[index];
 		const childValue = resolveReactiveSnapshot(template.values[index]);
 
 		html += template.strings[index] ?? '';
-
-		if (!part || part.type === 'child') {
-			html += serializeRenderable(childValue as JsxRenderable, options);
-			continue;
-		}
-
-		const bindingIndex = hydrationState ? takeNextHydrationMarkerIndex(hydrationState) : 0;
-
-		if (options.mode === 'hydrate' && hydrationState) {
-			html += ` ${resolveHydrationMarkerAttributeName(bindingIndex)}="${serializeBindingDescriptor(part.kind, part.name)}"`;
-		}
-
-		if (isClientOnlyBinding(part.kind)) {
-			continue;
-		}
-
-		if (part.kind === 'bool') {
-			if (childValue) {
-				html += ` ${part.name}`;
-			}
-			continue;
-		}
-
-		if (childValue === undefined || childValue === null || childValue === false) {
-			continue;
-		}
-
-		const attributeValue =
-			part.name.toLowerCase() === 'style' ? serializeStyleSnapshot(childValue) : String(childValue);
-		html += ` ${part.name}="${escapeAttribute(attributeValue)}"`;
+		html += serializeTemplatePart(template.parts[index], childValue, options, hydrationState);
 	}
 
 	html += template.strings[template.strings.length - 1] ?? '';
 	return html;
+}
+
+function serializeTemplatePart(
+	part: TemplateResultLike['parts'][number] | undefined,
+	value: unknown,
+	options: SerializeRenderableOptions,
+	hydrationState: SerializeRenderableOptions['hydrationBindingState'],
+): string {
+	if (!part || part.type === 'child') {
+		return serializeRenderable(value as JsxRenderable, options);
+	}
+
+	const bindingIndex = hydrationState ? takeNextHydrationMarkerIndex(hydrationState) : 0;
+	const hydrationMarker =
+		options.mode === 'hydrate' && hydrationState
+			? ` ${resolveHydrationMarkerAttributeName(bindingIndex)}="${serializeBindingDescriptor(part.kind, part.name)}"`
+			: '';
+
+	if (isClientOnlyBinding(part.kind)) return hydrationMarker;
+	if (part.kind === 'bool') return value ? `${hydrationMarker} ${part.name}` : hydrationMarker;
+	if (value === undefined || value === null || value === false) return hydrationMarker;
+
+	const attributeValue = part.name.toLowerCase() === 'style' ? serializeStyleSnapshot(value) : String(value);
+	return `${hydrationMarker} ${part.name}="${escapeAttribute(attributeValue)}"`;
 }
 
 function serializeNodeLike(node: JsxNodeLike): string {

--- a/packages/oxlint-config/README.md
+++ b/packages/oxlint-config/README.md
@@ -2,4 +2,4 @@
 
 The workspace-wide Oxlint baseline. Import `@ecopages/oxlint-config/base` from an `oxlint.config.ts` file, extend it, and add only package-specific rules or plugins.
 
-The base configuration starts with a cyclomatic-complexity limit of 50 and preserves the repository's existing lint policy. Lower the limit only in a follow-up that refactors every affected workspace. Every rule belongs here only when it is valid across all apps, libraries, and playgrounds.
+The base configuration limits cyclomatic complexity to 15 and preserves the repository's existing lint policy. Every rule belongs here only when it is valid across all apps, libraries, and playgrounds.

--- a/packages/oxlint-config/base.js
+++ b/packages/oxlint-config/base.js
@@ -7,7 +7,7 @@ export const config = defineConfig({
 	plugins: ['typescript', 'react'],
 	ignorePatterns,
 	rules: {
-		complexity: ['error', { max: 50 }],
+		complexity: ['error', { max: 15 }],
 		'no-param-reassign': 'error',
 		'default-param-last': 'error',
 		'no-else-return': 'error',

--- a/packages/radiant-ui/src/components/ui/field/field.script.tsx
+++ b/packages/radiant-ui/src/components/ui/field/field.script.tsx
@@ -23,7 +23,7 @@ import {
 	wireFieldControlName,
 } from '../form/control-protocol';
 import { formContext, type FormContextValue } from '../form/form-context';
-import { fieldContext } from './field-context';
+import { fieldContext, type FieldContextValue } from './field-context';
 import type { FieldRules } from '../form/types';
 
 /**
@@ -345,60 +345,15 @@ export class RuiField extends RadiantElement {
 		const fieldName = this.resolveFieldName();
 		wireFieldControlName(controlHost, ariaTarget, fieldName);
 
-		const describedBy: string[] = [];
-		const description = findFieldDescription(this);
-		if (description) {
-			description.id = descriptionId;
-			describedBy.push(descriptionId);
-		}
-		const errorEl = findFieldError(this);
-		if (errorEl) {
-			errorEl.id = errorId;
-			if (errorMessage) {
-				describedBy.push(errorId);
-			}
-		}
-
-		for (const [index, target] of ariaTargets.entries()) {
-			if (!target.id) {
-				target.id = index === 0 ? controlId : `${controlId}-${index}`;
-			}
-			target.setAttribute(RUI_FIELD_MANAGED_ATTR, '');
-			target.setAttribute('aria-invalid', invalid ? 'true' : 'false');
-			if (this.isRequired()) {
-				target.setAttribute('aria-required', 'true');
-			} else {
-				target.removeAttribute('aria-required');
-			}
-
-			if (describedBy.length > 0) {
-				target.setAttribute('aria-describedby', describedBy.join(' '));
-			} else {
-				target.removeAttribute('aria-describedby');
-			}
-
-			if (this.disabled) {
-				target.setAttribute('aria-disabled', 'true');
-				if (isNativeTextControl(target)) {
-					target.disabled = true;
-				}
-			}
-		}
+		const describedBy = this.syncDescriptions(descriptionId, errorId, errorMessage);
+		this.syncAriaTargets(ariaTargets, controlId, describedBy, invalid, required);
 
 		const label = findFieldLabel(this);
 		if (label && ariaTarget) {
 			label.htmlFor = ariaTarget.id;
 		}
 
-		for (const errorEl of findFieldErrorElements(this)) {
-			errorEl.textContent = errorMessage ?? '';
-			if (errorMessage) {
-				errorEl.hidden = false;
-				errorEl.removeAttribute('hidden');
-			} else {
-				errorEl.hidden = true;
-			}
-		}
+		this.syncErrorPresentation(errorMessage);
 
 		const nextFieldContext = {
 			name: fieldName,
@@ -409,19 +364,69 @@ export class RuiField extends RadiantElement {
 			invalid,
 			required,
 		};
-		const prev = this.fieldProvider.getContext();
-		if (
-			prev.name === nextFieldContext.name &&
-			prev.controlId === nextFieldContext.controlId &&
-			prev.descriptionId === nextFieldContext.descriptionId &&
-			prev.errorId === nextFieldContext.errorId &&
-			prev.error === nextFieldContext.error &&
-			prev.invalid === nextFieldContext.invalid &&
-			prev.required === nextFieldContext.required
-		) {
-			return;
-		}
-
-		this.fieldProvider.setContext(nextFieldContext);
+		this.publishFieldContext(nextFieldContext);
 	}
+
+	private syncDescriptions(descriptionId: string, errorId: string, errorMessage: string | undefined): string[] {
+		const describedBy: string[] = [];
+		const description = findFieldDescription(this);
+		if (description) {
+			description.id = descriptionId;
+			describedBy.push(descriptionId);
+		}
+		const error = findFieldError(this);
+		if (error) error.id = errorId;
+		if (error && errorMessage) describedBy.push(errorId);
+		return describedBy;
+	}
+
+	private syncAriaTargets(
+		targets: HTMLElement[],
+		controlId: string,
+		describedBy: string[],
+		invalid: boolean,
+		required: boolean,
+	): void {
+		for (const [index, target] of targets.entries()) {
+			if (!target.id) target.id = index === 0 ? controlId : `${controlId}-${index}`;
+			target.setAttribute(RUI_FIELD_MANAGED_ATTR, '');
+			target.setAttribute('aria-invalid', String(invalid));
+			target.toggleAttribute('aria-required', required);
+			if (required) target.setAttribute('aria-required', 'true');
+			if (describedBy.length) target.setAttribute('aria-describedby', describedBy.join(' '));
+			else target.removeAttribute('aria-describedby');
+			if (this.disabled) this.disableAriaTarget(target);
+		}
+	}
+
+	private disableAriaTarget(target: HTMLElement): void {
+		target.setAttribute('aria-disabled', 'true');
+		if (isNativeTextControl(target)) target.disabled = true;
+	}
+
+	private syncErrorPresentation(errorMessage: string | undefined): void {
+		for (const error of findFieldErrorElements(this)) {
+			error.textContent = errorMessage ?? '';
+			error.hidden = !errorMessage;
+			if (errorMessage) error.removeAttribute('hidden');
+		}
+	}
+
+	private publishFieldContext(next: FieldContextValue): void {
+		const previous = this.fieldProvider.getContext();
+		if (isSameFieldContext(previous, next)) return;
+		this.fieldProvider.setContext(next);
+	}
+}
+
+function isSameFieldContext(previous: FieldContextValue, next: FieldContextValue): boolean {
+	return (
+		previous.name === next.name &&
+		previous.controlId === next.controlId &&
+		previous.descriptionId === next.descriptionId &&
+		previous.errorId === next.errorId &&
+		previous.error === next.error &&
+		previous.invalid === next.invalid &&
+		previous.required === next.required
+	);
 }

--- a/packages/radiant-ui/src/components/ui/form/control-protocol.ts
+++ b/packages/radiant-ui/src/components/ui/form/control-protocol.ts
@@ -24,6 +24,18 @@ const HOST_CONTROL_TAGS = new Set([
 /** Library controls only — `data-rui-control` (e.g. RuiInput) or known host tags. */
 const CONTROL_SELECTOR = `[${RUI_CONTROL_ATTR}], ${Array.from(HOST_CONTROL_TAGS).join(', ')}`;
 
+const ARIA_TARGET_SELECTORS: Readonly<Record<string, string>> = {
+	'rui-combobox': '[data-combobox-input]',
+	'rui-date-field': '[data-date-field-input]',
+	'rui-date-range-picker': '[data-range-start]',
+	'rui-select': '[data-select-trigger]',
+	'rui-tag-group': '[data-tag-list]',
+	'rui-number-field': '[data-number-field-input], input',
+	'rui-knob': '[data-knob-control]',
+	'rui-checkbox': 'input',
+	'rui-switch': 'input',
+};
+
 /**
  * Presentational text controls (`RuiInput` / `RuiTextarea`) are real `<input>` / `<textarea>`
  * nodes marked with `data-rui-control`. Detect by tag name — never `instanceof HTMLInputElement`,
@@ -443,49 +455,17 @@ export function getAriaControlTarget(control: HTMLElement): HTMLElement {
 		return marked;
 	}
 
-	if (control.localName === 'rui-combobox') {
-		return control.querySelector<HTMLElement>('[data-combobox-input]') ?? control;
-	}
-
-	if (control.localName === 'rui-date-field') {
-		return control.querySelector<HTMLInputElement>('[data-date-field-input]') ?? control;
-	}
-
-	if (control.localName === 'rui-date-range-picker') {
-		return control.querySelector<HTMLInputElement>('[data-range-start]') ?? control;
-	}
-
-	if (control.localName === 'rui-select') {
-		return control.querySelector<HTMLElement>('[data-select-trigger]') ?? control;
-	}
-
-	if (control.localName === 'rui-tag-group') {
-		return control.querySelector<HTMLElement>('[data-tag-list]') ?? control;
-	}
-
-	if (control.localName === 'rui-number-field') {
-		return control.querySelector<HTMLElement>('[data-number-field-input], input') ?? control;
-	}
-
-	if (control.localName === 'rui-knob') {
-		return control.querySelector<HTMLElement>('[data-knob-control]') ?? control;
-	}
-
-	if (control.localName === 'rui-checkbox' || control.localName === 'rui-switch') {
-		return control.querySelector<HTMLElement>('input') ?? control;
-	}
-
 	if (control.localName === 'rui-radio-group') {
-		const radios = control.querySelectorAll<HTMLInputElement>('input[type="radio"]');
-		for (const radio of radios) {
-			if (isChecked(radio)) {
-				return radio;
-			}
-		}
-		return radios[0] ?? control;
+		return getSelectedRadio(control) ?? control;
 	}
 
-	return control;
+	const selector = ARIA_TARGET_SELECTORS[control.localName];
+	return selector ? (control.querySelector<HTMLElement>(selector) ?? control) : control;
+}
+
+function getSelectedRadio(control: HTMLElement): HTMLInputElement | undefined {
+	const radios = control.querySelectorAll<HTMLInputElement>('input[type="radio"]');
+	return Array.from(radios).find(isChecked) ?? radios[0];
 }
 
 /** Focusable surfaces that Field should wire `aria-invalid` / `aria-describedby` onto. */

--- a/packages/radiant-ui/src/components/ui/form/resolvers.ts
+++ b/packages/radiant-ui/src/components/ui/form/resolvers.ts
@@ -2,7 +2,7 @@ import type { FieldRules, FieldValues, Resolver, ResolverContext, ResolverResult
 
 function resolveRuleMessage(
 	fallback: string,
-	rule: boolean | string | number | { value: unknown; message: string } | undefined,
+	rule: boolean | string | number | RegExp | { value: unknown; message: string } | undefined,
 ): string | undefined {
 	if (rule === undefined || rule === false) {
 		return undefined;
@@ -29,72 +29,59 @@ async function validateFieldRules(
 	rules: FieldRules | undefined,
 	values: FieldValues,
 ): Promise<string | undefined> {
-	if (!rules) {
-		return undefined;
+	if (!rules) return undefined;
+	for (const validator of [validateRequired, validateNumericRange, validateTextRules, validateCustomRules]) {
+		const message = await validator(value, rules, values);
+		if (message) return message;
 	}
+	return undefined;
+}
 
-	if (rules.required) {
-		const empty =
-			value === undefined ||
-			value === null ||
-			value === '' ||
-			(Array.isArray(value) && value.length === 0) ||
-			value === false;
-		if (empty) {
-			return resolveRuleMessage('This field is required', rules.required) ?? 'This field is required';
-		}
-	}
+function validateRequired(value: unknown, rules: FieldRules): string | undefined {
+	const empty =
+		value === undefined ||
+		value === null ||
+		value === '' ||
+		value === false ||
+		(Array.isArray(value) && value.length === 0);
+	return rules.required && empty
+		? (resolveRuleMessage('This field is required', rules.required) ?? 'This field is required')
+		: undefined;
+}
 
-	if (typeof value === 'number' || (typeof value === 'string' && value !== '' && !Number.isNaN(Number(value)))) {
-		const num = typeof value === 'number' ? value : Number(value);
-		if (rules.min !== undefined && num < ruleValue(rules.min)) {
-			return resolveRuleMessage(`Minimum value is ${ruleValue(rules.min)}`, rules.min);
-		}
-		if (rules.max !== undefined && num > ruleValue(rules.max)) {
-			return resolveRuleMessage(`Maximum value is ${ruleValue(rules.max)}`, rules.max);
-		}
-	}
+function validateNumericRange(value: unknown, rules: FieldRules): string | undefined {
+	const numberValue =
+		typeof value === 'number' ? value : typeof value === 'string' && value !== '' ? Number(value) : undefined;
+	if (numberValue === undefined || Number.isNaN(numberValue)) return undefined;
+	if (rules.min !== undefined && numberValue < ruleValue(rules.min))
+		return resolveRuleMessage(`Minimum value is ${ruleValue(rules.min)}`, rules.min);
+	if (rules.max !== undefined && numberValue > ruleValue(rules.max))
+		return resolveRuleMessage(`Maximum value is ${ruleValue(rules.max)}`, rules.max);
+	return undefined;
+}
 
-	const str = value == null ? '' : String(value);
-	if (rules.minLength !== undefined && str.length < ruleValue(rules.minLength)) {
+function validateTextRules(value: unknown, rules: FieldRules): string | undefined {
+	const text = value == null ? '' : String(value);
+	if (rules.minLength !== undefined && text.length < ruleValue(rules.minLength))
 		return resolveRuleMessage(`Minimum length is ${ruleValue(rules.minLength)}`, rules.minLength);
-	}
-	if (rules.maxLength !== undefined && str.length > ruleValue(rules.maxLength)) {
+	if (rules.maxLength !== undefined && text.length > ruleValue(rules.maxLength))
 		return resolveRuleMessage(`Maximum length is ${ruleValue(rules.maxLength)}`, rules.maxLength);
-	}
-	if (rules.pattern !== undefined) {
-		const pattern = ruleValue(rules.pattern);
-		if (!pattern.test(str)) {
-			const patternRule = rules.pattern;
-			const message =
-				typeof patternRule === 'object' && 'message' in patternRule && typeof patternRule.message === 'string'
-					? patternRule.message
-					: 'Invalid format';
-			return message;
-		}
-	}
+	if (rules.pattern !== undefined && !ruleValue(rules.pattern).test(text))
+		return resolveRuleMessage('Invalid format', rules.pattern) ?? 'Invalid format';
+	return undefined;
+}
 
-	if (rules.validate) {
-		if (typeof rules.validate === 'function') {
-			const result = await rules.validate(value, values);
-			if (result === true || result === undefined) {
-				return undefined;
-			}
-			if (result === false) {
-				return 'Invalid value';
-			}
-			return String(result);
-		}
-
-		for (const key of Object.keys(rules.validate)) {
-			const fn = rules.validate[key];
-			const result = await fn(value, values);
-			if (result !== true && result !== undefined) {
-				return result === false ? 'Invalid value' : String(result);
-			}
-		}
+async function validateCustomRules(
+	value: unknown,
+	rules: FieldRules,
+	values: FieldValues,
+): Promise<string | undefined> {
+	if (!rules.validate) return undefined;
+	const validators = typeof rules.validate === 'function' ? [rules.validate] : Object.values(rules.validate);
+	for (const validate of validators) {
+		const result = await validate(value, values);
+		if (result !== true && result !== undefined) return result === false ? 'Invalid value' : String(result);
 	}
-
 	return undefined;
 }
 

--- a/packages/radiant-ui/src/components/ui/knob/knob.script.tsx
+++ b/packages/radiant-ui/src/components/ui/knob/knob.script.tsx
@@ -154,40 +154,47 @@ export class RuiKnob extends RadiantElement {
 			this.valuePrecision,
 		);
 		const valuePosition = this.resolvedValuePosition;
+		this.syncKnobLayout(valuePosition);
+		this.syncControl(value, ring.valueText);
+		this.syncRing(ring);
+		this.syncReadout(ring.valueText, valuePosition);
+		this.syncFormValue(value);
+	}
 
+	private syncKnobLayout(valuePosition: RuiKnobValuePosition): void {
 		this.rootTarget?.classList.toggle('rui-knob--value-below', valuePosition === 'below');
 		this.labelTarget?.toggleAttribute('hidden', !this.label);
-		if (this.labelTarget) {
-			this.labelTarget.textContent = this.label;
-		}
-
+		if (this.labelTarget) this.labelTarget.textContent = this.label;
 		if (this.resolvedSize) {
 			this.style.setProperty('--rui-knob-size', `${this.resolvedSize}px`);
 		} else {
 			this.style.removeProperty('--rui-knob-size');
 		}
+	}
 
-		if (this.controlTarget) {
-			this.controlTarget.setAttribute('aria-valuemin', String(this.numericRange.lowerBound));
-			this.controlTarget.setAttribute('aria-valuemax', String(this.numericRange.upperBound));
-			this.controlTarget.setAttribute('aria-valuenow', String(value));
-			this.controlTarget.setAttribute('aria-valuetext', ring.valueText);
-			if (this.label) {
-				this.controlTarget.setAttribute('aria-label', this.label);
-			} else {
-				this.controlTarget.removeAttribute('aria-label');
-			}
-			this.controlTarget.setAttribute('aria-readonly', String(this.readOnly));
-			this.controlTarget.disabled = this.disabled;
-		}
+	private syncControl(value: number, valueText: string): void {
+		const control = this.controlTarget;
+		if (!control) return;
+		control.setAttribute('aria-valuemin', String(this.numericRange.lowerBound));
+		control.setAttribute('aria-valuemax', String(this.numericRange.upperBound));
+		control.setAttribute('aria-valuenow', String(value));
+		control.setAttribute('aria-valuetext', valueText);
+		if (this.label) control.setAttribute('aria-label', this.label);
+		else control.removeAttribute('aria-label');
+		control.setAttribute('aria-readonly', String(this.readOnly));
+		control.disabled = this.disabled;
+	}
 
+	private syncRing(ring: ReturnType<typeof createKnobRing>): void {
 		for (const circle of [this.trackTarget, this.progressTarget]) {
 			circle?.setAttribute('r', String(ring.radius));
 			circle?.setAttribute('stroke-width', String(ring.strokeWidth));
 		}
 		this.trackTarget?.setAttribute('stroke-dasharray', `${ring.arcLength} ${ring.circumference}`);
 		this.progressTarget?.setAttribute('stroke-dasharray', `${ring.progressLength} ${ring.circumference}`);
+	}
 
+	private syncReadout(valueText: string, valuePosition: RuiKnobValuePosition): void {
 		for (const [target, visible] of [
 			[this.centerValueTarget, this.showValue && valuePosition === 'center'],
 			[this.belowValueTarget, this.showValue && valuePosition === 'below'],
@@ -195,19 +202,18 @@ export class RuiKnob extends RadiantElement {
 			if (!target) {
 				continue;
 			}
-			target.textContent = ring.valueText;
+			target.textContent = valueText;
 			target.toggleAttribute('hidden', !visible);
 		}
+	}
 
-		if (this.inputTarget) {
-			this.inputTarget.value = String(value);
-			if (this.name) {
-				this.inputTarget.name = this.name;
-			} else {
-				this.inputTarget.removeAttribute('name');
-			}
-			this.inputTarget.disabled = this.disabled;
-		}
+	private syncFormValue(value: number): void {
+		const input = this.inputTarget;
+		if (!input) return;
+		input.value = String(value);
+		if (this.name) input.name = this.name;
+		else input.removeAttribute('name');
+		input.disabled = this.disabled;
 	}
 
 	private syncPresentation(): void {

--- a/packages/radiant-ui/src/components/ui/knob/knob.tsx
+++ b/packages/radiant-ui/src/components/ui/knob/knob.tsx
@@ -36,18 +36,15 @@ export function RuiKnob({
 	const range = createNumericRange(min, max, step);
 	const resolvedValue = range.clamp(value);
 	const ring = createKnobRing(resolvedValue, min, max, step, strokeWidth, valueTemplate, valuePrecision);
-	const valueBelow = valuePosition === 'below';
-	const sizeStyle = size ? { '--rui-knob-size': `${size}px` } : undefined;
-
 	return (
-		<rui-knob
-			{...props}
+		<KnobSurface
+			props={props}
 			value={resolvedValue}
 			min={min}
 			max={max}
 			step={step}
 			disabled={disabled}
-			prop:readOnly={readOnly}
+			readOnly={readOnly}
 			label={label}
 			name={name}
 			size={size}
@@ -56,69 +53,138 @@ export function RuiKnob({
 			valuePosition={valuePosition}
 			valueTemplate={valueTemplate}
 			valuePrecision={valuePrecision}
-			style={sizeStyle}
+			ring={ring}
+			range={range}
+		/>
+	);
+}
+
+type KnobSurfaceProps = {
+	props: Omit<JsxCustomElementAttributes<RuiKnobElement, RuiKnobProps>, keyof RuiKnobProps>;
+	value: number;
+	min: number;
+	max: number;
+	step: number;
+	disabled: boolean;
+	readOnly: boolean;
+	label: string | undefined;
+	name: string | undefined;
+	size: number | undefined;
+	strokeWidth: number;
+	showValue: boolean;
+	valuePosition: RuiKnobProps['valuePosition'];
+	valueTemplate: string;
+	valuePrecision: number | undefined;
+	ring: ReturnType<typeof createKnobRing>;
+	range: ReturnType<typeof createNumericRange>;
+};
+
+function KnobSurface({ props, ring, range, ...knob }: KnobSurfaceProps) {
+	return (
+		<rui-knob
+			{...props}
+			value={knob.value}
+			min={knob.min}
+			max={knob.max}
+			step={knob.step}
+			disabled={knob.disabled}
+			prop:readOnly={knob.readOnly}
+			label={knob.label}
+			name={knob.name}
+			size={knob.size}
+			strokeWidth={knob.strokeWidth}
+			showValue={knob.showValue}
+			valuePosition={knob.valuePosition}
+			valueTemplate={knob.valueTemplate}
+			valuePrecision={knob.valuePrecision}
+			style={knob.size ? { '--rui-knob-size': `${knob.size}px` } : undefined}
 		>
-			<div class={valueBelow ? 'rui-knob rui-knob--value-below' : 'rui-knob'} data-ref="root">
-				<span class="rui-knob__label" data-ref="label" hidden={!label}>
-					{label}
-				</span>
-				<button
-					type="button"
-					class="rui-knob__control"
-					data-ref="control"
-					data-knob-control
-					role="slider"
-					aria-label={label || undefined}
-					aria-valuemin={range.lowerBound}
-					aria-valuemax={range.upperBound}
-					aria-valuenow={resolvedValue}
-					aria-valuetext={ring.valueText}
-					aria-readonly={readOnly}
-					disabled={disabled}
-				>
-					<svg class="rui-knob__svg" viewBox="0 0 100 100" aria-hidden="true">
-						<circle
-							class="rui-knob__track"
-							data-ref="track"
-							cx="50"
-							cy="50"
-							r={ring.radius}
-							fill="none"
-							stroke-width={ring.strokeWidth}
-							stroke-dasharray={`${ring.arcLength} ${ring.circumference}`}
-							transform={`rotate(${ring.startAngle} 50 50)`}
-						/>
-						<circle
-							class="rui-knob__progress"
-							data-ref="progress"
-							cx="50"
-							cy="50"
-							r={ring.radius}
-							fill="none"
-							stroke-width={ring.strokeWidth}
-							stroke-dasharray={`${ring.progressLength} ${ring.circumference}`}
-							transform={`rotate(${ring.startAngle} 50 50)`}
-						/>
-					</svg>
-					<span
-						class="rui-knob__value"
-						data-ref="centerValue"
-						aria-hidden="true"
-						hidden={!showValue || valueBelow}
-					>
-						{ring.valueText}
-					</span>
-				</button>
-				<span
-					class="rui-knob__value rui-knob__value--below"
-					data-ref="belowValue"
-					aria-hidden="true"
-					hidden={!showValue || !valueBelow}
-				>
-					{ring.valueText}
-				</span>
-				<input data-ref="input" type="hidden" name={name || undefined} value={resolvedValue} />
-			</div>
+			<KnobBody knob={knob} ring={ring} range={range} />
 		</rui-knob>
+	);
+}
+
+function KnobBody({
+	knob,
+	ring,
+	range,
+}: Pick<KnobSurfaceProps, 'ring' | 'range'> & { knob: Omit<KnobSurfaceProps, 'props' | 'ring' | 'range'> }) {
+	const valueBelow = knob.valuePosition === 'below';
+	return (
+		<div class={valueBelow ? 'rui-knob rui-knob--value-below' : 'rui-knob'} data-ref="root">
+			<span class="rui-knob__label" data-ref="label" hidden={!knob.label}>
+				{knob.label}
+			</span>
+			<KnobControl knob={knob} ring={ring} range={range} valueBelow={valueBelow} />
+			<span
+				class="rui-knob__value rui-knob__value--below"
+				data-ref="belowValue"
+				aria-hidden="true"
+				hidden={!knob.showValue || !valueBelow}
+			>
+				{ring.valueText}
+			</span>
+			<input data-ref="input" type="hidden" name={knob.name || undefined} value={knob.value} />
+		</div>
+	);
+}
+
+function KnobControl({
+	knob,
+	ring,
+	range,
+	valueBelow,
+}: Pick<KnobSurfaceProps, 'ring' | 'range'> & {
+	knob: Omit<KnobSurfaceProps, 'props' | 'ring' | 'range'>;
+	valueBelow: boolean;
+}) {
+	return (
+		<button
+			type="button"
+			class="rui-knob__control"
+			data-ref="control"
+			data-knob-control
+			role="slider"
+			aria-label={knob.label || undefined}
+			aria-valuemin={range.lowerBound}
+			aria-valuemax={range.upperBound}
+			aria-valuenow={knob.value}
+			aria-valuetext={ring.valueText}
+			aria-readonly={knob.readOnly}
+			disabled={knob.disabled}
+		>
+			<svg class="rui-knob__svg" viewBox="0 0 100 100" aria-hidden="true">
+				<circle
+					class="rui-knob__track"
+					data-ref="track"
+					cx="50"
+					cy="50"
+					r={ring.radius}
+					fill="none"
+					stroke-width={ring.strokeWidth}
+					stroke-dasharray={`${ring.arcLength} ${ring.circumference}`}
+					transform={`rotate(${ring.startAngle} 50 50)`}
+				/>
+				<circle
+					class="rui-knob__progress"
+					data-ref="progress"
+					cx="50"
+					cy="50"
+					r={ring.radius}
+					fill="none"
+					stroke-width={ring.strokeWidth}
+					stroke-dasharray={`${ring.progressLength} ${ring.circumference}`}
+					transform={`rotate(${ring.startAngle} 50 50)`}
+				/>
+			</svg>
+			<span
+				class="rui-knob__value"
+				data-ref="centerValue"
+				aria-hidden="true"
+				hidden={!knob.showValue || valueBelow}
+			>
+				{ring.valueText}
+			</span>
+		</button>
 	);
 }

--- a/packages/radiant-ui/src/components/ui/navigation-menu/navigation-menu.script.tsx
+++ b/packages/radiant-ui/src/components/ui/navigation-menu/navigation-menu.script.tsx
@@ -235,63 +235,49 @@ export class RuiNavigationMenu extends RadiantElement {
 	@onEvent({ selector: '[data-navigation-item]', type: 'keydown' })
 	onBarItemKeydown(event: KeyboardEvent): void {
 		const item = (event.target as HTMLElement).closest<HTMLElement>('[data-navigation-item]');
-		if (!item) {
-			return;
-		}
-
-		const barItems = this.getBarItems();
-		const isTrigger = this.isBarTrigger(item);
-		const value = item.getAttribute('data-value');
-
-		if (event.key === 'Escape') {
-			if (this.openValue) {
-				event.preventDefault();
-				this.closeMenu(true);
-			}
-			return;
-		}
-
-		if (isTrigger && value && (event.key === 'Enter' || event.key === ' ')) {
-			event.preventDefault();
-			this.openPanel(value);
-			return;
-		}
-
-		if (isTrigger && value && event.key === 'ArrowDown') {
-			event.preventDefault();
-			if (this.openValue === value) {
-				this.focusPanelEntry(value);
-			} else {
-				this.openPanel(value);
-			}
-			return;
-		}
+		if (!item || this.handleBarTriggerKeydown(event, item)) return;
 
 		const result = navigateRovingTabindex({
-			items: barItems,
+			items: this.getBarItems(),
 			current: item,
 			key: event.key,
 			orientation: 'horizontal',
 			wrap: false,
 		});
 
-		if (!result.handled) {
-			return;
-		}
-
+		if (!result.handled) return;
 		event.preventDefault();
+		this.syncMenuToBarItem(result.item);
+	}
 
-		const nextItem = result.item;
-		const nextValue = nextItem.getAttribute('data-value');
-		const nextIsTrigger = this.isBarTrigger(nextItem);
-
-		if (this.openValue) {
-			if (nextIsTrigger && nextValue) {
-				this.openPanel(nextValue);
-			} else {
-				this.closeMenu(false);
+	private handleBarTriggerKeydown(event: KeyboardEvent, item: HTMLElement): boolean {
+		if (event.key === 'Escape') {
+			if (this.openValue) {
+				event.preventDefault();
+				this.closeMenu(true);
 			}
+			return true;
 		}
+
+		const value = item.getAttribute('data-value');
+		if (!this.isBarTrigger(item) || !value) return false;
+		if (event.key === 'Enter' || event.key === ' ') {
+			event.preventDefault();
+			this.openPanel(value);
+			return true;
+		}
+		if (event.key !== 'ArrowDown') return false;
+		event.preventDefault();
+		if (this.openValue === value) this.focusPanelEntry(value);
+		else this.openPanel(value);
+		return true;
+	}
+
+	private syncMenuToBarItem(item: HTMLElement): void {
+		if (!this.openValue) return;
+		const value = item.getAttribute('data-value');
+		if (this.isBarTrigger(item) && value) this.openPanel(value);
+		else this.closeMenu(false);
 	}
 
 	@onEvent({ selector: '[data-navigation-panel]', type: 'keydown' })

--- a/packages/radiant-ui/src/components/ui/shared/listbox-popover-behavior.ts
+++ b/packages/radiant-ui/src/components/ui/shared/listbox-popover-behavior.ts
@@ -120,64 +120,69 @@ export class ListboxPopoverBehavior {
 
 	/** Handles the APG keys shared by select-only and autocomplete listboxes. */
 	handleKeydown(event: KeyboardEvent, options: ListboxKeydownConfig): void {
-		if (event.ctrlKey || event.shiftKey || event.metaKey) {
+		if (event.ctrlKey || event.shiftKey || event.metaKey) return;
+		const handler = this.keydownHandlers[event.key];
+		handler?.call(this, event, options);
+	}
+
+	private readonly keydownHandlers: Record<string, (event: KeyboardEvent, options: ListboxKeydownConfig) => void> = {
+		ArrowDown: this.handleArrowKey,
+		ArrowUp: this.handleArrowKey,
+		Escape: this.handleEscapeKey,
+		Enter: this.handleActivationKey,
+		' ': this.handleActivationKey,
+		Tab: this.handleTabKey,
+	};
+
+	private handleArrowKey(event: KeyboardEvent, options: ListboxKeydownConfig): void {
+		event.preventDefault();
+		event.stopPropagation();
+		const direction = event.key === 'ArrowDown' ? 1 : -1;
+		if (event.altKey) {
+			this.handleModifiedArrow(direction, options);
 			return;
 		}
+		this.moveActive(direction, (activation) => options.onOpen(activation));
+	}
 
-		if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+	private handleModifiedArrow(direction: 1 | -1, options: ListboxKeydownConfig): void {
+		if (direction === 1 && !options.isOpen) options.onOpen();
+		if (direction === -1 && options.isOpen) options.onClose('arrow');
+	}
+
+	private handleEscapeKey(event: KeyboardEvent, options: ListboxKeydownConfig): void {
+		event.preventDefault();
+		if (options.isOpen) options.onClose('escape');
+		else options.onEscapeWhenClosed?.();
+	}
+
+	private handleActivationKey(event: KeyboardEvent, options: ListboxKeydownConfig): void {
+		if (event.key === ' ' && !options.canUseSpace) return;
+		if (!options.isOpen && options.enterWhenClosed === 'open') {
 			event.preventDefault();
-			event.stopPropagation();
-			const direction = event.key === 'ArrowDown' ? 1 : -1;
-
-			if (event.altKey) {
-				if (direction === 1 && !options.isOpen) {
-					options.onOpen();
-				} else if (direction === -1 && options.isOpen) {
-					options.onClose('arrow');
-				}
-				return;
-			}
-
-			this.moveActive(direction, (activation) => options.onOpen(activation));
+			options.onOpen();
 			return;
 		}
-
-		if (event.key === 'Escape') {
+		if (!options.isOpen) return;
+		if (this.hasActiveOption()) {
 			event.preventDefault();
-			if (options.isOpen) {
-				options.onClose('escape');
-			} else {
-				options.onEscapeWhenClosed?.();
-			}
+			options.onSelectActive();
 			return;
 		}
-
-		if (event.key === 'Enter' || (event.key === ' ' && options.canUseSpace)) {
-			if (!options.isOpen && options.enterWhenClosed === 'open') {
-				event.preventDefault();
-				options.onOpen();
-				return;
-			}
-
-			const visible = this.getVisibleOptions();
-			if (options.isOpen && this.visualFocus && visible[this.activeIndex]) {
-				event.preventDefault();
-				options.onSelectActive();
-			} else if (event.key === 'Enter' && options.isOpen && options.enterWithoutActive === 'close') {
-				event.preventDefault();
-				options.onClose('enter');
-			}
-			return;
+		if (event.key === 'Enter' && options.enterWithoutActive === 'close') {
+			event.preventDefault();
+			options.onClose('enter');
 		}
+	}
 
-		if (event.key === 'Tab' && options.isOpen) {
-			const visible = this.getVisibleOptions();
-			if (this.visualFocus && visible[this.activeIndex] && options.closesOnTab) {
-				options.onSelectActive();
-				return;
-			}
-			options.onClose('tab');
-		}
+	private handleTabKey(_event: KeyboardEvent, options: ListboxKeydownConfig): void {
+		if (!options.isOpen) return;
+		if (this.hasActiveOption() && options.closesOnTab) options.onSelectActive();
+		else options.onClose('tab');
+	}
+
+	private hasActiveOption(): boolean {
+		return this.visualFocus && Boolean(this.getVisibleOptions()[this.activeIndex]);
 	}
 
 	syncPopoverPosition(): void {

--- a/packages/radiant-ui/src/components/ui/shared/menu-tree.ts
+++ b/packages/radiant-ui/src/components/ui/shared/menu-tree.ts
@@ -11,6 +11,13 @@ type MenuTreeConfig = {
 	onCloseRoot: (returnFocus: boolean) => void;
 };
 
+type MenuKeyContext = {
+	item: HTMLElement;
+	items: HTMLElement[];
+	menu: HTMLElement;
+	submenu: HTMLElement | null;
+};
+
 /**
  * Coordinates nested menu branches shared by menu-button and menubar hosts.
  *
@@ -88,62 +95,83 @@ export class MenuTreeController {
 		const item = this.getDirectItem(event.target);
 		const menu = item?.parentElement;
 		if (!item || !menu || menu.getAttribute('role') !== 'menu') return false;
+		const handler = this.keyHandlers[event.key];
+		if (!handler) return false;
+		const handled = handler.call(this, {
+			item,
+			items: this.getFocusableItems(menu),
+			menu,
+			submenu: this.getSubmenu(item),
+		});
+		if (handled && event.key !== 'Tab') event.preventDefault();
+		return handled;
+	}
 
-		const items = this.getFocusableItems(menu);
-		const index = items.indexOf(item);
-		const submenu = this.getSubmenu(item);
+	private readonly keyHandlers: Record<string, (context: MenuKeyContext) => boolean> = {
+		ArrowDown: this.focusNextItem,
+		ArrowUp: this.focusPreviousItem,
+		Home: this.focusFirstItem,
+		End: this.focusLastItem,
+		ArrowRight: this.openNestedMenu,
+		ArrowLeft: this.closeNestedMenu,
+		Enter: this.activateOrOpenItem,
+		' ': this.activateOrOpenItem,
+		Escape: this.closeRootMenu,
+		Tab: this.closeMenuForTab,
+	};
 
-		switch (event.key) {
-			case 'ArrowDown':
-				if (index < 0 || items.length === 0) return false;
-				event.preventDefault();
-				items[(index + 1) % items.length]?.focus();
-				return true;
-			case 'ArrowUp':
-				if (index < 0 || items.length === 0) return false;
-				event.preventDefault();
-				items[(index - 1 + items.length) % items.length]?.focus();
-				return true;
-			case 'Home':
-				event.preventDefault();
-				items[0]?.focus();
-				return true;
-			case 'End':
-				event.preventDefault();
-				items[items.length - 1]?.focus();
-				return true;
-			case 'ArrowRight':
-				if (!submenu) return false;
-				event.preventDefault();
-				this.openSubmenu(item, true);
-				return true;
-			case 'ArrowLeft': {
-				if (this.getRootMenu() === menu) return false;
-				event.preventDefault();
-				const trigger = this.getTriggerForMenu(menu);
-				if (trigger) this.closeSubmenu(trigger, true);
-				return true;
-			}
-			case 'Enter':
-			case ' ':
-				if (submenu) {
-					event.preventDefault();
-					this.openSubmenu(item, true);
-					return true;
-				}
-				event.preventDefault();
-				this.config.onActivate(item);
-				return true;
-			case 'Escape':
-				event.preventDefault();
-				this.config.onCloseRoot(true);
-				return true;
-			case 'Tab':
-				this.config.onCloseRoot(false);
-				return true;
-			default:
-				return false;
-		}
+	private focusNextItem(context: MenuKeyContext): boolean {
+		return this.focusRelativeItem(context, 1);
+	}
+
+	private focusPreviousItem(context: MenuKeyContext): boolean {
+		return this.focusRelativeItem(context, -1);
+	}
+
+	private focusRelativeItem(context: MenuKeyContext, direction: 1 | -1): boolean {
+		const index = context.items.indexOf(context.item);
+		if (index < 0 || !context.items.length) return false;
+		context.items[(index + direction + context.items.length) % context.items.length]?.focus();
+		return true;
+	}
+
+	private focusFirstItem(context: MenuKeyContext): boolean {
+		context.items[0]?.focus();
+		return true;
+	}
+
+	private focusLastItem(context: MenuKeyContext): boolean {
+		context.items.at(-1)?.focus();
+		return true;
+	}
+
+	private openNestedMenu(context: MenuKeyContext): boolean {
+		if (!context.submenu) return false;
+		this.openSubmenu(context.item, true);
+		return true;
+	}
+
+	private closeNestedMenu(context: MenuKeyContext): boolean {
+		if (this.getRootMenu() === context.menu) return false;
+		const trigger = this.getTriggerForMenu(context.menu);
+		if (trigger) this.closeSubmenu(trigger, true);
+		return true;
+	}
+
+	private activateOrOpenItem(context: MenuKeyContext): boolean {
+		if (context.submenu) this.openSubmenu(context.item, true);
+		else this.config.onActivate(context.item);
+		return true;
+	}
+
+	private closeRootMenu(): boolean {
+		this.config.onCloseRoot(true);
+		return true;
+	}
+
+	private closeMenuForTab(): boolean {
+		this.config.onCloseRoot(false);
+		return true;
 	}
 
 	handleClick(event: Event): boolean {

--- a/packages/radiant-ui/src/components/ui/slider/slider.script.tsx
+++ b/packages/radiant-ui/src/components/ui/slider/slider.script.tsx
@@ -273,44 +273,46 @@ export class RuiSlider extends RadiantElement {
 	}
 
 	private syncChrome(): void {
-		const disabled = this.disabled;
-		const range = this.isRange;
-		const tabindex = disabled ? -1 : 0;
-		const orientation = this.isVertical ? 'vertical' : 'horizontal';
-		const hasDefaultValue = Boolean(this.defaultValueTarget);
-		const hasVisibleReadout = Boolean(this.valueTarget) && (!hasDefaultValue || this.showValue);
-		const rangeBounds = this.numericRange;
+		this.syncRootChrome();
+		this.syncThumbChrome();
+	}
 
-		this.rootTarget?.classList.toggle('rui-slider--single', !range);
-		this.rootTarget?.classList.toggle('rui-slider--range', range);
+	private syncRootChrome(): void {
+		const hasVisibleReadout = Boolean(this.valueTarget) && (!this.defaultValueTarget || this.showValue);
+		this.rootTarget?.classList.toggle('rui-slider--single', !this.isRange);
+		this.rootTarget?.classList.toggle('rui-slider--range', this.isRange);
 		this.rootTarget?.classList.toggle('rui-slider--vertical', this.isVertical);
 		this.labelTarget?.toggleAttribute('hidden', !this.label);
-		if (this.labelTarget) {
-			this.labelTarget.textContent = this.label;
-		}
+		if (this.labelTarget) this.labelTarget.textContent = this.label;
 		this.defaultValueTarget?.toggleAttribute('hidden', !this.showValue);
 		this.headerTarget?.toggleAttribute('hidden', !this.label && !hasVisibleReadout);
+	}
 
-		const thumbs: Array<[RuiSliderThumb, string, boolean]> = [
-			['value', this.label || 'Value', !range],
-			['min', this.label ? `${this.label} minimum` : 'Minimum value', range],
-			['max', this.label ? `${this.label} maximum` : 'Maximum value', range],
-		];
-
-		for (const [id, ariaLabel, visible] of thumbs) {
+	private syncThumbChrome(): void {
+		const tabindex = this.disabled ? -1 : 0;
+		const orientation = this.isVertical ? 'vertical' : 'horizontal';
+		const rangeBounds = this.numericRange;
+		for (const { id, label, visible } of this.getThumbChrome()) {
 			const thumb = this.thumbFor(id);
-			if (!thumb) {
-				continue;
-			}
+			if (!thumb) continue;
 			thumb.toggleAttribute('hidden', !visible);
-			thumb.toggleAttribute('disabled', disabled || !visible);
+			thumb.toggleAttribute('disabled', this.disabled || !visible);
 			thumb.setAttribute('tabindex', String(visible ? tabindex : -1));
-			thumb.setAttribute('aria-label', ariaLabel);
+			thumb.setAttribute('aria-label', label);
 			thumb.setAttribute('aria-orientation', orientation);
 			thumb.setAttribute('aria-valuemin', String(rangeBounds.lowerBound));
 			thumb.setAttribute('aria-valuemax', String(rangeBounds.upperBound));
 			thumb.setAttribute('aria-readonly', String(this.readOnly));
 		}
+	}
+
+	private getThumbChrome(): Array<{ id: RuiSliderThumb; label: string; visible: boolean }> {
+		const range = this.isRange;
+		return [
+			{ id: 'value', label: this.label || 'Value', visible: !range },
+			{ id: 'min', label: this.label ? `${this.label} minimum` : 'Minimum value', visible: range },
+			{ id: 'max', label: this.label ? `${this.label} maximum` : 'Maximum value', visible: range },
+		];
 	}
 
 	private paint(values: number[]): void {
@@ -385,35 +387,36 @@ export class RuiSlider extends RadiantElement {
 	}
 
 	private syncValueTitle(values: number[]): void {
-		const thumbs = [this.singleThumb, this.rangeMinThumb, this.rangeMaxThumb];
-		if (!this.valueTitle) {
-			this.inputTarget?.removeAttribute('title');
-			this.maxInputTarget?.removeAttribute('title');
-			this.rangeTrack?.removeAttribute('title');
-			for (const thumb of thumbs) {
-				thumb?.removeAttribute('title');
-			}
-			return;
+		const targets = [
+			[this.inputTarget, 'input'],
+			[this.maxInputTarget, 'maxInput'],
+			[this.rangeTrack, 'track'],
+			[this.singleThumb, 'value'],
+			[this.rangeMinThumb, 'min'],
+			[this.rangeMaxThumb, 'max'],
+		] as const;
+		const titles = this.getValueTitles(values);
+		for (const [target, key] of targets) {
+			const title = titles[key];
+			if (title) target?.setAttribute('title', title);
+			else target?.removeAttribute('title');
 		}
+	}
 
+	private getValueTitles(values: number[]): Partial<Record<'input' | 'maxInput' | 'track' | RuiSliderThumb, string>> {
+		if (!this.valueTitle) return {};
 		if (values.length === 1) {
-			const title = this.formatValue(values[0]);
-			this.inputTarget?.setAttribute('title', title);
-			this.maxInputTarget?.removeAttribute('title');
-			this.rangeTrack?.removeAttribute('title');
-			this.singleThumb?.setAttribute('title', title);
-			this.rangeMinThumb?.removeAttribute('title');
-			this.rangeMaxThumb?.removeAttribute('title');
-			return;
+			const value = this.formatValue(values[0]);
+			return { input: value, value };
 		}
-
 		const [low, high] = values;
-		this.inputTarget?.setAttribute('title', this.formatValue(low));
-		this.maxInputTarget?.setAttribute('title', this.formatValue(high));
-		this.rangeTrack?.setAttribute('title', this.formatValues(values));
-		this.singleThumb?.removeAttribute('title');
-		this.rangeMinThumb?.setAttribute('title', this.formatValue(low));
-		this.rangeMaxThumb?.setAttribute('title', this.formatValue(high));
+		return {
+			input: this.formatValue(low),
+			maxInput: this.formatValue(high),
+			min: this.formatValue(low),
+			max: this.formatValue(high),
+			track: this.formatValues(values),
+		};
 	}
 
 	private valueFromPointer(event: PointerEvent): number {

--- a/packages/radiant-ui/src/components/ui/toast/toast.script.tsx
+++ b/packages/radiant-ui/src/components/ui/toast/toast.script.tsx
@@ -350,88 +350,100 @@ export class RuiToast extends RadiantElement<RuiToastBindings> {
 	@bound
 	private onPointerMove(event: PointerEvent): void {
 		if (!this.pointerStart) return;
-		const { y, x } = splitToastPosition(this.position);
-		const deltaX = event.clientX - this.pointerStart.x;
-		const deltaY = event.clientY - this.pointerStart.y;
+		const delta = { x: event.clientX - this.pointerStart.x, y: event.clientY - this.pointerStart.y };
 
-		if (!this.swiping) {
-			if (Math.abs(deltaX) < 8 && Math.abs(deltaY) < 8) return;
-			this.swiping = true;
-			this.syncDomState();
-		}
+		if (!this.startSwipe(delta)) return;
+		this.swipeAxis ??= Math.abs(delta.x) > Math.abs(delta.y) ? 'x' : 'y';
+		const amount = this.swipeAxis === 'x' ? { x: delta.x, y: 0 } : { x: 0, y: delta.y };
+		if (this.isSwipeReversing(amount)) this.resetSwipeTranslation();
+		else this.setSwipeTranslation(amount);
+	}
 
-		if (!this.swipeAxis) {
-			this.swipeAxis = Math.abs(deltaX) > Math.abs(deltaY) ? 'x' : 'y';
-		}
+	private startSwipe(delta: { x: number; y: number }): boolean {
+		if (this.swiping) return true;
+		if (Math.abs(delta.x) < 8 && Math.abs(delta.y) < 8) return false;
+		this.swiping = true;
+		this.syncDomState();
+		return true;
+	}
 
-		const swipeAmountX = this.swipeAxis === 'x' ? deltaX : 0;
-		const swipeAmountY = this.swipeAxis === 'y' ? deltaY : 0;
+	private isSwipeReversing(amount: { x: number; y: number }): boolean {
+		const { x, y } = splitToastPosition(this.position);
+		if (this.swipeAxis === 'y')
+			return (y === 'bottom' ? amount.y < 0 : amount.y > 0) && Math.abs(amount.y) < TOAST_SWIPE_THRESHOLD;
+		return (
+			x !== 'center' &&
+			(x === 'start' ? amount.x > 0 : amount.x < 0) &&
+			Math.abs(amount.x) < TOAST_SWIPE_THRESHOLD
+		);
+	}
 
-		if (this.swipeAxis === 'y') {
-			const towardExit = y === 'bottom' ? swipeAmountY > 0 : swipeAmountY < 0;
-			if (!towardExit && Math.abs(swipeAmountY) < TOAST_SWIPE_THRESHOLD) {
-				this.style.setProperty('--swipe-amount-x', '0px');
-				this.style.setProperty('--swipe-amount-y', '0px');
-				return;
-			}
-		}
+	private setSwipeTranslation(amount: { x: number; y: number }): void {
+		this.style.setProperty('--swipe-amount-x', `${amount.x}px`);
+		this.style.setProperty('--swipe-amount-y', `${amount.y}px`);
+	}
 
-		if (this.swipeAxis === 'x') {
-			const towardExit = x === 'start' ? swipeAmountX < 0 : swipeAmountX > 0;
-			if (x !== 'center' && !towardExit && Math.abs(swipeAmountX) < TOAST_SWIPE_THRESHOLD) {
-				this.style.setProperty('--swipe-amount-x', '0px');
-				this.style.setProperty('--swipe-amount-y', '0px');
-				return;
-			}
-		}
-
-		this.style.setProperty('--swipe-amount-x', `${swipeAmountX}px`);
-		this.style.setProperty('--swipe-amount-y', `${swipeAmountY}px`);
+	private resetSwipeTranslation(): void {
+		this.setSwipeTranslation({ x: 0, y: 0 });
 	}
 
 	@bound
 	private onPointerUp(event: PointerEvent): void {
 		if (!this.pointerStart) return;
-		try {
-			this.releasePointerCapture(event.pointerId);
-		} catch {}
-
-		const wasSwiping = this.swiping;
+		this.releaseToastPointer(event.pointerId);
+		const swipe = this.readSwipe();
 		this.swiping = false;
+		if (swipe && this.dismissible && this.shouldDismissSwipe(swipe)) this.dismissFromSwipe(swipe);
+		else this.cancelSwipe();
+		this.clearPointerState();
+	}
 
-		if (!wasSwiping) {
-			this.pointerStart = null;
-			this.dragStartTime = null;
-			this.swipeAxis = null;
-			return;
-		}
+	private releaseToastPointer(pointerId: number): void {
+		try {
+			this.releasePointerCapture(pointerId);
+		} catch {}
+	}
 
-		const swipeAmountX = Number.parseFloat(this.style.getPropertyValue('--swipe-amount-x') || '0');
-		const swipeAmountY = Number.parseFloat(this.style.getPropertyValue('--swipe-amount-y') || '0');
-		const swipeAmount = this.swipeAxis === 'x' ? swipeAmountX : swipeAmountY;
-		const swipeTime = this.dragStartTime ? Date.now() - this.dragStartTime : 0;
-		const velocity = Math.abs(swipeAmount) / Math.max(swipeTime, 1);
-		const shouldDismiss = Math.abs(swipeAmount) >= TOAST_SWIPE_THRESHOLD || velocity > 0.11;
+	private readSwipe(): { x: number; y: number } | undefined {
+		if (!this.swiping) return undefined;
+		return {
+			x: Number.parseFloat(this.style.getPropertyValue('--swipe-amount-x') || '0'),
+			y: Number.parseFloat(this.style.getPropertyValue('--swipe-amount-y') || '0'),
+		};
+	}
 
-		if (shouldDismiss && this.dismissible) {
-			const { y, x } = splitToastPosition(this.position);
-			if (this.swipeAxis === 'x') {
-				this.swipeOutDirection = swipeAmountX < 0 ? 'left' : 'right';
-				if (x === 'start') this.swipeOutDirection = 'left';
-				if (x === 'end') this.swipeOutDirection = 'right';
-			} else {
-				this.swipeOutDirection = y === 'bottom' ? 'down' : 'up';
-			}
-			this.swipeOut = true;
-			this.syncDomState();
-			this.beginRemove();
-		} else {
-			this.style.setProperty('--swipe-amount-x', '0px');
-			this.style.setProperty('--swipe-amount-y', '0px');
-			this.swipeAxis = null;
-			this.syncDomState();
-		}
+	private shouldDismissSwipe(swipe: { x: number; y: number }): boolean {
+		const amount = this.swipeAxis === 'x' ? swipe.x : swipe.y;
+		const duration = this.dragStartTime ? Date.now() - this.dragStartTime : 0;
+		return Math.abs(amount) >= TOAST_SWIPE_THRESHOLD || Math.abs(amount) / Math.max(duration, 1) > 0.11;
+	}
 
+	private dismissFromSwipe(swipe: { x: number; y: number }): void {
+		const { x, y } = splitToastPosition(this.position);
+		this.swipeOutDirection =
+			this.swipeAxis === 'y'
+				? y === 'bottom'
+					? 'down'
+					: 'up'
+				: x === 'start'
+					? 'left'
+					: x === 'end'
+						? 'right'
+						: swipe.x < 0
+							? 'left'
+							: 'right';
+		this.swipeOut = true;
+		this.syncDomState();
+		this.beginRemove();
+	}
+
+	private cancelSwipe(): void {
+		this.resetSwipeTranslation();
+		this.swipeAxis = null;
+		this.syncDomState();
+	}
+
+	private clearPointerState(): void {
 		this.pointerStart = null;
 		this.dragStartTime = null;
 	}

--- a/packages/radiant-ui/src/components/ui/tree/tree.script.tsx
+++ b/packages/radiant-ui/src/components/ui/tree/tree.script.tsx
@@ -150,74 +150,81 @@ export class RuiTree extends RadiantElement {
 	onKeydown(event: KeyboardEvent): void {
 		const current = (event.target as HTMLElement).closest('[role="treeitem"]') as HTMLElement | null;
 		if (!current) return;
+		const handler = this.treeKeyHandlers[event.key];
+		if (!handler?.call(this, current, event)) return;
+		event.preventDefault();
+	}
 
-		switch (event.key) {
-			case 'ArrowDown':
-			case 'ArrowUp':
-			case 'Home':
-			case 'End': {
-				const result = navigateRovingTabindex({
-					items: this.getVisibleItems(),
-					current,
-					key: event.key,
-					orientation: 'vertical',
-					wrap: false,
-				});
-				if (!result.handled) return;
-				event.preventDefault();
-				break;
-			}
-			case 'ArrowRight': {
-				event.preventDefault();
-				if (current.getAttribute('aria-expanded') === 'false') {
-					this.setExpanded(current, true);
-					return;
-				}
-				if (current.getAttribute('aria-expanded') === 'true') {
-					const items = this.getVisibleItems();
-					const index = items.indexOf(current);
-					if (items[index + 1]) focusRovingItem(items, index + 1);
-				}
-				break;
-			}
-			case 'ArrowLeft': {
-				event.preventDefault();
-				if (current.getAttribute('aria-expanded') === 'true') {
-					this.setExpanded(current, false);
-					return;
-				}
-				const parent = this.getParentItem(current);
-				if (parent) {
-					const nextItems = this.getVisibleItems();
-					const parentIndex = nextItems.indexOf(parent);
-					if (parentIndex >= 0) focusRovingItem(nextItems, parentIndex);
-				}
-				break;
-			}
-			case '*': {
-				event.preventDefault();
-				for (const sibling of this.getSiblingItems(current)) {
-					if (sibling.hasAttribute('aria-expanded')) {
-						this.setExpanded(sibling, true);
-					}
-				}
-				break;
-			}
-			case 'Enter': {
-				event.preventDefault();
-				if (current.hasAttribute('aria-expanded')) {
-					this.setExpanded(current, current.getAttribute('aria-expanded') !== 'true');
-				}
-				this.select(current);
-				break;
-			}
-			case ' ': {
-				event.preventDefault();
-				this.select(current);
-				break;
-			}
-			default:
-				break;
+	private readonly treeKeyHandlers: Record<string, (item: HTMLElement, event: KeyboardEvent) => boolean> = {
+		ArrowDown: this.navigateTreeItem,
+		ArrowUp: this.navigateTreeItem,
+		Home: this.navigateTreeItem,
+		End: this.navigateTreeItem,
+		ArrowRight: this.expandOrEnterChild,
+		ArrowLeft: this.collapseOrFocusParent,
+		'*': this.expandSiblings,
+		Enter: this.toggleAndSelect,
+		' ': this.selectTreeItem,
+	};
+
+	private navigateTreeItem(current: HTMLElement, event: KeyboardEvent): boolean {
+		return navigateRovingTabindex({
+			items: this.getVisibleItems(),
+			current,
+			key: event.key,
+			orientation: 'vertical',
+			wrap: false,
+		}).handled;
+	}
+
+	private expandOrEnterChild(current: HTMLElement): boolean {
+		if (current.getAttribute('aria-expanded') === 'false') {
+			this.setExpanded(current, true);
+			return true;
 		}
+		if (current.getAttribute('aria-expanded') !== 'true') return false;
+		this.focusAdjacentVisibleItem(current, 1);
+		return true;
+	}
+
+	private collapseOrFocusParent(current: HTMLElement): boolean {
+		if (current.getAttribute('aria-expanded') === 'true') {
+			this.setExpanded(current, false);
+			return true;
+		}
+		const parent = this.getParentItem(current);
+		if (parent) this.focusVisibleItem(parent);
+		return Boolean(parent);
+	}
+
+	private expandSiblings(current: HTMLElement): boolean {
+		for (const sibling of this.getSiblingItems(current)) {
+			if (sibling.hasAttribute('aria-expanded')) this.setExpanded(sibling, true);
+		}
+		return true;
+	}
+
+	private toggleAndSelect(current: HTMLElement): boolean {
+		if (current.hasAttribute('aria-expanded'))
+			this.setExpanded(current, current.getAttribute('aria-expanded') !== 'true');
+		this.select(current);
+		return true;
+	}
+
+	private selectTreeItem(current: HTMLElement): boolean {
+		this.select(current);
+		return true;
+	}
+
+	private focusAdjacentVisibleItem(current: HTMLElement, direction: 1 | -1): void {
+		const items = this.getVisibleItems();
+		const index = items.indexOf(current);
+		if (items[index + direction]) focusRovingItem(items, index + direction);
+	}
+
+	private focusVisibleItem(item: HTMLElement): void {
+		const items = this.getVisibleItems();
+		const index = items.indexOf(item);
+		if (index >= 0) focusRovingItem(items, index);
 	}
 }

--- a/packages/radiant-ui/src/components/ui/treegrid/treegrid.script.tsx
+++ b/packages/radiant-ui/src/components/ui/treegrid/treegrid.script.tsx
@@ -13,6 +13,14 @@ export type RuiTreegridChangeDetail = {
 	columnIndex: number;
 };
 
+type TreegridCellContext = {
+	cell: HTMLElement;
+	columnIndex: number;
+	row: HTMLElement;
+	rowCells: HTMLElement[];
+	visibleRows: HTMLElement[];
+};
+
 /**
  * `<rui-treegrid>` — a hierarchical grid navigated with arrow keys.
  *
@@ -195,104 +203,100 @@ export class RuiTreegrid extends RadiantElement {
 	onCellKeydown(event: KeyboardEvent): void {
 		const cell = (event.target as HTMLElement).closest<HTMLElement>('[role="gridcell"]');
 		const row = cell?.closest<HTMLElement>('[role="row"][data-row-id]');
-		if (!cell || !row) {
+		if (!cell || !row) return;
+		const context = this.createCellContext(cell, row);
+		const handler = this.cellKeyHandlers[event.key];
+		if (!handler) return;
+		event.preventDefault();
+		handler.call(this, context);
+	}
+
+	private readonly cellKeyHandlers: Record<string, (context: TreegridCellContext) => void> = {
+		ArrowRight: this.moveRight,
+		ArrowLeft: this.moveLeft,
+		ArrowDown: this.moveDown,
+		ArrowUp: this.moveUp,
+		Home: this.focusFirstCell,
+		End: this.focusLastCell,
+		'*': this.expandAllRows,
+		Enter: this.toggleOrActivateCell,
+		' ': this.activateContextCell,
+	};
+
+	private createCellContext(cell: HTMLElement, row: HTMLElement): TreegridCellContext {
+		return {
+			cell,
+			columnIndex: this.getRowCells(row).indexOf(cell),
+			row,
+			rowCells: this.getRowCells(row),
+			visibleRows: this.getVisibleRows(),
+		};
+	}
+
+	private moveRight(context: TreegridCellContext): void {
+		if (this.setExpandedFromFirstCell(context, true)) return;
+		if (context.columnIndex < context.rowCells.length - 1) this.focusCell(context.row, context.columnIndex + 1);
+	}
+
+	private moveLeft(context: TreegridCellContext): void {
+		if (this.setExpandedFromFirstCell(context, false)) return;
+		if (context.columnIndex > 0) {
+			this.focusCell(context.row, context.columnIndex - 1);
 			return;
 		}
+		const parent = this.getParentRow(context.row);
+		if (parent) this.focusCell(parent, 0);
+	}
 
-		const visibleRows = this.getVisibleRows();
-		const rowIndex = visibleRows.indexOf(row);
-		const rowCells = this.getRowCells(row);
-		const colIndex = rowCells.indexOf(cell);
-		const isFirstCell = colIndex === 0;
-		const isExpandable = row.hasAttribute('aria-expanded');
-		const isExpanded = row.getAttribute('aria-expanded') === 'true';
+	private moveDown(context: TreegridCellContext): void {
+		this.focusAdjacentRow(context, 1);
+	}
 
-		switch (event.key) {
-			case 'ArrowRight': {
-				event.preventDefault();
-				if (isFirstCell && isExpandable && !isExpanded) {
-					this.setExpanded(row, true);
-					this.syncSelection();
-					return;
-				}
+	private moveUp(context: TreegridCellContext): void {
+		this.focusAdjacentRow(context, -1);
+	}
 
-				if (colIndex < rowCells.length - 1) {
-					this.focusCell(row, colIndex + 1);
-				}
-				return;
-			}
-			case 'ArrowLeft': {
-				event.preventDefault();
-				if (isFirstCell && isExpandable && isExpanded) {
-					this.setExpanded(row, false);
-					this.syncSelection();
-					return;
-				}
+	private focusAdjacentRow(context: TreegridCellContext, direction: 1 | -1): void {
+		const index = context.visibleRows.indexOf(context.row);
+		const row = context.visibleRows[index + direction];
+		if (row) this.focusCell(row, context.columnIndex);
+	}
 
-				if (colIndex > 0) {
-					this.focusCell(row, colIndex - 1);
-					return;
-				}
+	private focusFirstCell(context: TreegridCellContext): void {
+		this.focusCell(context.row, 0);
+	}
 
-				const parent = this.getParentRow(row);
-				if (parent) {
-					this.focusCell(parent, 0);
-				}
-				return;
-			}
-			case 'ArrowDown': {
-				event.preventDefault();
-				const nextRow = visibleRows[Math.min(visibleRows.length - 1, rowIndex + 1)];
-				if (nextRow && nextRow !== row) {
-					this.focusCell(nextRow, colIndex);
-				}
-				return;
-			}
-			case 'ArrowUp': {
-				event.preventDefault();
-				const prevRow = visibleRows[Math.max(0, rowIndex - 1)];
-				if (prevRow && prevRow !== row) {
-					this.focusCell(prevRow, colIndex);
-				}
-				return;
-			}
-			case 'Home': {
-				event.preventDefault();
-				this.focusCell(row, 0);
-				return;
-			}
-			case 'End': {
-				event.preventDefault();
-				this.focusCell(row, rowCells.length - 1);
-				return;
-			}
-			case '*': {
-				event.preventDefault();
-				for (const sibling of this.getDataRows()) {
-					if (sibling.hasAttribute('aria-expanded')) {
-						this.setExpanded(sibling, true);
-					}
-				}
-				this.syncSelection();
-				return;
-			}
-			case 'Enter': {
-				event.preventDefault();
-				if (isFirstCell && isExpandable) {
-					this.setExpanded(row, !isExpanded);
-					this.syncSelection();
-					return;
-				}
-				this.activateCell(cell);
-				return;
-			}
-			case ' ': {
-				event.preventDefault();
-				this.activateCell(cell);
-				return;
-			}
-			default:
-				return;
-		}
+	private focusLastCell(context: TreegridCellContext): void {
+		this.focusCell(context.row, context.rowCells.length - 1);
+	}
+
+	private expandAllRows(): void {
+		for (const row of this.getDataRows()) if (row.hasAttribute('aria-expanded')) this.setExpanded(row, true);
+		this.syncSelection();
+	}
+
+	private toggleOrActivateCell(context: TreegridCellContext): void {
+		if (this.toggleExpansionFromFirstCell(context)) return;
+		this.activateCell(context.cell);
+	}
+
+	private activateContextCell(context: TreegridCellContext): void {
+		this.activateCell(context.cell);
+	}
+
+	private setExpandedFromFirstCell(context: TreegridCellContext, expanded: boolean): boolean {
+		const isExpanded = context.row.getAttribute('aria-expanded') === 'true';
+		if (context.columnIndex !== 0 || !context.row.hasAttribute('aria-expanded') || isExpanded === expanded)
+			return false;
+		this.setExpanded(context.row, expanded);
+		this.syncSelection();
+		return true;
+	}
+
+	private toggleExpansionFromFirstCell(context: TreegridCellContext): boolean {
+		if (context.columnIndex !== 0 || !context.row.hasAttribute('aria-expanded')) return false;
+		this.setExpanded(context.row, context.row.getAttribute('aria-expanded') !== 'true');
+		this.syncSelection();
+		return true;
 	}
 }

--- a/packages/radiant-ui/src/stories/fixtures/data.ts
+++ b/packages/radiant-ui/src/stories/fixtures/data.ts
@@ -112,28 +112,39 @@ export function cloneItems(): Item[] {
 	return structuredClone(initialItems);
 }
 
+const validMilkOptions = new Set<ItemDraft['milk']>(['Cow', 'Sheep', 'Goat', 'Mixed']);
+const validTextureOptions = new Set<ItemDraft['texture']>(['Soft', 'Semi-hard', 'Hard']);
+const validOriginOptions = new Set<ItemDraft['origin']>([
+	'France',
+	'Italy',
+	'Spain',
+	'Switzerland',
+	'Netherlands',
+	'Greece',
+	'United Kingdom',
+]);
+
 export function normalizeDraft(value: unknown): ItemDraft | null {
-	if (!value || typeof value !== 'object' || Array.isArray(value)) {
+	if (!isRecord(value)) {
 		return null;
 	}
-	const source = value as Record<string, unknown>;
-	const name = typeof source.name === 'string' ? source.name.trim() : '';
-	const milk = source.milk;
-	const texture = source.texture;
-	const origin = source.origin;
+	const name = typeof value.name === 'string' ? value.name.trim() : '';
 	if (
 		!name ||
-		(milk !== 'Cow' && milk !== 'Sheep' && milk !== 'Goat' && milk !== 'Mixed') ||
-		(texture !== 'Soft' && texture !== 'Semi-hard' && texture !== 'Hard') ||
-		(origin !== 'France' &&
-			origin !== 'Italy' &&
-			origin !== 'Spain' &&
-			origin !== 'Switzerland' &&
-			origin !== 'Netherlands' &&
-			origin !== 'Greece' &&
-			origin !== 'United Kingdom')
+		!validMilkOptions.has(value.milk as ItemDraft['milk']) ||
+		!validTextureOptions.has(value.texture as ItemDraft['texture']) ||
+		!validOriginOptions.has(value.origin as ItemDraft['origin'])
 	) {
 		return null;
 	}
-	return { name, milk, texture, origin };
+	return {
+		name,
+		milk: value.milk as ItemDraft['milk'],
+		texture: value.texture as ItemDraft['texture'],
+		origin: value.origin as ItemDraft['origin'],
+	};
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
 }

--- a/packages/radiant/README.md
+++ b/packages/radiant/README.md
@@ -233,9 +233,7 @@ export class KeyboardPanel extends RadiantElement<{ lastKey: string }> {
 }
 ```
 
-Important: `@onEvent({ selector: ... })` and `@onEvent({ ref: ... })` currently check `event.target.matches(...)` directly. That means matching is strict against the original target, not ancestor-aware. If a nested element inside a button receives the click, the nested element must match for the handler to run.
-
-Also note that selector- and ref-based `@onEvent(...)` handlers rely on bubbling. Use `focusin` and `focusout` instead of `focus` and `blur` for that pattern.
+Selector- and ref-based `@onEvent(...)` handlers, and `subscribeEvent(...)` / `subscribeEvents(...)`, match with `Element.closest(...)` from the event target, so a click on a nested icon still reaches a wrapping `button[data-ref]` or selector match. They still rely on bubbling, so use `focusin` and `focusout` instead of `focus` and `blur` for that pattern.
 
 ### `@event(...)`
 

--- a/packages/radiant/src/core/delegated-event.ts
+++ b/packages/radiant/src/core/delegated-event.ts
@@ -1,0 +1,18 @@
+/**
+ * Returns whether a bubbling event should fire a delegated listener on `root`.
+ *
+ * @remarks
+ * Resolves text-node targets to their owning element, then uses `closest()` so a
+ * click on a nested icon still matches a wrapping button. `matches()` alone
+ * misses that case. The match must still be `root` or contained by it.
+ */
+export function eventMatchesDelegatedSelector(event: Event, root: Node, selector: string): boolean {
+	const eventTarget = event.target;
+	if (!(eventTarget instanceof Node)) return false;
+
+	const elementTarget = eventTarget instanceof Element ? eventTarget : eventTarget.parentElement;
+	if (!elementTarget) return false;
+
+	const matched = elementTarget.closest(selector);
+	return Boolean(matched && (matched === root || root.contains(matched)));
+}

--- a/packages/radiant/src/core/event-subscription-registry.ts
+++ b/packages/radiant/src/core/event-subscription-registry.ts
@@ -1,3 +1,5 @@
+import { eventMatchesDelegatedSelector } from './delegated-event';
+
 export type ElementEventListenerConfig = {
 	selector: string;
 	type: string;
@@ -21,7 +23,10 @@ export class EventSubscriptionRegistry {
 		const interactionTarget = this.getInteractionTarget();
 		const listenerContext = this.getListenerContext();
 		const delegatedListener = (delegatedEvent: Event) => {
-			if (delegatedEvent.target && (delegatedEvent.target as Element).matches(eventConfig.selector)) {
+			if (
+				interactionTarget instanceof Node &&
+				eventMatchesDelegatedSelector(delegatedEvent, interactionTarget, eventConfig.selector)
+			) {
 				eventConfig.listener.call(listenerContext, delegatedEvent);
 			}
 		};

--- a/packages/radiant/src/core/slot-projection-runtime.ts
+++ b/packages/radiant/src/core/slot-projection-runtime.ts
@@ -2,6 +2,7 @@ import {
 	createMarkupNodeLike,
 	isKeyedJsxValue,
 	isSlotJsxValue,
+	type JsxNodeLike,
 	type JsxRenderable,
 	type KeyedJsxValue,
 	type SlotJsxValue,
@@ -207,11 +208,7 @@ function renderableToHtmlFragment(renderable: JsxRenderable): string | undefined
 	}
 
 	if (typeof Node !== 'undefined' && renderable instanceof Node) {
-		if (renderable.nodeType === Node.TEXT_NODE) {
-			return renderable.textContent ?? '';
-		}
-
-		return (renderable as Element).outerHTML ?? renderable.textContent ?? undefined;
+		return renderDomNode(renderable);
 	}
 
 	if (isKeyedJsxValue(renderable)) {
@@ -222,8 +219,8 @@ function renderableToHtmlFragment(renderable: JsxRenderable): string | undefined
 		return String(renderable);
 	}
 
-	if (typeof renderable === 'object' && renderable !== null && 'outerHTML' in renderable) {
-		return typeof renderable.outerHTML === 'string' ? renderable.outerHTML : (renderable.textContent ?? undefined);
+	if (hasOuterHtml(renderable)) {
+		return renderOuterHtmlValue(renderable);
 	}
 
 	if (isIterableRenderable(renderable)) {
@@ -231,6 +228,22 @@ function renderableToHtmlFragment(renderable: JsxRenderable): string | undefined
 	}
 
 	return undefined;
+}
+
+function renderDomNode(node: Node): string | undefined {
+	if (node.nodeType === Node.TEXT_NODE) {
+		return node.textContent ?? '';
+	}
+
+	return (node as Element).outerHTML ?? node.textContent ?? undefined;
+}
+
+function hasOuterHtml(renderable: JsxRenderable): renderable is JsxNodeLike & { outerHTML: unknown } {
+	return typeof renderable === 'object' && renderable !== null && 'outerHTML' in renderable;
+}
+
+function renderOuterHtmlValue(renderable: JsxNodeLike & { outerHTML: unknown }): string | undefined {
+	return typeof renderable.outerHTML === 'string' ? renderable.outerHTML : (renderable.textContent ?? undefined);
 }
 
 function resolveSlotValue(

--- a/packages/radiant/src/helpers/create-event-listener.ts
+++ b/packages/radiant/src/helpers/create-event-listener.ts
@@ -138,69 +138,16 @@ export function createEventListener(
 
 	const hostElement = resolveEventListenerHostElement(host);
 	const boundCallback = callback.bind(host);
-	let windowCleanup: (() => void) | null = null;
-	let documentCleanup: (() => void) | null = null;
-	let mediaQueryCleanup: (() => void) | null = null;
-	let lightCleanup: (() => void) | null = null;
-	let shadowCleanup: (() => void) | null = null;
+	const cleanups = new Map<EventListenerScope, () => void>();
 	let disposed = false;
 
 	const detachListeners = () => {
-		windowCleanup?.();
-		documentCleanup?.();
-		mediaQueryCleanup?.();
-		lightCleanup?.();
-		shadowCleanup?.();
-
-		windowCleanup = null;
-		documentCleanup = null;
-		mediaQueryCleanup = null;
-		lightCleanup = null;
-		shadowCleanup = null;
+		for (const cleanup of cleanups.values()) cleanup();
+		cleanups.clear();
 	};
 
 	const attachListeners = () => {
-		if (disposed) {
-			return;
-		}
-
-		if ('window' in config && !windowCleanup) {
-			window.addEventListener(config.type, boundCallback, config.options);
-			windowCleanup = () => {
-				window.removeEventListener(config.type, boundCallback, config.options);
-			};
-		}
-
-		if ('document' in config && !documentCleanup) {
-			document.addEventListener(config.type, boundCallback, config.options);
-			documentCleanup = () => {
-				document.removeEventListener(config.type, boundCallback, config.options);
-			};
-		}
-
-		if ('mediaQuery' in config && !mediaQueryCleanup) {
-			if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
-				return;
-			}
-
-			const mediaQueryList = window.matchMedia(config.mediaQuery);
-			mediaQueryList.addEventListener(config.type, boundCallback, config.options);
-			mediaQueryCleanup = () => {
-				mediaQueryList.removeEventListener(config.type, boundCallback, config.options);
-			};
-		}
-
-		if ('selector' in config || 'ref' in config) {
-			const selector = 'selector' in config ? config.selector : `[data-ref='${escapeCssIdentifier(config.ref)}']`;
-
-			if (config.scope !== 'shadow' && !lightCleanup) {
-				lightCleanup = addDelegatedListener(hostElement, config, selector, boundCallback);
-			}
-
-			if (config.scope !== 'light' && hostElement.shadowRoot && !shadowCleanup) {
-				shadowCleanup = addDelegatedListener(hostElement.shadowRoot, config, selector, boundCallback);
-			}
-		}
+		if (!disposed) attachConfiguredListeners(cleanups, hostElement, config, boundCallback);
 	};
 
 	if ('selector' in config || 'ref' in config) {
@@ -225,3 +172,60 @@ export function createEventListener(
 		detachListeners();
 	};
 }
+
+function attachConfiguredListeners(
+	cleanups: Map<EventListenerScope, () => void>,
+	hostElement: Element,
+	config: OnEventConfig,
+	listener: EventListener,
+): void {
+	if ('window' in config) attachNativeListener(cleanups, 'window', window, config, listener);
+	if ('document' in config) attachNativeListener(cleanups, 'document', document, config, listener);
+	if ('mediaQuery' in config) attachMediaQueryListener(cleanups, config, listener);
+	if ('selector' in config || 'ref' in config) attachDelegatedListeners(cleanups, hostElement, config, listener);
+}
+
+function attachNativeListener(
+	cleanups: Map<EventListenerScope, () => void>,
+	key: 'document' | 'window',
+	target: Window | Document,
+	config: OnEventConfig,
+	listener: EventListener,
+): void {
+	if (cleanups.has(key)) return;
+	target.addEventListener(config.type, listener, config.options);
+	cleanups.set(key, () => target.removeEventListener(config.type, listener, config.options));
+}
+
+function attachMediaQueryListener(
+	cleanups: Map<EventListenerScope, () => void>,
+	config: OnEventConfig,
+	listener: EventListener,
+): void {
+	if (
+		!('mediaQuery' in config) ||
+		cleanups.has('mediaQuery') ||
+		typeof window === 'undefined' ||
+		typeof window.matchMedia !== 'function'
+	)
+		return;
+	const mediaQueryList = window.matchMedia(config.mediaQuery);
+	mediaQueryList.addEventListener(config.type, listener, config.options);
+	cleanups.set('mediaQuery', () => mediaQueryList.removeEventListener(config.type, listener, config.options));
+}
+
+function attachDelegatedListeners(
+	cleanups: Map<EventListenerScope, () => void>,
+	hostElement: Element,
+	config: OnEventConfig,
+	listener: EventListener,
+): void {
+	if (!('selector' in config || 'ref' in config)) return;
+	const selector = 'selector' in config ? config.selector : `[data-ref='${escapeCssIdentifier(config.ref)}']`;
+	if (config.scope !== 'shadow' && !cleanups.has('light'))
+		cleanups.set('light', addDelegatedListener(hostElement, config, selector, listener));
+	if (config.scope !== 'light' && hostElement.shadowRoot && !cleanups.has('shadow'))
+		cleanups.set('shadow', addDelegatedListener(hostElement.shadowRoot, config, selector, listener));
+}
+
+type EventListenerScope = 'document' | 'light' | 'mediaQuery' | 'shadow' | 'window';

--- a/packages/radiant/src/helpers/create-event-listener.ts
+++ b/packages/radiant/src/helpers/create-event-listener.ts
@@ -1,6 +1,6 @@
 import type { RadiantElementEventListener } from '../core/radiant-element';
+import { eventMatchesDelegatedSelector } from '../core/delegated-event';
 import { isServer } from '@ecopages/radiant/is-server';
-import { escapeCssIdentifier } from '../tools/escape-css-identifier';
 import { isControllerHost, resolveHostElement } from './resolve-host-element';
 
 /**
@@ -67,19 +67,7 @@ function addDelegatedListener(
 	listener: EventListener,
 ): () => void {
 	const delegatedListener = (event: Event) => {
-		const eventTarget = event.target;
-		if (!(eventTarget instanceof Node)) return;
-
-		// Text nodes are valid event targets; resolve to the owning element.
-		const elementTarget = eventTarget instanceof Element ? eventTarget : eventTarget.parentElement;
-		if (!elementTarget) return;
-
-		// Use closest() so clicks on descendants of the matched node still fire —
-		// matches() alone breaks buttons that wrap icons, tracks, labels, etc.
-		const matched = elementTarget.closest(selector);
-		if (matched && (matched === root || root.contains(matched))) {
-			listener(event);
-		}
+		if (eventMatchesDelegatedSelector(event, root, selector)) listener(event);
 	};
 
 	root.addEventListener(config.type, delegatedListener, config.options);
@@ -204,14 +192,14 @@ function attachMediaQueryListener(
 ): void {
 	if (
 		!('mediaQuery' in config) ||
-		cleanups.has('mediaQuery') ||
+		cleanups.has('media') ||
 		typeof window === 'undefined' ||
 		typeof window.matchMedia !== 'function'
 	)
 		return;
 	const mediaQueryList = window.matchMedia(config.mediaQuery);
 	mediaQueryList.addEventListener(config.type, listener, config.options);
-	cleanups.set('mediaQuery', () => mediaQueryList.removeEventListener(config.type, listener, config.options));
+	cleanups.set('media', () => mediaQueryList.removeEventListener(config.type, listener, config.options));
 }
 
 function attachDelegatedListeners(
@@ -221,11 +209,11 @@ function attachDelegatedListeners(
 	listener: EventListener,
 ): void {
 	if (!('selector' in config || 'ref' in config)) return;
-	const selector = 'selector' in config ? config.selector : `[data-ref='${escapeCssIdentifier(config.ref)}']`;
+	const selector = 'selector' in config ? config.selector : `[data-ref='${CSS.escape(config.ref)}']`;
 	if (config.scope !== 'shadow' && !cleanups.has('light'))
 		cleanups.set('light', addDelegatedListener(hostElement, config, selector, listener));
 	if (config.scope !== 'light' && hostElement.shadowRoot && !cleanups.has('shadow'))
 		cleanups.set('shadow', addDelegatedListener(hostElement.shadowRoot, config, selector, listener));
 }
 
-type EventListenerScope = 'document' | 'light' | 'mediaQuery' | 'shadow' | 'window';
+type EventListenerScope = 'document' | 'light' | 'media' | 'shadow' | 'window';

--- a/packages/radiant/src/server/html/html-parser.ts
+++ b/packages/radiant/src/server/html/html-parser.ts
@@ -40,73 +40,51 @@ export function collectTopLevelHtmlFragments(html: string): string[] {
 	let index = 0;
 
 	while (index < html.length) {
-		const fragmentStart = index;
-
-		if (html.startsWith('<!--', index)) {
-			const commentEnd = html.indexOf('-->', index + 4);
-			index = commentEnd === -1 ? html.length : commentEnd + 3;
-			fragments.push(html.slice(fragmentStart, index));
-			continue;
-		}
-
-		if (html[index] !== '<') {
-			const nextTagIndex = html.indexOf('<', index);
-			index = nextTagIndex === -1 ? html.length : nextTagIndex;
-			fragments.push(html.slice(fragmentStart, index));
-			continue;
-		}
-
-		const token = parseHtmlTagToken(html, index);
-
-		if (!token) {
-			fragments.push(html.slice(fragmentStart));
-			break;
-		}
-
-		if (token.type !== 'open' || token.selfClosing || voidElementNames.has(token.tagName)) {
-			index = token.end;
-			fragments.push(html.slice(fragmentStart, index));
-			continue;
-		}
-
-		index = token.end;
-		let depth = 1;
-
-		while (index < html.length && depth > 0) {
-			const nextTagIndex = html.indexOf('<', index);
-
-			if (nextTagIndex === -1) {
-				index = html.length;
-				break;
-			}
-
-			const nestedToken = parseHtmlTagToken(html, nextTagIndex);
-
-			if (!nestedToken) {
-				index = html.length;
-				break;
-			}
-
-			index = nestedToken.end;
-
-			if (nestedToken.type === 'comment' || nestedToken.type === 'declaration') {
-				continue;
-			}
-
-			if (nestedToken.type === 'open' && !nestedToken.selfClosing && !voidElementNames.has(nestedToken.tagName)) {
-				depth += 1;
-				continue;
-			}
-
-			if (nestedToken.type === 'close') {
-				depth -= 1;
-			}
-		}
-
-		fragments.push(html.slice(fragmentStart, index));
+		const nextIndex = findTopLevelFragmentEnd(html, index);
+		fragments.push(html.slice(index, nextIndex));
+		index = nextIndex;
 	}
 
 	return fragments.filter((fragment) => fragment !== '');
+}
+
+function findTopLevelFragmentEnd(html: string, startIndex: number): number {
+	if (html.startsWith('<!--', startIndex)) return findCommentEnd(html, startIndex);
+	if (html[startIndex] !== '<') return findTextEnd(html, startIndex);
+	const token = parseHtmlTagToken(html, startIndex);
+	if (!token || token.type !== 'open' || token.selfClosing || voidElementNames.has(token.tagName))
+		return token?.end ?? html.length;
+	return findElementEnd(html, token.end);
+}
+
+function findCommentEnd(html: string, startIndex: number): number {
+	const commentEnd = html.indexOf('-->', startIndex + 4);
+	return commentEnd === -1 ? html.length : commentEnd + 3;
+}
+
+function findTextEnd(html: string, startIndex: number): number {
+	const nextTagIndex = html.indexOf('<', startIndex);
+	return nextTagIndex === -1 ? html.length : nextTagIndex;
+}
+
+function findElementEnd(html: string, startIndex: number): number {
+	let index = startIndex;
+	let depth = 1;
+	while (index < html.length && depth > 0) {
+		const nextTagIndex = html.indexOf('<', index);
+		if (nextTagIndex === -1) return html.length;
+		const token = parseHtmlTagToken(html, nextTagIndex);
+		if (!token) return html.length;
+		index = token.end;
+		depth += getElementDepthDelta(token);
+	}
+	return index;
+}
+
+function getElementDepthDelta(token: ParsedHtmlToken): number {
+	if (token.type === 'close') return -1;
+	if (token.type === 'open' && !token.selfClosing && !voidElementNames.has(token.tagName)) return 1;
+	return 0;
 }
 
 export function findHtmlTagEnd(html: string, startIndex: number): number {

--- a/packages/radiant/src/server/shim/minimal-dom/install.ts
+++ b/packages/radiant/src/server/shim/minimal-dom/install.ts
@@ -1,4 +1,4 @@
-import { escapeCssIdentifier } from '../../../tools/escape-css-identifier';
+import { escapeCssIdentifierFallback } from '../../../tools/escape-css-identifier';
 import { MinimalCustomElementsRegistry, MinimalDocument, type MinimalCustomElementRegistry } from './document';
 import './html';
 import {
@@ -98,7 +98,7 @@ type DomSurfaceCandidates = Pick<
 
 const minimalCssNamespace: MinimalCssNamespace = {
 	escape(value: string): string {
-		return escapeCssIdentifier(String(value));
+		return escapeCssIdentifierFallback(String(value));
 	},
 };
 

--- a/packages/radiant/src/server/shim/minimal-dom/install.ts
+++ b/packages/radiant/src/server/shim/minimal-dom/install.ts
@@ -81,6 +81,21 @@ type GlobalDomScope = typeof globalThis & {
 	cancelAnimationFrame?: typeof cancelAnimationFrame;
 };
 
+type DomSurfaceCandidates = Pick<
+	GlobalDomScope,
+	| 'CustomEvent'
+	| 'Document'
+	| 'Element'
+	| 'Event'
+	| 'EventTarget'
+	| 'HTMLElement'
+	| 'Node'
+	| 'cancelAnimationFrame'
+	| 'customElements'
+	| 'document'
+	| 'requestAnimationFrame'
+>;
+
 const minimalCssNamespace: MinimalCssNamespace = {
 	escape(value: string): string {
 		return escapeCssIdentifier(String(value));
@@ -132,94 +147,105 @@ function hasUsableElementSurface(value: unknown, verifyStyleOperation = false): 
 
 function getCompleteDomSurface(): LightDomShimWindow | undefined {
 	const globalScope = globalThis as GlobalDomScope;
-	let NodeConstructor: GlobalDomScope['Node'];
-	let DocumentConstructor: GlobalDomScope['Document'];
-	let ElementConstructor: GlobalDomScope['Element'];
-	let HTMLElementConstructor: GlobalDomScope['HTMLElement'];
-	let document: GlobalDomScope['document'];
-	let customElements: GlobalDomScope['customElements'];
-	let EventConstructor: GlobalDomScope['Event'];
-	let CustomEventConstructor: GlobalDomScope['CustomEvent'];
-	let EventTargetConstructor: GlobalDomScope['EventTarget'];
-	let requestAnimationFrame: GlobalDomScope['requestAnimationFrame'];
-	let cancelAnimationFrame: GlobalDomScope['cancelAnimationFrame'];
+	const candidates = readDomSurfaceCandidates(globalScope);
+	if (!candidates || !hasCompleteDomSurface(candidates)) return undefined;
+	return createCompleteDomSurface(globalScope, candidates);
+}
 
+function readDomSurfaceCandidates(globalScope: GlobalDomScope): DomSurfaceCandidates | undefined {
 	try {
-		NodeConstructor = globalScope.Node;
-		DocumentConstructor = globalScope.Document;
-		ElementConstructor = globalScope.Element;
-		HTMLElementConstructor = globalScope.HTMLElement;
-		document = globalScope.document;
-		customElements = globalScope.customElements;
-		EventConstructor = globalScope.Event;
-		CustomEventConstructor = globalScope.CustomEvent;
-		EventTargetConstructor = globalScope.EventTarget;
-		requestAnimationFrame = globalScope.requestAnimationFrame;
-		cancelAnimationFrame = globalScope.cancelAnimationFrame;
+		const {
+			CustomEvent,
+			Document,
+			Element,
+			Event,
+			EventTarget,
+			HTMLElement,
+			Node,
+			cancelAnimationFrame,
+			customElements,
+			document,
+			requestAnimationFrame,
+		} = globalScope;
+		return {
+			CustomEvent,
+			Document,
+			Element,
+			Event,
+			EventTarget,
+			HTMLElement,
+			Node,
+			cancelAnimationFrame,
+			customElements,
+			document,
+			requestAnimationFrame,
+		};
 	} catch {
 		return undefined;
 	}
+}
 
-	if (
-		typeof NodeConstructor !== 'function' ||
-		typeof DocumentConstructor !== 'function' ||
-		typeof ElementConstructor !== 'function' ||
-		typeof HTMLElementConstructor !== 'function' ||
-		!isObjectLike(document) ||
-		!isObjectLike(customElements) ||
-		typeof EventConstructor !== 'function' ||
-		typeof CustomEventConstructor !== 'function' ||
-		typeof EventTargetConstructor !== 'function'
-	) {
-		return undefined;
-	}
+function hasCompleteDomSurface(candidates: DomSurfaceCandidates): candidates is Required<DomSurfaceCandidates> {
+	return hasDomConstructors(candidates) && hasDomCapabilities(candidates) && hasUsableDomElements(candidates);
+}
 
-	let elementProbe: unknown;
-	let customElementProbe: unknown;
+function hasDomConstructors(candidates: DomSurfaceCandidates): boolean {
+	return ['Node', 'Document', 'Element', 'HTMLElement', 'Event', 'CustomEvent', 'EventTarget'].every(
+		(key) => typeof candidates[key as keyof DomSurfaceCandidates] === 'function',
+	);
+}
 
+function hasDomCapabilities(candidates: DomSurfaceCandidates): boolean {
+	return (
+		isObjectLike(candidates.document) &&
+		isObjectLike(candidates.customElements) &&
+		typeof candidates.document.createElement === 'function' &&
+		typeof candidates.document.getElementById === 'function' &&
+		typeof candidates.customElements.define === 'function' &&
+		typeof candidates.customElements.get === 'function' &&
+		typeof candidates.requestAnimationFrame === 'function' &&
+		typeof candidates.cancelAnimationFrame === 'function'
+	);
+}
+
+function hasUsableDomElements(candidates: DomSurfaceCandidates): boolean {
 	try {
-		if (
-			typeof document.createElement !== 'function' ||
-			typeof document.getElementById !== 'function' ||
-			typeof customElements.define !== 'function' ||
-			typeof customElements.get !== 'function' ||
-			typeof requestAnimationFrame !== 'function' ||
-			typeof cancelAnimationFrame !== 'function'
-		) {
-			return undefined;
-		}
-		elementProbe = document.createElement('div');
+		if (typeof candidates.HTMLElement !== 'function' || !candidates.document) return false;
+		const elementProbe = candidates.document.createElement('div');
 		/**
 		 * @remarks Browser-like runtimes can reject direct construction of an unregistered
 		 * custom element, so the probe uses the subclass prototype without mutating the registry.
 		 */
-		class ProbeHost extends HTMLElementConstructor {}
-		customElementProbe = Object.create(ProbeHost.prototype);
+		class ProbeHost extends candidates.HTMLElement {}
+		return (
+			hasUsableElementSurface(elementProbe, true) && hasUsableElementSurface(Object.create(ProbeHost.prototype))
+		);
 	} catch {
-		return undefined;
+		return false;
 	}
+}
 
-	if (!hasUsableElementSurface(elementProbe, true) || !hasUsableElementSurface(customElementProbe)) {
-		return undefined;
-	}
-
+function createCompleteDomSurface(
+	globalScope: GlobalDomScope,
+	candidates: Required<DomSurfaceCandidates>,
+): LightDomShimWindow | undefined {
 	try {
 		return {
 			CSS: getCssNamespace(globalScope),
-			CustomEvent: CustomEventConstructor,
-			Document: DocumentConstructor,
-			Element: ElementConstructor,
-			Event: EventConstructor,
-			EventTarget: EventTargetConstructor,
+			CustomEvent: candidates.CustomEvent,
+			Document: candidates.Document,
+			Element: candidates.Element,
+			Event: candidates.Event,
+			EventTarget: candidates.EventTarget,
 			HTMLScriptElement: (typeof globalScope.HTMLScriptElement === 'function'
 				? globalScope.HTMLScriptElement
-				: HTMLElementConstructor) as typeof HTMLScriptElement,
-			HTMLElement: HTMLElementConstructor,
-			Node: NodeConstructor,
-			document,
-			customElements,
-			requestAnimationFrame,
-			cancelAnimationFrame,
+				: candidates.HTMLElement) as typeof HTMLScriptElement,
+			HTMLElement: candidates.HTMLElement,
+			Node: candidates.Node,
+			document: candidates.document,
+			customElements: candidates.customElements,
+			requestAnimationFrame: candidates.requestAnimationFrame,
+			cancelAnimationFrame: candidates.cancelAnimationFrame,
 		};
 	} catch {
 		return undefined;

--- a/packages/radiant/src/server/shim/minimal-dom/selectors.ts
+++ b/packages/radiant/src/server/shim/minimal-dom/selectors.ts
@@ -93,7 +93,13 @@ function parseCompoundSelector(selector: string): CompoundSelector[] {
 		throw new SyntaxError(`Failed to execute 'querySelector' on 'Element': '${selector}' is not a valid selector.`);
 	}
 
-	const tokens: Array<{ type: 'child' | 'compound' | 'descendant'; value?: string }> = [];
+	return buildCompoundSelectors(tokenizeCompoundSelector(trimmed), selector);
+}
+
+type CompoundSelectorToken = { type: 'child' | 'compound' | 'descendant'; value?: string };
+
+function tokenizeCompoundSelector(trimmed: string): CompoundSelectorToken[] {
+	const tokens: CompoundSelectorToken[] = [];
 	let current = '';
 	let inBrackets = false;
 	let quote: '"' | "'" | undefined;
@@ -115,9 +121,14 @@ function parseCompoundSelector(selector: string): CompoundSelector[] {
 			continue;
 		}
 
-		const bracketState = getBracketState(character);
-		if (bracketState !== undefined) {
-			inBrackets = bracketState;
+		if (character === '[') {
+			inBrackets = true;
+			current += character;
+			continue;
+		}
+
+		if (character === ']') {
+			inBrackets = false;
 			current += character;
 			continue;
 		}
@@ -147,17 +158,11 @@ function parseCompoundSelector(selector: string): CompoundSelector[] {
 		tokens.push({ type: 'compound', value: current.trim() });
 	}
 
-	return buildCompoundSelectors(tokens, selector);
-}
-
-function getBracketState(character: string | undefined): boolean | undefined {
-	if (character === '[') return true;
-	if (character === ']') return false;
-	return undefined;
+	return tokens;
 }
 
 function buildCompoundSelectors(
-	tokens: Array<{ type: 'child' | 'compound' | 'descendant'; value?: string }>,
+	tokens: CompoundSelectorToken[],
 	selector: string,
 ): CompoundSelector[] {
 	const compounds: CompoundSelector[] = [];

--- a/packages/radiant/src/server/shim/minimal-dom/selectors.ts
+++ b/packages/radiant/src/server/shim/minimal-dom/selectors.ts
@@ -161,10 +161,7 @@ function tokenizeCompoundSelector(trimmed: string): CompoundSelectorToken[] {
 	return tokens;
 }
 
-function buildCompoundSelectors(
-	tokens: CompoundSelectorToken[],
-	selector: string,
-): CompoundSelector[] {
+function buildCompoundSelectors(tokens: CompoundSelectorToken[], selector: string): CompoundSelector[] {
 	const compounds: CompoundSelector[] = [];
 	let nextCombinator: CompoundSelector['combinator'] = null;
 

--- a/packages/radiant/src/server/shim/minimal-dom/selectors.ts
+++ b/packages/radiant/src/server/shim/minimal-dom/selectors.ts
@@ -115,14 +115,9 @@ function parseCompoundSelector(selector: string): CompoundSelector[] {
 			continue;
 		}
 
-		if (character === '[') {
-			inBrackets = true;
-			current += character;
-			continue;
-		}
-
-		if (character === ']') {
-			inBrackets = false;
+		const bracketState = getBracketState(character);
+		if (bracketState !== undefined) {
+			inBrackets = bracketState;
 			current += character;
 			continue;
 		}
@@ -152,6 +147,19 @@ function parseCompoundSelector(selector: string): CompoundSelector[] {
 		tokens.push({ type: 'compound', value: current.trim() });
 	}
 
+	return buildCompoundSelectors(tokens, selector);
+}
+
+function getBracketState(character: string | undefined): boolean | undefined {
+	if (character === '[') return true;
+	if (character === ']') return false;
+	return undefined;
+}
+
+function buildCompoundSelectors(
+	tokens: Array<{ type: 'child' | 'compound' | 'descendant'; value?: string }>,
+	selector: string,
+): CompoundSelector[] {
 	const compounds: CompoundSelector[] = [];
 	let nextCombinator: CompoundSelector['combinator'] = null;
 
@@ -185,72 +193,56 @@ function parseSelectorParts(selector: string): SelectorPart[] {
 	let index = 0;
 
 	while (index < selector.length) {
-		const character = selector[index];
-
-		if (character === ' ' || character === '\t' || character === '\n' || character === '\r') {
-			index += 1;
-			continue;
-		}
-
-		if (character === '#') {
-			const match = /^#([A-Za-z0-9_.-]+)/.exec(selector.slice(index));
-			if (!match) {
-				throwUnsupported(selector);
-			}
-			parts.push({ type: 'id', value: match[1]! });
-			index += match[0].length;
-			continue;
-		}
-
-		if (character === '.') {
-			const match = /^\.([A-Za-z0-9_-]+)/.exec(selector.slice(index));
-			if (!match) {
-				throwUnsupported(selector);
-			}
-			parts.push({ type: 'class', value: match[1]! });
-			index += match[0].length;
-			continue;
-		}
-
-		if (character === '[') {
-			const closeIndex = selector.indexOf(']', index);
-			if (closeIndex === -1) {
-				throwUnsupported(selector);
-			}
-
-			const attributeBody = selector.slice(index + 1, closeIndex);
-			const attributeMatch = /^([A-Za-z0-9_:.-]+)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s\]]+)))?$/.exec(
-				attributeBody,
-			);
-
-			if (!attributeMatch) {
-				throwUnsupported(selector);
-			}
-
-			const [, name, doubleQuoted, singleQuoted, bareValue] = attributeMatch;
-			const value = doubleQuoted ?? singleQuoted ?? bareValue;
-			parts.push(value === undefined ? { type: 'attr', name: name! } : { type: 'attr', name: name!, value });
-			index = closeIndex + 1;
-			continue;
-		}
-
-		if (character === ':' || character === '~' || character === '+') {
-			throwUnsupported(selector);
-		}
-
-		const tagMatch = /^([A-Za-z][A-Za-z0-9_:-]*|\*)/.exec(selector.slice(index));
-		if (!tagMatch) {
-			throwUnsupported(selector);
-		}
-
-		if (tagMatch[1] !== '*') {
-			parts.push({ type: 'tag', value: tagMatch[1]!.toLowerCase() });
-		}
-
-		index += tagMatch[0].length;
+		const result = parseSelectorPart(selector, index);
+		if (result.part) parts.push(result.part);
+		index = result.nextIndex;
 	}
 
 	return parts;
+}
+
+function parseSelectorPart(selector: string, index: number): { nextIndex: number; part?: SelectorPart } {
+	const character = selector[index];
+	if (character && /\s/.test(character)) return { nextIndex: index + 1 };
+	if (character === '#') return parseSimplePart(selector, index, /^#([A-Za-z0-9_.-]+)/, 'id');
+	if (character === '.') return parseSimplePart(selector, index, /^\.([A-Za-z0-9_-]+)/, 'class');
+	if (character === '[') return parseAttributePart(selector, index);
+	if (character === ':' || character === '~' || character === '+') throwUnsupported(selector);
+	return parseTagPart(selector, index);
+}
+
+function parseSimplePart(
+	selector: string,
+	index: number,
+	pattern: RegExp,
+	type: 'class' | 'id',
+): { nextIndex: number; part: SelectorPart } {
+	const match = pattern.exec(selector.slice(index));
+	if (!match) throwUnsupported(selector);
+	return { nextIndex: index + match[0].length, part: { type, value: match[1]! } };
+}
+
+function parseAttributePart(selector: string, index: number): { nextIndex: number; part: SelectorPart } {
+	const closeIndex = selector.indexOf(']', index);
+	if (closeIndex === -1) throwUnsupported(selector);
+	const match = /^([A-Za-z0-9_:.-]+)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s\]]+)))?$/.exec(
+		selector.slice(index + 1, closeIndex),
+	);
+	if (!match) throwUnsupported(selector);
+	const [, name, doubleQuoted, singleQuoted, bareValue] = match;
+	const value = doubleQuoted ?? singleQuoted ?? bareValue;
+	return {
+		nextIndex: closeIndex + 1,
+		part: value === undefined ? { type: 'attr', name: name! } : { type: 'attr', name: name!, value },
+	};
+}
+
+function parseTagPart(selector: string, index: number): { nextIndex: number; part?: SelectorPart } {
+	const match = /^([A-Za-z][A-Za-z0-9_:-]*|\*)/.exec(selector.slice(index));
+	if (!match) throwUnsupported(selector);
+	return match[1] === '*'
+		? { nextIndex: index + match[0].length }
+		: { nextIndex: index + match[0].length, part: { type: 'tag', value: match[1]!.toLowerCase() } };
 }
 
 function throwUnsupported(selector: string): never {

--- a/packages/radiant/src/tools/escape-css-identifier.ts
+++ b/packages/radiant/src/tools/escape-css-identifier.ts
@@ -1,6 +1,6 @@
 export function escapeCssIdentifier(value: string): string {
-	const cssNamespace = globalThis.CSS as { escape?: (value: string) => string } | undefined;
-	if (typeof cssNamespace?.escape === 'function') return cssNamespace.escape(value);
+	const escape = globalThis.CSS?.escape;
+	if (typeof escape === 'function') return escape(value);
 	let escaped = '';
 	for (let index = 0; index < value.length; index += 1) escaped += escapeCharacter(value, index);
 	return escaped;
@@ -18,20 +18,12 @@ function escapeCharacter(value: string, index: number): string {
 
 function requiresCodePointEscape(value: string, index: number, codePoint: number): boolean {
 	return (
-		(codePoint >= 0x0001 && codePoint <= 0x001f) ||
+		(codePoint > 0 && codePoint < 0x0020) ||
 		codePoint === 0x007f ||
-		(index === 0 && codePoint >= 0x0030 && codePoint <= 0x0039) ||
-		(index === 1 && codePoint >= 0x0030 && codePoint <= 0x0039 && (value[0] ?? '') === '-')
+		(codePoint >= 0x0030 && codePoint <= 0x0039 && (index === 0 || (index === 1 && value[0] === '-')))
 	);
 }
 
 function isCssIdentifierCharacter(character: string, codePoint: number): boolean {
-	return (
-		codePoint >= 0x0080 ||
-		character === '-' ||
-		character === '_' ||
-		(codePoint >= 0x0030 && codePoint <= 0x0039) ||
-		(codePoint >= 0x0041 && codePoint <= 0x005a) ||
-		(codePoint >= 0x0061 && codePoint <= 0x007a)
-	);
+	return codePoint >= 0x0080 || /[-_0-9A-Za-z]/.test(character);
 }

--- a/packages/radiant/src/tools/escape-css-identifier.ts
+++ b/packages/radiant/src/tools/escape-css-identifier.ts
@@ -1,46 +1,37 @@
 export function escapeCssIdentifier(value: string): string {
 	const cssNamespace = globalThis.CSS as { escape?: (value: string) => string } | undefined;
-
-	if (typeof cssNamespace?.escape === 'function') {
-		return cssNamespace.escape(value);
-	}
-
+	if (typeof cssNamespace?.escape === 'function') return cssNamespace.escape(value);
 	let escaped = '';
-
-	for (let index = 0; index < value.length; index += 1) {
-		const character = value[index] ?? '';
-		const codePoint = character.codePointAt(0) ?? 0;
-
-		if (codePoint === 0) {
-			escaped += '\uFFFD';
-			continue;
-		}
-
-		const isControlCharacter = (codePoint >= 0x0001 && codePoint <= 0x001f) || codePoint === 0x007f;
-		const startsWithDigit = index === 0 && codePoint >= 0x0030 && codePoint <= 0x0039;
-		const startsWithHyphenDigit =
-			index === 1 && codePoint >= 0x0030 && codePoint <= 0x0039 && (value[0] ?? '') === '-';
-		const isSingleHyphen = index === 0 && character === '-' && value.length === 1;
-
-		if (isControlCharacter || startsWithDigit || startsWithHyphenDigit) {
-			escaped += `\\${codePoint.toString(16)} `;
-			continue;
-		}
-
-		if (
-			codePoint >= 0x0080 ||
-			character === '-' ||
-			character === '_' ||
-			(codePoint >= 0x0030 && codePoint <= 0x0039) ||
-			(codePoint >= 0x0041 && codePoint <= 0x005a) ||
-			(codePoint >= 0x0061 && codePoint <= 0x007a)
-		) {
-			escaped += isSingleHyphen ? `\\${character}` : character;
-			continue;
-		}
-
-		escaped += `\\${character}`;
-	}
-
+	for (let index = 0; index < value.length; index += 1) escaped += escapeCharacter(value, index);
 	return escaped;
+}
+
+function escapeCharacter(value: string, index: number): string {
+	const character = value[index] ?? '';
+	const codePoint = character.codePointAt(0) ?? 0;
+	if (codePoint === 0) return '\uFFFD';
+	if (requiresCodePointEscape(value, index, codePoint)) return `\\${codePoint.toString(16)} `;
+	if (isCssIdentifierCharacter(character, codePoint))
+		return index === 0 && character === '-' && value.length === 1 ? `\\${character}` : character;
+	return `\\${character}`;
+}
+
+function requiresCodePointEscape(value: string, index: number, codePoint: number): boolean {
+	return (
+		(codePoint >= 0x0001 && codePoint <= 0x001f) ||
+		codePoint === 0x007f ||
+		(index === 0 && codePoint >= 0x0030 && codePoint <= 0x0039) ||
+		(index === 1 && codePoint >= 0x0030 && codePoint <= 0x0039 && (value[0] ?? '') === '-')
+	);
+}
+
+function isCssIdentifierCharacter(character: string, codePoint: number): boolean {
+	return (
+		codePoint >= 0x0080 ||
+		character === '-' ||
+		character === '_' ||
+		(codePoint >= 0x0030 && codePoint <= 0x0039) ||
+		(codePoint >= 0x0041 && codePoint <= 0x005a) ||
+		(codePoint >= 0x0061 && codePoint <= 0x007a)
+	);
 }

--- a/packages/radiant/src/tools/escape-css-identifier.ts
+++ b/packages/radiant/src/tools/escape-css-identifier.ts
@@ -1,6 +1,25 @@
+/**
+ * Escapes a value for use in a CSS selector.
+ *
+ * @remarks
+ * Prefers native `CSS.escape` when the runtime already provides it. The fallback
+ * exists for the SSR light-DOM shim, which installs this function as `CSS.escape`
+ * rather than wrapping `escapeCssIdentifier` (that would recurse).
+ */
 export function escapeCssIdentifier(value: string): string {
 	const escape = globalThis.CSS?.escape;
 	if (typeof escape === 'function') return escape(value);
+	return escapeCssIdentifierFallback(value);
+}
+
+/**
+ * CSS.escape polyfill used when the runtime has no native implementation.
+ *
+ * @remarks
+ * Must not look up `globalThis.CSS.escape`. The light-DOM shim assigns this
+ * function to that slot, so a lookup here would recurse forever.
+ */
+export function escapeCssIdentifierFallback(value: string): string {
 	let escaped = '';
 	for (let index = 0; index < value.length; index += 1) escaped += escapeCharacter(value, index);
 	return escaped;

--- a/packages/radiant/test/core/radiant-element.browser.test.ts
+++ b/packages/radiant/test/core/radiant-element.browser.test.ts
@@ -129,6 +129,28 @@ describe('RadiantElement', () => {
 		expect(customElement.hasEventSubscription('click:[data-ref="click-it"]')).toBeTruthy();
 	});
 
+	test('subscribeEvent fires when the click target is nested inside the match', () => {
+		const customElement = document.createElement('my-radiant-element') as MyRadiantElement;
+		const button = document.createElement('button');
+		button.setAttribute('data-ref', 'nested-btn');
+		const icon = document.createElement('span');
+		button.appendChild(icon);
+		customElement.appendChild(button);
+		document.body.appendChild(customElement);
+
+		let received = false;
+		customElement.subscribeEvent({
+			selector: '[data-ref="nested-btn"]',
+			type: 'click',
+			listener: () => {
+				received = true;
+			},
+		});
+
+		icon.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+		expect(received).toBe(true);
+	});
+
 	test('it can create a reactive property', () => {
 		const customElement = document.createElement('my-radiant-element') as MyRadiantElement;
 		document.body.appendChild(customElement);

--- a/packages/radiant/test/decorators/on-event.browser.test.ts
+++ b/packages/radiant/test/decorators/on-event.browser.test.ts
@@ -127,6 +127,29 @@ describe('onEvent', () => {
 		expect(element.received).toBeTruthy();
 	});
 
+	it('should fire delegated listeners when the click target is nested inside the match', () => {
+		@customElement('nested-on-event-listener')
+		class NestedOnEventListener extends RadiantElement {
+			received = false;
+
+			@onEvent({ ref: 'nested-btn', type: 'click' })
+			onNestedClick() {
+				this.received = true;
+			}
+		}
+
+		const element = document.createElement('nested-on-event-listener') as NestedOnEventListener;
+		const button = document.createElement('button');
+		button.setAttribute('data-ref', 'nested-btn');
+		const icon = document.createElement('span');
+		button.appendChild(icon);
+		element.appendChild(button);
+		document.body.appendChild(element);
+
+		icon.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+		expect(element.received).toBeTruthy();
+	});
+
 	it('should not duplicate delegated listeners across reconnects', () => {
 		@customElement('reconnect-on-event-listener')
 		class ReconnectOnEventListener extends RadiantElement {

--- a/packages/radiant/test/server/minimal-dom-install.test.ts
+++ b/packages/radiant/test/server/minimal-dom-install.test.ts
@@ -224,6 +224,15 @@ describe('minimal DOM installation boundary', () => {
 		expect(globalThis.window).toBe(second);
 	});
 
+	test('installs CSS.escape without wrapping itself', async () => {
+		clearDomGlobals();
+		const { installLightDomShim } = await import('../../src/server/shim/minimal-dom/install');
+		const surface = installLightDomShim();
+
+		expect(surface.CSS.escape('1foo')).toBe('\\31 foo');
+		expect(globalThis.CSS.escape('a:b')).toBe('a\\:b');
+	});
+
 	test('fails before mutation when a required global is locked', async () => {
 		clearDomGlobals();
 		const foreignDocument = {};

--- a/packages/radiant/test/tools/escape-css-identifier.test.ts
+++ b/packages/radiant/test/tools/escape-css-identifier.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from 'vitest';
+import { escapeCssIdentifier, escapeCssIdentifierFallback } from '../../src/tools/escape-css-identifier';
+
+describe('escapeCssIdentifierFallback', () => {
+	test('replaces NUL with the replacement character', () => {
+		expect(escapeCssIdentifierFallback('\0')).toBe('\uFFFD');
+	});
+
+	test('escapes leading digits and hyphen-digit identifiers', () => {
+		expect(escapeCssIdentifierFallback('1foo')).toBe('\\31 foo');
+		expect(escapeCssIdentifierFallback('-1foo')).toBe('-\\31 foo');
+	});
+
+	test('escapes a lone hyphen and other non-identifier characters', () => {
+		expect(escapeCssIdentifierFallback('-')).toBe('\\-');
+		expect(escapeCssIdentifierFallback('a:b')).toBe('a\\:b');
+	});
+
+	test('leaves ordinary identifier characters unchanged', () => {
+		expect(escapeCssIdentifierFallback('ref_1')).toBe('ref_1');
+	});
+});
+
+describe('escapeCssIdentifier', () => {
+	test('uses native CSS.escape when present, otherwise the fallback', () => {
+		const expected =
+			typeof globalThis.CSS?.escape === 'function' ? CSS.escape('1foo') : escapeCssIdentifierFallback('1foo');
+		expect(escapeCssIdentifier('1foo')).toBe(expected);
+	});
+});

--- a/packages/storybook-radiant-vite/src/compose-story-render.ts
+++ b/packages/storybook-radiant-vite/src/compose-story-render.ts
@@ -26,27 +26,55 @@ export function composeStoryRender(
 ): () => JsxRenderable {
 	const meta = storyModule.default as SsrStoryDefinition | undefined;
 	const story = storyExport ? (storyModule[storyExport] as SsrStoryDefinition | undefined) : undefined;
-	const render = story?.render ?? meta?.render ?? meta?.component;
-	if (typeof render !== 'function') {
-		throw new Error(`Story "${storyExport ?? 'default'}" does not provide a JSX render function.`);
-	}
+	const render = resolveStoryRender(meta, story, storyExport);
+	return applyDecorators(
+		createStoryRender(render, args),
+		getDecorators(meta, story),
+		createDecoratorContext(meta, story, storyExport, args),
+	);
+}
 
-	let storyRender = () => (render as (nextArgs: Record<string, unknown>) => JsxRenderable)(args);
-	const decorators = [...(meta?.decorators ?? []), ...(story?.decorators ?? [])];
-	const context: SsrDecoratorContext = {
+function resolveStoryRender(
+	meta: SsrStoryDefinition | undefined,
+	story: SsrStoryDefinition | undefined,
+	storyExport: string | undefined,
+): (args: Record<string, unknown>) => JsxRenderable {
+	const render = story?.render ?? meta?.render ?? meta?.component;
+	if (typeof render !== 'function')
+		throw new Error(`Story "${storyExport ?? 'default'}" does not provide a JSX render function.`);
+	return render as (args: Record<string, unknown>) => JsxRenderable;
+}
+
+function createStoryRender(
+	render: (args: Record<string, unknown>) => JsxRenderable,
+	args: Record<string, unknown>,
+): () => JsxRenderable {
+	return () => render(args);
+}
+
+function getDecorators(meta: SsrStoryDefinition | undefined, story: SsrStoryDefinition | undefined): unknown[] {
+	return [...(meta?.decorators ?? []), ...(story?.decorators ?? [])];
+}
+
+function createDecoratorContext(
+	meta: SsrStoryDefinition | undefined,
+	story: SsrStoryDefinition | undefined,
+	storyExport: string | undefined,
+	args: Record<string, unknown>,
+): SsrDecoratorContext {
+	return {
 		args,
 		id: storyExport ?? 'default',
 		parameters: { ...(meta?.parameters ?? {}), ...(story?.parameters ?? {}) },
 	};
+}
 
-	for (const decorator of decorators.toReversed()) {
-		if (typeof decorator !== 'function') {
-			continue;
-		}
-
-		const previousRender = storyRender;
-		storyRender = () => (decorator as SsrStoryDecorator)(previousRender, context);
-	}
-
-	return storyRender;
+function applyDecorators(
+	storyRender: () => JsxRenderable,
+	decorators: unknown[],
+	context: SsrDecoratorContext,
+): () => JsxRenderable {
+	return decorators.toReversed().reduce<() => JsxRenderable>((render, decorator) => {
+		return typeof decorator === 'function' ? () => (decorator as SsrStoryDecorator)(render, context) : render;
+	}, storyRender);
 }

--- a/packages/storybook-radiant-vite/src/mount-ssr.ts
+++ b/packages/storybook-radiant-vite/src/mount-ssr.ts
@@ -16,6 +16,8 @@ type RenderContextWithCallbacks = RenderContext<RadiantRenderer> & {
 	showStoryDuringRender?: () => void;
 };
 
+type SsrTarget = NonNullable<ReturnType<typeof resolveSsrTarget>>;
+
 function showStoryDuringRender(context: RenderContext<RadiantRenderer>): void {
 	(context as RenderContextWithCallbacks).showStoryDuringRender?.();
 }
@@ -129,47 +131,63 @@ export async function mountSsrResult(
 	mode: 'ssr-hydrate' | 'ssr-static',
 ): Promise<void> {
 	context.showMain();
-
 	const radiant = (context.storyContext.parameters as RadiantStoryParameters).radiant;
-	const component = context.storyContext.component;
-	syncViewMetadata(component, radiant?.element);
-
-	const storyModule = radiant?.storyModule;
-	const storyExport = radiant?.storyExport ?? storyIdToExportName(context.storyContext.id);
-
-	const ssrTarget = resolveSsrTarget({
-		component,
-		radiant,
-		storyModule,
-		storyExport,
-	});
-
+	const ssrTarget = resolveContextSsrTarget(context, radiant);
 	if (!ssrTarget) {
-		mountSsrErrorBanner(
-			canvasElement,
-			`Cannot SSR story "${context.name}"`,
-			dedent`
+		mountMissingSsrTargetBanner(canvasElement, context.name);
+		return;
+	}
+	const payload = await requestSsrPayload(context, canvasElement, ssrTarget, mode);
+	if (!payload || !validateSsrPayload(canvasElement, context.name, ssrTarget, payload)) return;
+	teardownCanvas(canvasElement);
+	if (mode === 'ssr-static') {
+		uninstallRadiantHydrator();
+		mountStaticMarkup(canvasElement, payload.markup, payload.assets);
+		showStoryDuringRender(context);
+		return;
+	}
+	if (!(await mountHydratedSsr(context, canvasElement, radiant, ssrTarget, payload))) return;
+	simulatePageLoad(canvasElement);
+	showStoryDuringRender(context);
+}
+
+function resolveContextSsrTarget(
+	context: RenderContext<RadiantRenderer>,
+	radiant: RadiantStoryParameters['radiant'],
+): SsrTarget | null {
+	syncViewMetadata(context.storyContext.component, radiant?.element);
+	return resolveSsrTarget({
+		component: context.storyContext.component,
+		radiant,
+		storyModule: radiant?.storyModule,
+		storyExport: radiant?.storyExport ?? storyIdToExportName(context.storyContext.id),
+	});
+}
+
+function mountMissingSsrTargetBanner(canvasElement: HTMLElement, storyName: string): void {
+	mountSsrErrorBanner(
+		canvasElement,
+		`Cannot SSR story "${storyName}"`,
+		dedent`
         Set \`meta.component\` to a RadiantElement constructor, a view linked via
         \`parameters.radiant.element\`, or a registered custom-element tag string
         (with the \`.script\` module imported in the story file).
 
         For multi-export script modules, set \`parameters.radiant.ssrExport\`.
         For edge cases, set \`parameters.radiant.ssrModule\` explicitly.
-			`,
-		);
-		return;
-	}
+	`,
+	);
+}
 
-	let payload: RadiantSsrResponseBody;
+async function requestSsrPayload(
+	context: RenderContext<RadiantRenderer>,
+	canvasElement: HTMLElement,
+	target: SsrTarget,
+	mode: 'ssr-hydrate' | 'ssr-static',
+): Promise<RadiantSsrResponseBody | undefined> {
 	try {
-		payload = await fetchSsrPayload({
-			kind: ssrTarget.kind,
-			ssrModule: ssrTarget.ssrModule,
-			ssrExport: ssrTarget.ssrExport,
-			viewModule: ssrTarget.viewModule,
-			viewExport: ssrTarget.viewExport,
-			storyModule: ssrTarget.storyModule,
-			storyExport: ssrTarget.storyExport,
+		return await fetchSsrPayload({
+			...target,
 			args: sanitizeSsrArgs(context.storyContext.args as Record<string, unknown>),
 			mode: mode === 'ssr-hydrate' ? 'hydrate' : 'plain',
 		});
@@ -179,81 +197,97 @@ export async function mountSsrResult(
 			`Radiant SSR failed for "${context.name}"`,
 			error instanceof Error ? error.message : String(error),
 		);
-		return;
+		return undefined;
 	}
+}
 
+function validateSsrPayload(
+	canvasElement: HTMLElement,
+	storyName: string,
+	target: SsrTarget,
+	payload: RadiantSsrResponseBody,
+): boolean {
 	if (!payload.markup?.trim()) {
 		mountSsrErrorBanner(
 			canvasElement,
-			`Radiant SSR returned empty markup for "${context.name}"`,
-			`Module: ${ssrTarget.ssrModule ?? ssrTarget.storyModule}`,
+			`Radiant SSR returned empty markup for "${storyName}"`,
+			`Module: ${target.ssrModule ?? target.storyModule}`,
 		);
-		return;
+		return false;
 	}
-
-	if (payload.tagName && isEmptyHostShell(payload.markup, payload.tagName)) {
-		mountSsrErrorBanner(
-			canvasElement,
-			`Radiant SSR produced an empty host shell for "${context.name}"`,
-			dedent`
+	if (!payload.tagName || !isEmptyHostShell(payload.markup, payload.tagName)) return true;
+	mountSsrErrorBanner(
+		canvasElement,
+		`Radiant SSR produced an empty host shell for "${storyName}"`,
+		dedent`
         The SSR bridge could not render authored light-DOM content for this story.
         Use a component with a \`render()\` implementation, a view export stamped with a
         view module path, or set \`parameters.radiant.authoredContent\`.
-			`,
-		);
-		return;
-	}
+	`,
+	);
+	return false;
+}
 
-	teardownCanvas(canvasElement);
-
-	if (mode === 'ssr-static') {
-		uninstallRadiantHydrator();
-		mountStaticMarkup(canvasElement, payload.markup, payload.assets);
-		showStoryDuringRender(context);
-		return;
-	}
-
-	await loadSsrStyles(payload.assets);
-
+async function mountHydratedSsr(
+	context: RenderContext<RadiantRenderer>,
+	canvasElement: HTMLElement,
+	radiant: RadiantStoryParameters['radiant'],
+	target: SsrTarget,
+	payload: RadiantSsrResponseBody,
+): Promise<boolean> {
 	const moduleSrc = radiant?.clientModule ?? payload.clientModuleSrc;
-	let clientModule: Record<string, unknown> | undefined;
-	if (moduleSrc) {
-		try {
-			clientModule = (await import(/* @vite-ignore */ moduleSrc)) as Record<string, unknown>;
-		} catch (error) {
-			mountSsrErrorBanner(
-				canvasElement,
-				`Radiant hydration module failed for "${context.name}"`,
-				error instanceof Error ? error.message : String(error),
-			);
-			return;
-		}
-	}
-
+	const clientModule = await loadClientModule(canvasElement, context.name, moduleSrc);
+	if (moduleSrc && !clientModule) return false;
+	await loadSsrStyles(payload.assets);
 	const mountRoot = ensureSsrMountRoot(canvasElement);
 	installRadiantHydrator();
 	mountRoot.innerHTML = stripModuleScripts(payload.markup);
-	if (ssrTarget.kind === 'jsx') {
-		try {
-			const storyModule =
-				ssrTarget.storyModule === moduleSrc
-					? clientModule
-					: ((await import(/* @vite-ignore */ ssrTarget.storyModule!)) as Record<string, unknown>);
-			hydrateStoryJsx(
-				storyModule!,
-				ssrTarget.storyExport,
-				context.storyContext.args as Record<string, unknown>,
-				mountRoot,
-			);
-		} catch (error) {
-			mountSsrErrorBanner(
-				canvasElement,
-				`Radiant JSX hydration failed for "${context.name}"`,
-				error instanceof Error ? error.message : String(error),
-			);
-			return;
-		}
+	return hydrateJsxStory(context, canvasElement, target, moduleSrc, clientModule, mountRoot);
+}
+
+async function loadClientModule(
+	canvasElement: HTMLElement,
+	storyName: string,
+	moduleSrc: string | undefined,
+): Promise<Record<string, unknown> | undefined> {
+	if (!moduleSrc) return undefined;
+	try {
+		return (await import(/* @vite-ignore */ moduleSrc)) as Record<string, unknown>;
+	} catch (error) {
+		mountSsrErrorBanner(
+			canvasElement,
+			`Radiant hydration module failed for "${storyName}"`,
+			error instanceof Error ? error.message : String(error),
+		);
+		return undefined;
 	}
-	simulatePageLoad(canvasElement);
-	showStoryDuringRender(context);
+}
+
+async function hydrateJsxStory(
+	context: RenderContext<RadiantRenderer>,
+	canvasElement: HTMLElement,
+	target: SsrTarget,
+	moduleSrc: string | undefined,
+	clientModule: Record<string, unknown> | undefined,
+	mountRoot: HTMLElement,
+): Promise<boolean> {
+	if (target.kind !== 'jsx') return true;
+	try {
+		const storyModule =
+			target.storyModule === moduleSrc ? clientModule : await import(/* @vite-ignore */ target.storyModule!);
+		hydrateStoryJsx(
+			storyModule!,
+			target.storyExport,
+			context.storyContext.args as Record<string, unknown>,
+			mountRoot,
+		);
+		return true;
+	} catch (error) {
+		mountSsrErrorBanner(
+			canvasElement,
+			`Radiant JSX hydration failed for "${context.name}"`,
+			error instanceof Error ? error.message : String(error),
+		);
+		return false;
+	}
 }

--- a/packages/storybook-radiant-vite/src/resolve-ssr.ts
+++ b/packages/storybook-radiant-vite/src/resolve-ssr.ts
@@ -15,6 +15,16 @@ export type RadiantViewComponent<TArgs = unknown> = ((args: TArgs) => unknown) &
 	[RADIANT_VIEW_MODULE]?: string;
 };
 
+type SsrTarget = {
+	kind: 'host' | 'jsx';
+	ssrModule?: string;
+	ssrExport?: string;
+	viewModule?: string;
+	viewExport?: string;
+	storyModule?: string;
+	storyExport?: string;
+};
+
 export function getRadiantViewModule(target: CustomElementConstructor | RadiantViewComponent): string | undefined {
 	return (target as RadiantViewComponent)[RADIANT_VIEW_MODULE];
 }
@@ -96,79 +106,102 @@ export function resolveSsrTarget(options: {
 	radiant?: RadiantStoryParameters['radiant'];
 	storyModule?: string;
 	storyExport?: string;
-}): {
-	kind: 'host' | 'jsx';
-	ssrModule?: string;
-	ssrExport?: string;
-	viewModule?: string;
-	viewExport?: string;
+}): SsrTarget | null {
+	return resolveExplicitSsrTarget(options) ?? resolveViewSsrTarget(options) ?? resolveElementSsrTarget(options);
+}
+
+function resolveExplicitSsrTarget(options: {
+	radiant?: RadiantStoryParameters['radiant'];
 	storyModule?: string;
 	storyExport?: string;
-} | null {
-	const { component, radiant, storyModule, storyExport } = options;
-	if (radiant?.ssrModule) {
-		return {
-			kind: 'host',
-			ssrModule: normalizeSsrModulePath(radiant.ssrModule),
-			ssrExport: radiant.ssrExport,
-			viewModule: radiant.viewModule ? normalizeSsrModulePath(radiant.viewModule) : undefined,
-			viewExport: radiant.viewExport,
-			storyModule: radiant.storyModule ? normalizeSsrModulePath(radiant.storyModule) : storyModule,
-			storyExport: radiant.storyExport ?? storyExport,
-		};
-	}
+}): SsrTarget | undefined {
+	const { radiant, storyModule, storyExport } = options;
+	if (!radiant?.ssrModule) return undefined;
+	return {
+		kind: 'host',
+		ssrModule: normalizeSsrModulePath(radiant.ssrModule),
+		ssrExport: radiant.ssrExport,
+		viewModule: radiant.viewModule ? normalizeSsrModulePath(radiant.viewModule) : undefined,
+		viewExport: radiant.viewExport,
+		storyModule: radiant.storyModule ? normalizeSsrModulePath(radiant.storyModule) : storyModule,
+		storyExport: radiant.storyExport ?? storyExport,
+	};
+}
 
-	if (typeof component === 'function') {
-		const view = component as RadiantViewComponent;
-		const linkedElement = view[RADIANT_VIEW_ELEMENT];
-		const viewModule = getRadiantViewModule(view);
-		const viewModulePath = viewModule ? normalizeSsrModulePath(viewModule) : undefined;
-		const scriptModule =
-			getRadiantScriptModule(view) ?? (linkedElement ? getRadiantScriptModule(linkedElement) : undefined);
-		const scriptExport =
-			radiant?.ssrExport ??
-			(linkedElement ? getRadiantScriptExport(linkedElement) : undefined) ??
-			getRadiantScriptExport(view) ??
-			linkedElement?.name;
-		const viewExport = radiant?.viewExport ?? scriptExport;
+function resolveViewSsrTarget(options: {
+	component: RadiantComponent | undefined;
+	radiant?: RadiantStoryParameters['radiant'];
+	storyModule?: string;
+	storyExport?: string;
+}): SsrTarget | undefined {
+	if (typeof options.component !== 'function') return undefined;
+	const view = options.component as RadiantViewComponent;
+	const linkedElement = view[RADIANT_VIEW_ELEMENT];
+	const modules = resolveViewModules(view, linkedElement);
+	const { scriptModule, viewModulePath } = modules;
+	if (!scriptModule && !viewModulePath) return undefined;
+	if (options.storyModule) return { kind: 'jsx', storyModule: options.storyModule, storyExport: options.storyExport };
+	const scriptExport = resolveViewExport(view, linkedElement, options.radiant);
+	return {
+		kind: 'host',
+		ssrModule: scriptModule
+			? normalizeSsrModulePath(scriptModule)
+			: preferredScriptModuleFromViewModule(viewModulePath!),
+		ssrExport: scriptExport,
+		viewModule: viewModulePath,
+		viewExport: options.radiant?.viewExport ?? scriptExport,
+		storyModule: options.storyModule,
+		storyExport: options.storyExport,
+	};
+}
 
-		if (scriptModule || viewModulePath) {
-			if (storyModule) {
-				return { kind: 'jsx', storyModule, storyExport };
-			}
+function resolveViewModules(
+	view: RadiantViewComponent,
+	linkedElement: CustomElementConstructor | undefined,
+): {
+	scriptModule: string | undefined;
+	viewModulePath: string | undefined;
+} {
+	const viewModule = getRadiantViewModule(view);
+	return {
+		scriptModule:
+			getRadiantScriptModule(view) ?? (linkedElement ? getRadiantScriptModule(linkedElement) : undefined),
+		viewModulePath: viewModule ? normalizeSsrModulePath(viewModule) : undefined,
+	};
+}
 
-			return {
-				kind: 'host',
-				ssrModule: scriptModule
-					? normalizeSsrModulePath(scriptModule)
-					: viewModulePath
-						? preferredScriptModuleFromViewModule(viewModulePath)
-						: undefined,
-				ssrExport: scriptExport,
-				viewModule: viewModulePath,
-				viewExport,
-				storyModule,
-				storyExport,
-			};
-		}
-	}
+function resolveViewExport(
+	view: RadiantViewComponent,
+	linkedElement: CustomElementConstructor | undefined,
+	radiant: RadiantStoryParameters['radiant'],
+): string | undefined {
+	return (
+		radiant?.ssrExport ??
+		(linkedElement ? getRadiantScriptExport(linkedElement) : undefined) ??
+		getRadiantScriptExport(view) ??
+		linkedElement?.name
+	);
+}
 
-	const element = resolveRadiantElement(component);
-	if (!element) {
-		return typeof component === 'function' && storyModule ? { kind: 'jsx', storyModule, storyExport } : null;
-	}
-
+function resolveElementSsrTarget(options: {
+	component: RadiantComponent | undefined;
+	radiant?: RadiantStoryParameters['radiant'];
+	storyModule?: string;
+	storyExport?: string;
+}): SsrTarget | null {
+	const element = resolveRadiantElement(options.component);
+	if (!element)
+		return typeof options.component === 'function' && options.storyModule
+			? { kind: 'jsx', storyModule: options.storyModule, storyExport: options.storyExport }
+			: null;
 	const ssrModule = getRadiantScriptModule(element);
-	if (!ssrModule) {
-		return null;
-	}
-
+	if (!ssrModule) return null;
 	return {
 		kind: 'host',
 		ssrModule: normalizeSsrModulePath(ssrModule),
-		ssrExport: radiant?.ssrExport ?? getRadiantScriptExport(element) ?? element.name,
-		storyModule,
-		storyExport,
+		ssrExport: options.radiant?.ssrExport ?? getRadiantScriptExport(element) ?? element.name,
+		storyModule: options.storyModule,
+		storyExport: options.storyExport,
 	};
 }
 

--- a/packages/storybook-radiant-vite/src/storybook-ssr.ts
+++ b/packages/storybook-radiant-vite/src/storybook-ssr.ts
@@ -190,26 +190,47 @@ export async function renderStorybookSsrPayload(
 }> {
 	const args = await resolveStoryArgs(server, body.storyModule, body.storyExport, body.args ?? {});
 	const mode = body.mode ?? 'hydrate';
+	return body.kind === 'jsx'
+		? renderJsxSsrPayload(server, body, args, mode, options)
+		: renderHostSsrPayload(server, body, args, mode, options);
+}
 
-	if (body.kind === 'jsx') {
-		const markup = await renderStoryMarkup(server, body.storyModule, body.storyExport, args, mode);
-		const assets =
-			mode === 'plain' && body.storyModule
-				? await collectSsrStyleAssets(server, [body.storyModule], {
-						includeGlobalStyles: true,
-						globalStyleModules: options.globalStyleModules,
-					})
-				: [];
+async function renderJsxSsrPayload(
+	server: ViteDevServer,
+	body: RadiantSsrRequestBody,
+	args: Record<string, unknown>,
+	mode: 'hydrate' | 'plain',
+	options: { globalStyleModules?: readonly string[] },
+): Promise<{
+	markup: string;
+	tagName: string;
+	assets: RadiantSsrAsset[];
+	clientModuleSrc?: string;
+	generatedAt: string;
+}> {
+	const markup = await renderStoryMarkup(server, body.storyModule, body.storyExport, args, mode);
+	return {
+		markup,
+		tagName: '',
+		assets: await collectPlainStoryAssets(server, body.storyModule, mode, options),
+		clientModuleSrc: body.storyModule,
+		generatedAt: new Date().toISOString(),
+	};
+}
 
-		return {
-			markup,
-			tagName: '',
-			assets,
-			clientModuleSrc: body.storyModule,
-			generatedAt: new Date().toISOString(),
-		};
-	}
-
+async function renderHostSsrPayload(
+	server: ViteDevServer,
+	body: RadiantSsrRequestBody,
+	args: Record<string, unknown>,
+	mode: 'hydrate' | 'plain',
+	options: { globalStyleModules?: readonly string[] },
+): Promise<{
+	markup: string;
+	tagName: string;
+	assets: RadiantSsrAsset[];
+	clientModuleSrc?: string;
+	generatedAt: string;
+}> {
 	const { ssrModule, ssrExport } = await resolveScriptSsrModule(server, {
 		ssrModule: body.ssrModule,
 		ssrExport: body.ssrExport,
@@ -221,24 +242,7 @@ export async function renderStorybookSsrPayload(
 	const Component = pickComponentExport(mod, ssrExport);
 	const tagName = getCustomElementTagName(Component) ?? Component.name.toLowerCase();
 
-	let authoredContent: string | undefined;
-	if (body.viewModule) {
-		authoredContent = await renderViewAuthoredContent(
-			server,
-			body.viewModule,
-			body.viewExport,
-			args,
-			mode,
-			body.storyModule,
-			body.storyExport,
-		);
-		if (!authoredContent?.trim()) {
-			const itemCount = Array.isArray(args.items) ? args.items.length : 0;
-			throw new Error(
-				`View SSR produced empty authored content for ${body.viewModule} (items=${itemCount}, args=${Object.keys(args).join(',')})`,
-			);
-		}
-	}
+	const authoredContent = await resolveAuthoredContent(server, body, args, mode);
 
 	const rendered = await renderSsrComponent(Component, {
 		authoredContent,
@@ -249,14 +253,7 @@ export async function renderStorybookSsrPayload(
 		},
 	});
 
-	const styleAssets =
-		mode === 'plain'
-			? await collectSsrStyleAssets(
-					server,
-					[ssrModule, body.viewModule].filter((entry): entry is string => Boolean(entry)),
-					{ includeGlobalStyles: true, globalStyleModules: options.globalStyleModules },
-				)
-			: [];
+	const styleAssets = await collectPlainStoryAssets(server, [ssrModule, body.viewModule], mode, options);
 
 	return {
 		markup: rendered.markup,
@@ -265,6 +262,45 @@ export async function renderStorybookSsrPayload(
 		clientModuleSrc: body.viewModule ?? rendered.metadata.clientModuleUrl ?? ssrModule,
 		generatedAt: rendered.metadata.generatedAt,
 	};
+}
+
+async function resolveAuthoredContent(
+	server: ViteDevServer,
+	body: RadiantSsrRequestBody,
+	args: Record<string, unknown>,
+	mode: 'hydrate' | 'plain',
+): Promise<string | undefined> {
+	if (!body.viewModule) return undefined;
+	const authoredContent = await renderViewAuthoredContent(
+		server,
+		body.viewModule,
+		body.viewExport,
+		args,
+		mode,
+		body.storyModule,
+		body.storyExport,
+	);
+	if (authoredContent?.trim()) return authoredContent;
+	const itemCount = Array.isArray(args.items) ? args.items.length : 0;
+	throw new Error(
+		`View SSR produced empty authored content for ${body.viewModule} (items=${itemCount}, args=${Object.keys(args).join(',')})`,
+	);
+}
+
+async function collectPlainStoryAssets(
+	server: ViteDevServer,
+	modules: string | readonly (string | undefined)[] | undefined,
+	mode: 'hydrate' | 'plain',
+	options: { globalStyleModules?: readonly string[] },
+): Promise<RadiantSsrAsset[]> {
+	const modulePaths = (typeof modules === 'string' ? [modules] : (modules ?? [])).filter((entry): entry is string =>
+		Boolean(entry),
+	);
+	if (mode !== 'plain' || !modulePaths.length) return [];
+	return collectSsrStyleAssets(server, modulePaths, {
+		includeGlobalStyles: true,
+		globalStyleModules: options.globalStyleModules,
+	});
 }
 
 async function renderStoryMarkup(

--- a/packages/vite-plugin-radiant/src/lib/escape-css-identifier.ts
+++ b/packages/vite-plugin-radiant/src/lib/escape-css-identifier.ts
@@ -1,46 +1,29 @@
 export function escapeCssIdentifier(value: string): string {
-	const cssNamespace = globalThis.CSS as { escape?: (value: string) => string } | undefined;
-
-	if (typeof cssNamespace?.escape === 'function') {
-		return cssNamespace.escape(value);
-	}
-
+	const escape = globalThis.CSS?.escape;
+	if (typeof escape === 'function') return escape(value);
 	let escaped = '';
-
-	for (let index = 0; index < value.length; index += 1) {
-		const character = value[index] ?? '';
-		const codePoint = character.codePointAt(0) ?? 0;
-
-		if (codePoint === 0) {
-			escaped += '\uFFFD';
-			continue;
-		}
-
-		const isControlCharacter = (codePoint >= 0x0001 && codePoint <= 0x001f) || codePoint === 0x007f;
-		const startsWithDigit = index === 0 && codePoint >= 0x0030 && codePoint <= 0x0039;
-		const startsWithHyphenDigit =
-			index === 1 && codePoint >= 0x0030 && codePoint <= 0x0039 && (value[0] ?? '') === '-';
-		const isSingleHyphen = index === 0 && character === '-' && value.length === 1;
-
-		if (isControlCharacter || startsWithDigit || startsWithHyphenDigit) {
-			escaped += `\\${codePoint.toString(16)} `;
-			continue;
-		}
-
-		if (
-			codePoint >= 0x0080 ||
-			character === '-' ||
-			character === '_' ||
-			(codePoint >= 0x0030 && codePoint <= 0x0039) ||
-			(codePoint >= 0x0041 && codePoint <= 0x005a) ||
-			(codePoint >= 0x0061 && codePoint <= 0x007a)
-		) {
-			escaped += isSingleHyphen ? `\\${character}` : character;
-			continue;
-		}
-
-		escaped += `\\${character}`;
-	}
-
+	for (let index = 0; index < value.length; index += 1) escaped += escapeCharacter(value, index);
 	return escaped;
+}
+
+function escapeCharacter(value: string, index: number): string {
+	const character = value[index] ?? '';
+	const codePoint = character.codePointAt(0) ?? 0;
+	if (codePoint === 0) return '\uFFFD';
+	if (requiresCodePointEscape(value, index, codePoint)) return `\\${codePoint.toString(16)} `;
+	if (isCssIdentifierCharacter(character, codePoint))
+		return index === 0 && character === '-' && value.length === 1 ? `\\${character}` : character;
+	return `\\${character}`;
+}
+
+function requiresCodePointEscape(value: string, index: number, codePoint: number): boolean {
+	return (
+		(codePoint > 0 && codePoint < 0x0020) ||
+		codePoint === 0x007f ||
+		(codePoint >= 0x0030 && codePoint <= 0x0039 && (index === 0 || (index === 1 && value[0] === '-')))
+	);
+}
+
+function isCssIdentifierCharacter(character: string, codePoint: number): boolean {
+	return codePoint >= 0x0080 || /[-_0-9A-Za-z]/.test(character);
 }

--- a/playground/vite-nitro/src/lib/escape-css-identifier.ts
+++ b/playground/vite-nitro/src/lib/escape-css-identifier.ts
@@ -1,46 +1,29 @@
 export function escapeCssIdentifier(value: string): string {
-	const cssNamespace = globalThis.CSS as { escape?: (value: string) => string } | undefined;
-
-	if (typeof cssNamespace?.escape === 'function') {
-		return cssNamespace.escape(value);
-	}
-
+	const escape = globalThis.CSS?.escape;
+	if (typeof escape === 'function') return escape(value);
 	let escaped = '';
-
-	for (let index = 0; index < value.length; index += 1) {
-		const character = value[index] ?? '';
-		const codePoint = character.codePointAt(0) ?? 0;
-
-		if (codePoint === 0) {
-			escaped += '\uFFFD';
-			continue;
-		}
-
-		const isControlCharacter = (codePoint >= 0x0001 && codePoint <= 0x001f) || codePoint === 0x007f;
-		const startsWithDigit = index === 0 && codePoint >= 0x0030 && codePoint <= 0x0039;
-		const startsWithHyphenDigit =
-			index === 1 && codePoint >= 0x0030 && codePoint <= 0x0039 && (value[0] ?? '') === '-';
-		const isSingleHyphen = index === 0 && character === '-' && value.length === 1;
-
-		if (isControlCharacter || startsWithDigit || startsWithHyphenDigit) {
-			escaped += `\\${codePoint.toString(16)} `;
-			continue;
-		}
-
-		if (
-			codePoint >= 0x0080 ||
-			character === '-' ||
-			character === '_' ||
-			(codePoint >= 0x0030 && codePoint <= 0x0039) ||
-			(codePoint >= 0x0041 && codePoint <= 0x005a) ||
-			(codePoint >= 0x0061 && codePoint <= 0x007a)
-		) {
-			escaped += isSingleHyphen ? `\\${character}` : character;
-			continue;
-		}
-
-		escaped += `\\${character}`;
-	}
-
+	for (let index = 0; index < value.length; index += 1) escaped += escapeCharacter(value, index);
 	return escaped;
+}
+
+function escapeCharacter(value: string, index: number): string {
+	const character = value[index] ?? '';
+	const codePoint = character.codePointAt(0) ?? 0;
+	if (codePoint === 0) return '\uFFFD';
+	if (requiresCodePointEscape(value, index, codePoint)) return `\\${codePoint.toString(16)} `;
+	if (isCssIdentifierCharacter(character, codePoint))
+		return index === 0 && character === '-' && value.length === 1 ? `\\${character}` : character;
+	return `\\${character}`;
+}
+
+function requiresCodePointEscape(value: string, index: number, codePoint: number): boolean {
+	return (
+		(codePoint > 0 && codePoint < 0x0020) ||
+		codePoint === 0x007f ||
+		(codePoint >= 0x0030 && codePoint <= 0x0039 && (index === 0 || (index === 1 && value[0] === '-')))
+	);
+}
+
+function isCssIdentifierCharacter(character: string, codePoint: number): boolean {
+	return codePoint >= 0x0080 || /[-_0-9A-Za-z]/.test(character);
 }


### PR DESCRIPTION
## Summary
Enforces cyclomatic complexity 15 and restructures dense rendering, SSR, and interaction paths around explicit domain stages.

## What changed
Lowers the shared Oxlint complexity rule from 50 to 15 as an error. Refactors JSX child updates, SSR orchestration, DOM-shim validation, and UI keyboard, swipe, form, and presentation logic into focused state transitions and command handlers.

## How to verify
1. Run `pnpm lint`.
2. Run `pnpm run typecheck`.
3. Run `pnpm -r --sequential test:all`. Functional tests pass; the Radiant strict client bundle check remains a few bytes above its 13.50 KB gzip cap (the output rounds to 13.50 KB).

## Notes
Stacked on #197. The final rule remains an error with a maximum of 15.