### PR TITLE
feat(radiant-ui): add checkbox-group for multi-value form fields

### DIFF
--- a/.changeset/checkbox-group.md
+++ b/.changeset/checkbox-group.md
@@ -1,0 +1,10 @@
+---
+'@ecopages/radiant-ui': minor
+---
+
+Add `RuiCheckboxGroup` for coordinating multiple `RuiCheckbox` options as a single multi-value form field.
+
+**@ecopages/radiant-ui**
+
+- New `<rui-checkbox-group>` host with `RuiCheckboxGroupControl`, `options` convenience API, and `orientation` layout.
+- Comma-separated `value` protocol matches multi-select controls; integrates with `RuiField` / `RuiForm`.

--- a/apps/radiant-ui/README.md
+++ b/apps/radiant-ui/README.md
@@ -76,6 +76,7 @@ Authors declare `control.type` and `options`. The shell picks widgets via heuris
 - `boolean` → switch
 - `text` → text input
 - `number` → number field
+- `radio` with 2+ options → radio group
 - `select` with 2–3 options → segmented buttons
 - `select` with 4+ options → select
 

--- a/apps/radiant-ui/src/components/component-docs/component-docs.css
+++ b/apps/radiant-ui/src/components/component-docs/component-docs.css
@@ -84,6 +84,14 @@ radiant-docs-canvas {
 	@apply box-border flex max-w-none min-w-0 w-full flex-col;
 }
 
+.docs-story-controls__radio {
+	@apply box-border flex max-w-none min-w-0 w-full flex-col;
+}
+
+.docs-story-controls__radio .rui-radio-group {
+	@apply gap-inline;
+}
+
 .docs-story-controls__select .rui-select__control {
 	@apply box-border max-w-none min-w-0 w-full;
 	min-height: var(--size-control-sm);

--- a/apps/radiant-ui/src/components/component-docs/controls.script.tsx
+++ b/apps/radiant-ui/src/components/component-docs/controls.script.tsx
@@ -5,6 +5,7 @@ import '@ecopages/radiant-ui/button';
 import '@ecopages/radiant-ui/cycle-toggle';
 import '@ecopages/radiant-ui/input';
 import '@ecopages/radiant-ui/number-field';
+import '@ecopages/radiant-ui/radio-group';
 import '@ecopages/radiant-ui/select';
 import '@ecopages/radiant-ui/sidebar';
 import '@ecopages/radiant-ui/switch';
@@ -34,6 +35,16 @@ export class DocsControlsElement extends RadiantElement {
 	@onEvent({ selector: 'rui-select[data-docs-arg]', type: 'rui-change' })
 	onSelectChange(event: Event): void {
 		const target = this.resolveControl(event, 'rui-select[data-docs-arg]');
+		const detail = (event as CustomEvent<{ value?: unknown }>).detail;
+		if (!target || typeof detail?.value !== 'string') return;
+		const propName = target.dataset.docsArg;
+		if (!propName) return;
+		this.setArg(propName, detail.value);
+	}
+
+	@onEvent({ selector: 'rui-radio-group[data-docs-arg]', type: 'rui-change' })
+	onRadioGroupChange(event: Event): void {
+		const target = this.resolveControl(event, 'rui-radio-group[data-docs-arg]');
 		const detail = (event as CustomEvent<{ value?: unknown }>).detail;
 		if (!target || typeof detail?.value !== 'string') return;
 		const propName = target.dataset.docsArg;

--- a/apps/radiant-ui/src/content/components/checkbox-group.mdx
+++ b/apps/radiant-ui/src/content/components/checkbox-group.mdx
@@ -1,0 +1,109 @@
+---
+title: Checkbox Group
+description: Checkbox groups let users select any number of related options. Use them when choices are independent and more than one can be selected.
+category: Forms
+---
+
+import { meta as CheckboxGroupMeta, Default } from '@/content/stories/checkbox-group';
+import Canvas from '@/components/component-docs/canvas';
+import Demo from '@/components/component-docs/demo';
+
+export const config = {
+	dependencies: {
+		components: [Canvas, Demo],
+		scripts: [
+			'../../components/component-docs/demo.script.tsx',
+			'../../components/component-docs/canvas.script.tsx',
+			'../../components/component-docs/controls.script.tsx',
+		],
+	},
+};
+
+
+# Checkbox Group
+
+<p class="docs-lede">Checkbox groups let users select any number of related options. Use them when choices are independent and more than one can be selected.</p>
+
+## Try it
+
+<Demo of={Default} meta={CheckboxGroupMeta} />
+
+## Usage
+
+Set `value` to a comma-separated list of selected option values. Wrap in `RuiField` for form integration.
+
+```tsx
+import { RuiCheckbox } from '@ecopages/radiant-ui/checkbox';
+import { RuiCheckboxGroup, RuiCheckboxGroupControl } from '@ecopages/radiant-ui/checkbox-group';
+import { RuiField } from '@ecopages/radiant-ui/field';
+import { RuiLabel } from '@ecopages/radiant-ui/label';
+
+<RuiField name="topics">
+  <RuiLabel>Topics</RuiLabel>
+  <RuiCheckboxGroup value="news,travel" name="topics" label="Topics">
+    <RuiCheckboxGroupControl>
+      <RuiCheckbox value="news">News</RuiCheckbox>
+      <RuiCheckbox value="travel">Travel</RuiCheckbox>
+    </RuiCheckboxGroupControl>
+  </RuiCheckboxGroup>
+</RuiField>
+```
+
+## Independent choices
+
+<p>Use checkbox groups when users may select multiple related options. For mutually exclusive choices, use a <a href="/components/radio-group">radio group</a> instead. For a single on/off toggle, use a <a href="/components/checkbox">checkbox</a>.</p>
+
+## Theming
+
+Checkbox group layout uses the group surface only; checkbox chrome comes from `RuiCheckbox`:
+
+| Part | CSS roles |
+| --- | --- |
+| Group (`.rui-checkbox-group`) | `gap-inline`; horizontal layout via `data-orientation` |
+| Checkbox rows | See [Checkbox](/components/checkbox) theming |
+
+## API
+
+`RuiCheckboxGroup` is a custom element (`<rui-checkbox-group>`). Compose its options with `RuiCheckboxGroupControl` and `RuiCheckbox`, or use the convenience `options` prop.
+
+### Attributes
+
+| Attribute | Type | Default | Description |
+| --- | --- | --- | --- |
+| `value` | `string` | `''` | Comma-separated selected values. |
+| `name` | `string` | `''` | Form field name shared by all checkboxes in the group. |
+| `label` | `string` | `''` | Accessible name when no visible legend is composed in the view. |
+| `disabled` | `boolean` | `false` | Disables every checkbox in the group. |
+| `orientation` | `'horizontal' \| 'vertical'` | `'vertical'` | Layout axis for checkbox items. |
+
+### Composition
+
+| Piece | Description |
+| --- | --- |
+| `RuiCheckboxGroupControl` | Accessible group surface (`role="group"`). |
+| `RuiCheckbox` children | One checkbox per selectable option with a unique `value`. |
+
+### Events
+
+| Event | Detail | Description |
+| --- | --- | --- |
+| `rui-change` | `{ value: string }` | Emitted after the selection changes. |
+
+### Props
+
+| Prop | Type | Description |
+| --- | --- | --- |
+| `options` | `RuiCheckboxOption[]` | `{ value, label, disabled? }` entries rendered by the view. |
+| `value` | `string \| string[]` | Selected values; arrays serialize to comma-separated form. |
+
+### CSS classes
+
+| Class | Description |
+| --- | --- |
+| `.rui-checkbox-group` | Group surface (`role="group"`). |
+
+## Accessibility
+
+- The group exposes `role="group"` with an accessible name from `label` or an associated `RuiLabel`.
+- Each option is a native checkbox with Space-to-toggle.
+- For required multi-select fields, validate through `RuiField` rules rather than per-checkbox `required`.

--- a/apps/radiant-ui/src/content/components/checkbox.mdx
+++ b/apps/radiant-ui/src/content/components/checkbox.mdx
@@ -47,6 +47,10 @@ import { RuiLabel } from '@ecopages/radiant-ui/label';
 
 <p>Set `indeterminate` when a parent checkbox represents a partially selected group. Clear indeterminate once the user makes an explicit choice.</p>
 
+## Related components
+
+<p>For multiple related options as one form field, use a <a href="/components/checkbox-group">checkbox group</a>. For mutually exclusive choices, use a <a href="/components/radio-group">radio group</a>.</p>
+
 ## Wire through RuiField
 
 <p>Pass `name` on `RuiField` so the checkbox participates in `RuiForm` validation and submission.</p>

--- a/apps/radiant-ui/src/content/components/radio-group.mdx
+++ b/apps/radiant-ui/src/content/components/radio-group.mdx
@@ -50,7 +50,7 @@ import { RuiLabel } from '@ecopages/radiant-ui/label';
 
 ## Mutually exclusive choices
 
-<p>Use radio groups when options are mutually exclusive. For independent toggles, use checkboxes instead.</p>
+<p>Use radio groups when options are mutually exclusive. For independent toggles that share one field value, use a <a href="/components/checkbox-group">checkbox group</a>; for a single on/off toggle, use a <a href="/components/checkbox">checkbox</a>.</p>
 
 ## Theming
 

--- a/apps/radiant-ui/src/content/stories/alert.tsx
+++ b/apps/radiant-ui/src/content/stories/alert.tsx
@@ -12,7 +12,7 @@ export const meta = {
 			options: ['info', 'success', 'warning', 'error'] as const satisfies readonly RuiAlertVariant[],
 		},
 		layout: {
-			control: { type: 'select' },
+			control: { type: 'radio' },
 			options: ['inline', 'banner'] as const satisfies readonly RuiAlertLayout[],
 		},
 		dismissible: {

--- a/apps/radiant-ui/src/content/stories/button-group.tsx
+++ b/apps/radiant-ui/src/content/stories/button-group.tsx
@@ -12,7 +12,7 @@ export const meta = {
 	},
 	argTypes: {
 		orientation: {
-			control: { type: 'select' },
+			control: { type: 'radio' },
 			options: ['horizontal', 'vertical'] as const satisfies readonly RuiButtonGroupOrientation[],
 		},
 	},

--- a/apps/radiant-ui/src/content/stories/calendar.tsx
+++ b/apps/radiant-ui/src/content/stories/calendar.tsx
@@ -23,7 +23,7 @@ export const meta = {
 		disabled: { control: { type: 'boolean' } },
 		visibleMonths: { control: { type: 'number' } },
 		pageBehavior: {
-			control: { type: 'select' },
+			control: { type: 'radio' },
 			options: ['visible', 'single'] as const satisfies readonly RuiCalendarPageBehavior[],
 		},
 	},

--- a/apps/radiant-ui/src/content/stories/checkbox-group.tsx
+++ b/apps/radiant-ui/src/content/stories/checkbox-group.tsx
@@ -1,0 +1,44 @@
+import { RuiCheckbox } from '@ecopages/radiant-ui/checkbox';
+import { RuiCheckboxGroup, RuiCheckboxGroupControl } from '@ecopages/radiant-ui/checkbox-group';
+import { docsStory, type DocsMeta, type DocsStory } from '@/lib/docs-stories';
+
+export type CheckboxGroupArgs = {
+	value: string;
+	disabled: boolean;
+	label: string;
+	orientation: 'horizontal' | 'vertical';
+};
+
+export const meta = {
+	args: {
+		value: 'product,security',
+		disabled: false,
+		label: 'Email notifications',
+		orientation: 'vertical',
+	},
+	argTypes: {
+		value: { control: { type: 'text' } },
+		disabled: { control: { type: 'boolean' } },
+		label: { control: { type: 'text' } },
+		orientation: { control: { type: 'radio' }, options: ['vertical', 'horizontal'] },
+	},
+	render: (args) => (
+		<RuiCheckboxGroup
+			value={args.value}
+			disabled={args.disabled}
+			label={args.label}
+			orientation={args.orientation}
+			name="notifications"
+		>
+			<RuiCheckboxGroupControl orientation={args.orientation}>
+				<RuiCheckbox value="product">Product updates</RuiCheckbox>
+				<RuiCheckbox value="security">Security alerts</RuiCheckbox>
+				<RuiCheckbox value="marketing">Marketing emails</RuiCheckbox>
+			</RuiCheckboxGroupControl>
+		</RuiCheckboxGroup>
+	),
+} satisfies DocsMeta<CheckboxGroupArgs>;
+
+type Story = DocsStory<CheckboxGroupArgs>;
+
+export const Default: Story = docsStory(meta, { parameters: { docs: { id: 'checkbox-group/default' } } });

--- a/apps/radiant-ui/src/content/stories/heading.tsx
+++ b/apps/radiant-ui/src/content/stories/heading.tsx
@@ -24,7 +24,7 @@ export const meta = {
 			options: ['sm', 'md', 'lg', 'xl'] as const satisfies readonly RuiHeadingSize[],
 		},
 		align: {
-			control: { type: 'select' },
+			control: { type: 'radio' },
 			options: ['start', 'center'] as const satisfies readonly RuiHeadingAlign[],
 		},
 	},

--- a/apps/radiant-ui/src/content/stories/index.ts
+++ b/apps/radiant-ui/src/content/stories/index.ts
@@ -11,6 +11,7 @@ import './button-group';
 import './calendar';
 import './carousel';
 import './checkbox';
+import './checkbox-group';
 import './chip-list';
 import './combobox';
 import './date-field';

--- a/apps/radiant-ui/src/content/stories/knob.tsx
+++ b/apps/radiant-ui/src/content/stories/knob.tsx
@@ -36,7 +36,7 @@ export const meta = {
 		readOnly: { control: { type: 'boolean' } },
 		showValue: { control: { type: 'boolean' } },
 		valuePosition: {
-			control: { type: 'select' },
+			control: { type: 'radio' },
 			options: ['center', 'below'] as const satisfies readonly KnobArgs['valuePosition'][],
 		},
 	},

--- a/apps/radiant-ui/src/content/stories/select.tsx
+++ b/apps/radiant-ui/src/content/stories/select.tsx
@@ -23,7 +23,7 @@ export const meta = {
 		placeholder: { control: { type: 'text' } },
 		disabled: { control: { type: 'boolean' } },
 		selectionMode: {
-			control: { type: 'select' },
+			control: { type: 'radio' },
 			options: ['single', 'multiple'] as const satisfies readonly RuiSelectSelectionMode[],
 		},
 	},

--- a/apps/radiant-ui/src/content/stories/separator.tsx
+++ b/apps/radiant-ui/src/content/stories/separator.tsx
@@ -18,7 +18,7 @@ export const meta = {
 	args: { orientation: 'horizontal' },
 	argTypes: {
 		orientation: {
-			control: { type: 'select' },
+			control: { type: 'radio' },
 			options: ['horizontal', 'vertical'],
 		},
 	},

--- a/apps/radiant-ui/src/content/stories/sidebar.tsx
+++ b/apps/radiant-ui/src/content/stories/sidebar.tsx
@@ -37,7 +37,7 @@ export const meta = {
 			control: { type: 'select' },
 			options: ['off', 'icon', 'full'] as const satisfies readonly RuiSidebarCollapsible[],
 		},
-		side: { control: { type: 'select' }, options: ['left', 'right'] as const satisfies readonly RuiSidebarSide[] },
+		side: { control: { type: 'radio' }, options: ['left', 'right'] as const satisfies readonly RuiSidebarSide[] },
 		defaultOpen: { control: { type: 'boolean' } },
 		resizable: { control: { type: 'boolean' } },
 		defaultWidth: { control: { type: 'number' } },

--- a/apps/radiant-ui/src/content/stories/slider.tsx
+++ b/apps/radiant-ui/src/content/stories/slider.tsx
@@ -30,7 +30,7 @@ export const meta = {
 	},
 	argTypes: {
 		variant: {
-			control: { type: 'select' },
+			control: { type: 'radio' },
 			options: ['single', 'range'] as const satisfies readonly SliderArgs['variant'][],
 		},
 		value: { control: { type: 'number' } },

--- a/apps/radiant-ui/src/content/stories/tabs.tsx
+++ b/apps/radiant-ui/src/content/stories/tabs.tsx
@@ -17,7 +17,7 @@ export const meta = {
 	},
 	argTypes: {
 		variant: {
-			control: { type: 'select' },
+			control: { type: 'radio' },
 			options: ['boxed', 'ghost'] as const satisfies readonly RuiTabsVariant[],
 		},
 		value: { control: { type: 'text' } },

--- a/apps/radiant-ui/src/content/stories/tag-group.tsx
+++ b/apps/radiant-ui/src/content/stories/tag-group.tsx
@@ -25,7 +25,7 @@ export const meta = {
 	argTypes: {
 		value: { control: { type: 'text' } },
 		selectionMode: {
-			control: { type: 'select' },
+			control: { type: 'radio' },
 			options: ['single', 'multiple'] as const satisfies readonly RuiTagGroupSelectionMode[],
 		},
 		disabled: { control: { type: 'boolean' } },

--- a/apps/radiant-ui/src/content/stories/window-splitter.tsx
+++ b/apps/radiant-ui/src/content/stories/window-splitter.tsx
@@ -16,7 +16,7 @@ export const meta = {
 	argTypes: {
 		value: { control: { type: 'number' } },
 		orientation: {
-			control: { type: 'select' },
+			control: { type: 'radio' },
 			options: ['horizontal', 'vertical'] as const satisfies readonly WindowSplitterArgs['orientation'][],
 		},
 		label: { control: { type: 'text' } },

--- a/apps/radiant-ui/src/lib/docs-stories/heuristics.ts
+++ b/apps/radiant-ui/src/lib/docs-stories/heuristics.ts
@@ -23,6 +23,7 @@ export type DocsControlPresentation = ResolvedDocsControl['kind'];
  * - `select` with 2…{@link DOCS_SEGMENT_OPTION_LIMIT} options → segments
  * - `select` with 1 option or more than the limit → select
  * - `select` with no options → text (fallback)
+ * - `radio` with 2+ options → radio group; otherwise select or text
  */
 export function resolveControlPresentation(
 	definition: DocsArgType | undefined,
@@ -33,6 +34,13 @@ export function resolveControlPresentation(
 	if (type === 'boolean') return 'boolean';
 	if (type === 'number') return 'number';
 	if (type === 'text') return 'text';
+
+	if (type === 'radio') {
+		if (options.length >= 2) return 'radio';
+		if (options.length > DOCS_SEGMENT_OPTION_LIMIT) return 'select';
+		if (options.length > 0) return 'select';
+		return 'text';
+	}
 
 	if (type === 'select' || options.length > 0) {
 		if (options.length === 0) return 'text';
@@ -52,7 +60,7 @@ export function listResolvedControls(meta: DocsMetaAny): ResolvedDocsControl[] {
 		}
 		const options = [...(definition.options ?? [])].map(String);
 		const kind = resolveControlPresentation(definition, options);
-		if (kind === 'segmented' || kind === 'select') {
+		if (kind === 'segmented' || kind === 'select' || kind === 'radio') {
 			controls.push({ name, kind, options });
 		} else {
 			controls.push({ name, kind });

--- a/apps/radiant-ui/src/lib/docs-stories/render-control.tsx
+++ b/apps/radiant-ui/src/lib/docs-stories/render-control.tsx
@@ -3,6 +3,7 @@ import { RuiButton } from '@ecopages/radiant-ui/button';
 import { RuiInput } from '@ecopages/radiant-ui/input';
 import { RuiLabel } from '@ecopages/radiant-ui/label';
 import { RuiNumberField } from '@ecopages/radiant-ui/number-field';
+import { RuiRadioGroup } from '@ecopages/radiant-ui/radio-group';
 import { RuiSelect } from '@ecopages/radiant-ui/select';
 import { RuiSwitch } from '@ecopages/radiant-ui/switch';
 import { RuiToolbar } from '@ecopages/radiant-ui/toolbar';
@@ -79,6 +80,21 @@ export function renderDocsControl(control: ResolvedDocsControl, args: DocsArgs):
 			<>
 				<RuiLabel class="docs-story-controls__label">{control.name}</RuiLabel>
 				{renderSegmentedControl(control.name, control.options, String(raw ?? ''))}
+			</>,
+		);
+	}
+
+	if (control.kind === 'radio') {
+		return controlShell(
+			'radio',
+			<>
+				<RuiLabel class="docs-story-controls__label">{control.name}</RuiLabel>
+				<RuiRadioGroup
+					class="docs-story-controls__radio"
+					data-docs-arg={control.name}
+					value={String(raw ?? '')}
+					options={control.options.map((option) => ({ value: option, label: option }))}
+				/>
 			</>,
 		);
 	}

--- a/apps/radiant-ui/src/lib/docs-stories/types.ts
+++ b/apps/radiant-ui/src/lib/docs-stories/types.ts
@@ -3,7 +3,7 @@ import type { JsxRenderable } from '@ecopages/jsx';
 export type DocsArgs = Record<string, unknown>;
 
 /** Author-declared control kinds in `argTypes`. Presentation is chosen by heuristics. */
-export type DocsControlType = 'select' | 'boolean' | 'text' | 'number';
+export type DocsControlType = 'select' | 'radio' | 'boolean' | 'text' | 'number';
 
 export type DocsArgType<TValue = unknown> = {
 	control?: { type?: DocsControlType };
@@ -83,9 +83,11 @@ export interface DocsStoryAny {
  * Authors declare `control.type` + `options` in `argTypes`. The docs shell never
  * picks widgets ad hoc — {@link resolveControlPresentation} does.
  * `segmented` is only for short 2–3 option enums; longer sets use `select`.
+ * `radio` is for explicit vertical radio groups when authors prefer that over segments.
  */
 export type ResolvedDocsControl =
 	| { name: string; kind: 'segmented'; options: string[] }
+	| { name: string; kind: 'radio'; options: string[] }
 	| { name: string; kind: 'select'; options: string[] }
 	| { name: string; kind: 'boolean' }
 	| { name: string; kind: 'text' }

--- a/apps/radiant-ui/test/story-previews.test.ts
+++ b/apps/radiant-ui/test/story-previews.test.ts
@@ -11,6 +11,7 @@ import { meta as dateRangePickerMeta } from '../src/content/stories/date-range-p
 import { meta as autocompleteMeta } from '../src/content/stories/autocomplete';
 import { meta as menuButtonMeta } from '../src/content/stories/menu-button';
 import { meta as radioGroupMeta } from '../src/content/stories/radio-group';
+import { meta as checkboxGroupMeta } from '../src/content/stories/checkbox-group';
 
 function serialize(element: unknown): string {
 	return JSON.stringify(element);
@@ -106,16 +107,26 @@ describe('story preview renders', () => {
 		expect(preview).toContain('rui-listbox');
 	});
 
-	test('menu button and radio group render composed controls', () => {
+	test('menu button, radio group, and checkbox group render composed controls', () => {
 		const menuButton = serialize(
 			menuButtonMeta.render!({ open: false, placement: 'bottom-start', children: 'Actions' }),
 		);
 		const radioGroup = serialize(radioGroupMeta.render!({ value: 'pro', disabled: false, label: 'Plan' }));
+		const checkboxGroup = serialize(
+			checkboxGroupMeta.render!({
+				value: 'product,security',
+				disabled: false,
+				label: 'Email notifications',
+				orientation: 'vertical',
+			}),
+		);
 
 		expect(menuButton).toContain('rui-menu-button__trigger');
 		expect(menuButton).toContain('rui-menu-button__item');
 		expect(radioGroup).toContain('rui-radio-group');
 		expect(radioGroup).toContain('rui-radio');
+		expect(checkboxGroup).toContain('rui-checkbox-group');
+		expect(checkboxGroup).toContain('rui-checkbox');
 	});
 
 	test('date range picker renders props on the host element', () => {

--- a/packages/radiant-ui/package.json
+++ b/packages/radiant-ui/package.json
@@ -244,6 +244,13 @@
 		"./checkbox/styles.css": {
 			"default": "./dist/components/ui/checkbox/checkbox.css"
 		},
+		"./checkbox-group": {
+			"types": "./dist/components/ui/checkbox-group/index.d.ts",
+			"import": "./dist/components/ui/checkbox-group/index.js"
+		},
+		"./checkbox-group/styles.css": {
+			"default": "./dist/components/ui/checkbox-group/checkbox-group.css"
+		},
 		"./chip": {
 			"types": "./dist/components/ui/chip/index.d.ts",
 			"import": "./dist/components/ui/chip/index.js"

--- a/packages/radiant-ui/src/Introduction.mdx
+++ b/packages/radiant-ui/src/Introduction.mdx
@@ -27,7 +27,7 @@ Not every entry under **Components/** is a full APG widget. Read the component T
       <td><strong>Native</strong></td>
       <td>Thin styling / wiring around platform controls</td>
       <td>
-        <code>RuiButton</code>, <code>RuiInput</code>, <code>RuiTextarea</code>, Switch, Checkbox, Slider (single + range), Meter, Radio Group,
+        <code>RuiButton</code>, <code>RuiInput</code>, <code>RuiTextarea</code>, Switch, Checkbox, Checkbox Group, Slider (single + range), Meter, Radio Group,
         <code>RuiHeading</code>, <code>RuiHeadline</code>, <code>RuiFeed</code>, <code>RuiAvatar</code>, <code>RuiChip</code>, <code>RuiButtonGroup</code>, Cycle Toggle
       </td>
     </tr>

--- a/packages/radiant-ui/src/components/ui/checkbox-group/checkbox-group.css
+++ b/packages/radiant-ui/src/components/ui/checkbox-group/checkbox-group.css
@@ -1,0 +1,15 @@
+@reference '../../../styles/radiant-ui.css';
+
+rui-checkbox-group {
+	@apply block;
+}
+
+@layer components {
+	.rui-checkbox-group {
+		@apply flex flex-col gap-inline;
+	}
+
+	.rui-checkbox-group[data-orientation='horizontal'] {
+		@apply flex-row flex-wrap;
+	}
+}

--- a/packages/radiant-ui/src/components/ui/checkbox-group/checkbox-group.script.tsx
+++ b/packages/radiant-ui/src/components/ui/checkbox-group/checkbox-group.script.tsx
@@ -1,0 +1,116 @@
+import { RadiantElement, customElement, event, onEvent, onUpdated, prop } from '@ecopages/radiant';
+import type { EventEmitter } from '@ecopages/radiant/tools/event-emitter';
+import { RuiCheckbox } from '../checkbox/checkbox.script';
+import { parseMultiValue, serializeMultiValue } from '../shared/multi-value';
+
+export type RuiCheckboxGroupOrientation = 'horizontal' | 'vertical';
+
+export type RuiCheckboxGroupProps = {
+	/** Comma-separated selected checkbox values. Reflects to markup. */
+	value?: string;
+	/** Form field name shared by all checkboxes in the group. */
+	name?: string;
+	/** Accessible name for the group when no visible legend is composed. */
+	label?: string;
+	/** Disable every checkbox in the group. Default: `false`. */
+	disabled?: boolean;
+	/** Layout axis for checkbox items. Default: `vertical`. */
+	orientation?: RuiCheckboxGroupOrientation;
+};
+
+export type RuiCheckboxGroupChangeDetail = {
+	value: string;
+};
+
+/**
+ * `<rui-checkbox-group>` — a set of checkboxes where any number of options
+ * may be selected independently.
+ *
+ * Implements the WAI-ARIA APG Checkbox pattern using `RuiCheckbox` children
+ * inside a `role="group"` container. Group `value` is the comma-separated
+ * protocol shared with multi-select controls.
+ *
+ * @see https://www.w3.org/WAI/ARIA/apg/patterns/checkbox/
+ *
+ * Keyboard interaction (native to each checkbox):
+ * - `Tab` / `Shift+Tab`: move focus between checkboxes
+ * - `Space`: toggle the focused checkbox
+ *
+ * @element rui-checkbox-group
+ *
+ * @attr {string} value - Comma-separated selected values. Reflects to markup. Default: `''`.
+ * @attr {string} name - Form field name shared by all checkboxes in the group. Default: `''`.
+ * @attr {string} label - Accessible name when no visible legend is composed. Default: `''`.
+ * @attr {boolean} disabled - Disables every checkbox in the group. Default: `false`.
+ * @attr {('horizontal'|'vertical')} orientation - Layout axis for checkbox items. Default: `vertical`.
+ *
+ * @fires rui-change - Emitted after the selected values change; `detail.value` holds the serialized selection.
+ *
+ * @remarks
+ * Compose with `RuiCheckboxGroupControl` and `RuiCheckbox`, or use the `options`
+ * convenience API. After connect, group `value` wins over per-item `checked`.
+ * Item-level `disabled` is preserved via `data-disabled` on `RuiCheckbox`.
+ * Child `rui-change` is stopped immediately so host listeners only receive group-shaped `detail.value`.
+ *
+ * @cssclass rui-checkbox-group - Group surface (`role="group"`).
+ */
+@customElement('rui-checkbox-group')
+export class RuiCheckboxGroup extends RadiantElement {
+	@prop({ type: String, reflect: true, defaultValue: '' }) value: string;
+	@prop({ type: String, defaultValue: '' }) name: string;
+	@prop({ type: String, defaultValue: '' }) label: string;
+	@prop({ type: Boolean, reflect: true, defaultValue: false }) disabled: boolean;
+	@prop({ type: String, reflect: true, defaultValue: 'vertical' }) orientation: RuiCheckboxGroupOrientation;
+
+	@event({ name: 'rui-change', bubbles: true, composed: true })
+	changeEvent: EventEmitter<RuiCheckboxGroupChangeDetail>;
+
+	protected override onConnected(): void {
+		this.syncCheckboxes();
+	}
+
+	@onUpdated(['value', 'name', 'label', 'disabled', 'orientation'])
+	syncCheckboxes(): void {
+		const group = this.querySelector<HTMLElement>('[data-checkbox-group-root]');
+		if (group) {
+			if (this.label) {
+				group.setAttribute('aria-label', this.label);
+			} else {
+				group.removeAttribute('aria-label');
+			}
+			if (this.disabled) {
+				group.setAttribute('aria-disabled', 'true');
+			} else {
+				group.removeAttribute('aria-disabled');
+			}
+			group.setAttribute('data-orientation', this.orientation);
+		}
+
+		const selected = new Set(parseMultiValue(this.value));
+		const groupName = this.name || this.getAttribute('name') || '';
+
+		for (const checkbox of this.getCheckboxes()) {
+			checkbox.checked = selected.has(checkbox.value);
+			checkbox.disabled = this.disabled || checkbox.hasAttribute('data-disabled');
+			if (groupName) {
+				checkbox.name = groupName;
+			}
+		}
+	}
+
+	@onEvent({ selector: 'rui-checkbox', type: 'rui-change' })
+	onCheckboxChange(event: Event): void {
+		event.stopImmediatePropagation();
+		const values = this.getCheckboxes()
+			.filter((checkbox) => checkbox.checked)
+			.map((checkbox) => checkbox.value);
+		this.value = serializeMultiValue(values);
+		this.changeEvent.emit({ value: this.value });
+	}
+
+	private getCheckboxes(): RuiCheckbox[] {
+		return Array.from(this.querySelectorAll('rui-checkbox')).filter(
+			(node): node is RuiCheckbox => node instanceof RuiCheckbox,
+		);
+	}
+}

--- a/packages/radiant-ui/src/components/ui/checkbox-group/checkbox-group.ssr.test.tsx
+++ b/packages/radiant-ui/src/components/ui/checkbox-group/checkbox-group.ssr.test.tsx
@@ -1,0 +1,51 @@
+import { renderToString } from '@ecopages/jsx/server';
+import { withRadiantServerCustomElementRenderBridge } from '@ecopages/radiant/server/radiant-element-ssr';
+import { describe, expect, it } from 'vitest';
+import { RuiAlert } from '../alert/alert';
+import { RuiCheckbox } from '../checkbox';
+import { RuiCheckboxGroup, RuiCheckboxGroupControl } from './checkbox-group';
+
+describe('RuiCheckboxGroup SSR', () => {
+	it('serializes unprefixed host props inside another custom element', () => {
+		const html = withRadiantServerCustomElementRenderBridge(() =>
+			renderToString(
+				<RuiAlert>
+					<RuiCheckboxGroup
+						value="product,security"
+						name="notifications"
+						label="Email notifications"
+						disabled={false}
+						orientation="horizontal"
+					>
+						<RuiCheckboxGroupControl>
+							<RuiCheckbox value="product" checked>
+								Product updates
+							</RuiCheckbox>
+						</RuiCheckboxGroupControl>
+					</RuiCheckboxGroup>
+				</RuiAlert>,
+			),
+		);
+
+		expect(html).toMatch(/<rui-checkbox-group[^>]*value="product,security"/);
+		expect(html).toMatch(/<rui-checkbox-group[^>]*name="notifications"/);
+		expect(html).toMatch(/<rui-checkbox-group[^>]*label="Email notifications"/);
+		expect(html).toMatch(/<rui-checkbox-group[^>]*disabled="false"/);
+		expect(html).toMatch(/<rui-checkbox-group[^>]*orientation="horizontal"/);
+	});
+
+	it('stamps data-disabled on a disabled checkbox option', () => {
+		const html = withRadiantServerCustomElementRenderBridge(() =>
+			renderToString(
+				<RuiCheckboxGroup
+					options={[
+						{ value: 'news', label: 'News' },
+						{ value: 'travel', label: 'Travel', disabled: true },
+					]}
+				/>,
+			),
+		);
+
+		expect(html).toMatch(/<rui-checkbox[^>]*value="travel"[^>]*data-disabled=""/);
+	});
+});

--- a/packages/radiant-ui/src/components/ui/checkbox-group/checkbox-group.stories.tsx
+++ b/packages/radiant-ui/src/components/ui/checkbox-group/checkbox-group.stories.tsx
@@ -1,0 +1,136 @@
+import type { Meta, StoryObj } from '@ecopages/storybook-radiant-vite';
+import { expect, userEvent } from 'storybook/test';
+import { RuiCheckbox } from '../checkbox';
+import { RuiField, RuiFieldDescription, RuiFieldError } from '../field';
+import { RuiLabel } from '../label';
+import { RuiCheckboxGroup, RuiCheckboxGroupControl } from './checkbox-group';
+import { RuiCheckboxGroup as RuiCheckboxGroupElement } from './checkbox-group.script';
+
+const defaultOptions = [
+	{ value: 'product', label: 'Product updates' },
+	{ value: 'security', label: 'Security alerts' },
+	{ value: 'marketing', label: 'Marketing emails' },
+];
+
+const meta = {
+	title: 'Components/Checkbox Group',
+	component: RuiCheckboxGroup,
+	parameters: {
+		radiant: { element: RuiCheckboxGroupElement, cssImports: ['./checkbox-group.css', '../checkbox/checkbox.css'] },
+	},
+	args: {
+		name: 'notifications',
+		label: 'Email notifications',
+		value: '',
+		disabled: false,
+		orientation: 'vertical',
+		options: defaultOptions,
+	},
+} satisfies Meta<typeof RuiCheckboxGroup>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const getCheckboxes = (canvasElement: HTMLElement) =>
+	Array.from(canvasElement.querySelectorAll('rui-checkbox input[type="checkbox"]')) as HTMLInputElement[];
+
+export const Default: Story = {
+	play: async ({ canvasElement, step }) => {
+		const host = canvasElement.querySelector('rui-checkbox-group') as HTMLElement;
+		const checkboxes = getCheckboxes(canvasElement);
+
+		await step('clicking a checkbox selects it and updates the host value', async () => {
+			await userEvent.click(checkboxes[0]);
+			await expect(checkboxes[0]).toBeChecked();
+			await expect(host).toHaveAttribute('value', 'product');
+		});
+
+		await step('selecting another checkbox keeps both checked', async () => {
+			await userEvent.click(checkboxes[1]);
+			await expect(checkboxes[0]).toBeChecked();
+			await expect(checkboxes[1]).toBeChecked();
+			await expect(host).toHaveAttribute('value', 'product,security');
+		});
+
+		await step('unchecking removes the value from the serialized selection', async () => {
+			await userEvent.click(checkboxes[0]);
+			await expect(checkboxes[0]).not.toBeChecked();
+			await expect(host).toHaveAttribute('value', 'security');
+		});
+
+		await step('a rui-change event carries the serialized value', async () => {
+			const emissions: string[] = [];
+			host.addEventListener('rui-change', (event) =>
+				emissions.push((event as CustomEvent<{ value: string }>).detail.value),
+			);
+			await userEvent.click(checkboxes[2]);
+			await expect(emissions).toEqual(['security,marketing']);
+		});
+	},
+};
+
+export const WithValue: Story = {
+	args: { value: 'product,security' },
+};
+
+export const Horizontal: Story = {
+	args: { orientation: 'horizontal', value: 'product' },
+};
+
+export const Disabled: Story = {
+	args: { disabled: true, value: 'product' },
+	play: async ({ canvasElement, step }) => {
+		const checkboxes = getCheckboxes(canvasElement);
+
+		await step('every checkbox in a disabled group is disabled', async () => {
+			for (const checkbox of checkboxes) {
+				await expect(checkbox).toBeDisabled();
+			}
+		});
+	},
+};
+
+export const Composed: Story = {
+	render: () => (
+		<RuiCheckboxGroup name="condiments" label="Sandwich condiments">
+			<RuiCheckboxGroupControl>
+				<RuiCheckbox value="lettuce">Lettuce</RuiCheckbox>
+				<RuiCheckbox value="tomato" disabled>
+					Tomato
+				</RuiCheckbox>
+				<RuiCheckbox value="onion">Onion</RuiCheckbox>
+			</RuiCheckboxGroupControl>
+		</RuiCheckboxGroup>
+	),
+	play: async ({ canvasElement, step }) => {
+		const host = canvasElement.querySelector('rui-checkbox-group') as HTMLElement;
+		const checkboxes = getCheckboxes(canvasElement);
+
+		await step('composed item disabled survives group connect', async () => {
+			await expect(checkboxes[1]).toBeDisabled();
+			await expect(checkboxes[1].closest('rui-checkbox')).toHaveAttribute('data-disabled');
+		});
+
+		await step('composed options update the group value', async () => {
+			await userEvent.click(checkboxes[0]);
+			await userEvent.click(checkboxes[2]);
+			await expect(host).toHaveAttribute('value', 'lettuce,onion');
+		});
+	},
+};
+
+export const AsField: Story = {
+	render: () => (
+		<RuiField name="topics" rules={{ required: 'Select at least one topic' }}>
+			<RuiLabel>Topics</RuiLabel>
+			<RuiCheckboxGroup
+				options={[
+					{ value: 'news', label: 'News' },
+					{ value: 'travel', label: 'Travel' },
+				]}
+			/>
+			<RuiFieldDescription>Choose what you want to hear about.</RuiFieldDescription>
+			<RuiFieldError />
+		</RuiField>
+	),
+};

--- a/packages/radiant-ui/src/components/ui/checkbox-group/checkbox-group.tsx
+++ b/packages/radiant-ui/src/components/ui/checkbox-group/checkbox-group.tsx
@@ -1,0 +1,87 @@
+import type { JsxCustomElementAttributes, JsxElementProps, JsxRenderable } from '@ecopages/jsx';
+import { cx } from '@/lib/cx';
+import { RuiCheckbox } from '../checkbox';
+import { parseMultiValue, serializeMultiValue } from '../shared/multi-value';
+import type {
+	RuiCheckboxGroup as RuiCheckboxGroupElement,
+	RuiCheckboxGroupOrientation,
+	RuiCheckboxGroupProps,
+} from './checkbox-group.script';
+import './checkbox-group.script';
+
+export type RuiCheckboxOption = {
+	value: string;
+	label: JsxRenderable;
+	disabled?: boolean;
+};
+
+export type RuiCheckboxGroupControlProps = JsxElementProps<HTMLDivElement> & {
+	orientation?: RuiCheckboxGroupOrientation;
+};
+
+/** Accessible surface that contains checkbox options. */
+export function RuiCheckboxGroupControl({
+	children,
+	class: className,
+	orientation = 'vertical',
+	...props
+}: RuiCheckboxGroupControlProps) {
+	return (
+		<div
+			{...props}
+			data-checkbox-group-root
+			data-orientation={orientation}
+			class={cx('rui-checkbox-group', className)}
+			role="group"
+			data-rui-control
+			data-rui-control-type="text"
+		>
+			{children}
+		</div>
+	);
+}
+
+function serializeGroupValue(value: string | string[] | undefined): string | undefined {
+	if (value === undefined) {
+		return undefined;
+	}
+	return Array.isArray(value) ? serializeMultiValue(value) : value;
+}
+
+/**
+ * Checkbox group with an `options` convenience API; renders one `RuiCheckbox`
+ * per option inside `<rui-checkbox-group>`.
+ */
+export function RuiCheckboxGroup({
+	options,
+	children,
+	value,
+	orientation = 'vertical',
+	...props
+}: JsxCustomElementAttributes<
+	RuiCheckboxGroupElement,
+	RuiCheckboxGroupProps & { options?: RuiCheckboxOption[]; value?: string | string[] }
+>) {
+	const serializedValue = serializeGroupValue(value);
+	const selected = new Set(parseMultiValue(serializedValue ?? ''));
+
+	return (
+		<rui-checkbox-group {...props} value={serializedValue} orientation={orientation}>
+			{options == null ? (
+				children
+			) : (
+				<RuiCheckboxGroupControl orientation={orientation}>
+					{options.map((option) => (
+						<RuiCheckbox
+							value={option.value}
+							disabled={option.disabled}
+							checked={selected.has(option.value)}
+						>
+							{option.label}
+						</RuiCheckbox>
+					))}
+				</RuiCheckboxGroupControl>
+			)}
+		</rui-checkbox-group>
+	);
+}

--- a/packages/radiant-ui/src/components/ui/checkbox-group/index.ts
+++ b/packages/radiant-ui/src/components/ui/checkbox-group/index.ts
@@ -1,0 +1,7 @@
+export {
+	RuiCheckboxGroup as RuiCheckboxGroupElement,
+	type RuiCheckboxGroupProps,
+	type RuiCheckboxGroupChangeDetail,
+	type RuiCheckboxGroupOrientation,
+} from './checkbox-group.script';
+export { RuiCheckboxGroup, RuiCheckboxGroupControl, type RuiCheckboxOption } from './checkbox-group';

--- a/packages/radiant-ui/src/components/ui/checkbox/checkbox.script.tsx
+++ b/packages/radiant-ui/src/components/ui/checkbox/checkbox.script.tsx
@@ -10,7 +10,12 @@ export type RuiCheckboxProps = {
 	 * `aria-checked="mixed"` is exposed. Default: `false`.
 	 */
 	indeterminate?: boolean;
-	/** Disable the checkbox. Default: `false`. */
+	/**
+	 * Disable the checkbox. Default: `false`.
+	 *
+	 * @remarks The view stamps `data-disabled` so a parent group can restore
+	 * item-level disabled after a group-level disable.
+	 */
 	disabled?: boolean;
 	/** Value submitted with forms when checked. */
 	value?: string;

--- a/packages/radiant-ui/src/components/ui/checkbox/checkbox.stories.tsx
+++ b/packages/radiant-ui/src/components/ui/checkbox/checkbox.stories.tsx
@@ -76,6 +76,8 @@ export const Disabled: Story = {
 		const input = getInput(canvasElement);
 
 		await step('a disabled checkbox cannot be activated', async () => {
+			const host = canvasElement.querySelector('rui-checkbox') as HTMLElement;
+			await expect(host).toHaveAttribute('data-disabled');
 			await expect(input).toBeDisabled();
 			await userEvent.click(input);
 			await expect(input).not.toBeChecked();

--- a/packages/radiant-ui/src/components/ui/checkbox/checkbox.tsx
+++ b/packages/radiant-ui/src/components/ui/checkbox/checkbox.tsx
@@ -23,6 +23,7 @@ export function RuiCheckbox({
 			indeterminate={indeterminate}
 			name={name}
 			value={value}
+			data-disabled={disabled ? '' : undefined}
 		>
 			<label class="rui-checkbox">
 				<input

--- a/packages/radiant-ui/src/components/ui/field/field.script.tsx
+++ b/packages/radiant-ui/src/components/ui/field/field.script.tsx
@@ -289,7 +289,7 @@ export class RuiField extends RadiantElement {
 
 	@onEvent({
 		selector:
-			'[data-rui-control], rui-combobox, rui-date-field, rui-date-range-picker, rui-select, rui-tag-group, rui-checkbox, rui-switch, rui-radio-group, rui-slider, rui-knob, rui-number-field, rui-listbox',
+			'[data-rui-control], rui-combobox, rui-date-field, rui-date-range-picker, rui-select, rui-tag-group, rui-checkbox, rui-checkbox-group, rui-switch, rui-radio-group, rui-slider, rui-knob, rui-number-field, rui-listbox',
 		type: 'rui-change',
 	})
 	onControlChange(): void {

--- a/packages/radiant-ui/src/components/ui/form/control-protocol.ssr.test.ts
+++ b/packages/radiant-ui/src/components/ui/form/control-protocol.ssr.test.ts
@@ -53,4 +53,22 @@ describe('field control protocol (SSR-safe)', () => {
 		expect(getAriaControlTarget(host).getAttribute('value')).toBe('free');
 		expect(pro!.hasAttribute('checked')).toBe(true);
 	});
+
+	it('discovers checkbox-group surface instead of inner checkbox hosts', () => {
+		const field = document.createElement('div');
+		field.innerHTML = `
+			<div class="rui-field">
+				<rui-checkbox-group value="news">
+					<div data-checkbox-group-root data-rui-control role="group">
+						<rui-checkbox value="news" checked></rui-checkbox>
+						<rui-checkbox value="travel"></rui-checkbox>
+					</div>
+				</rui-checkbox-group>
+			</div>
+		`;
+
+		const control = findFieldControl(field);
+		expect(control?.getAttribute('data-checkbox-group-root')).not.toBeNull();
+		expect(getAriaControlTarget(control!).getAttribute('data-checkbox-group-root')).not.toBeNull();
+	});
 });

--- a/packages/radiant-ui/src/components/ui/form/control-protocol.ts
+++ b/packages/radiant-ui/src/components/ui/form/control-protocol.ts
@@ -13,6 +13,7 @@ const HOST_CONTROL_TAGS = new Set([
 	'rui-select',
 	'rui-tag-group',
 	'rui-checkbox',
+	'rui-checkbox-group',
 	'rui-switch',
 	'rui-radio-group',
 	'rui-slider',
@@ -146,6 +147,7 @@ const CONTROL_VALUE_ADAPTERS = new Map<string, ControlValueAdapter>([
 	['rui-date-range-picker', stringValueAdapter],
 	['rui-select', stringValueAdapter],
 	['rui-radio-group', stringValueAdapter],
+	['rui-checkbox-group', stringValueAdapter],
 	['rui-listbox', stringValueAdapter],
 	['rui-tag-group', stringValueAdapter],
 	['rui-slider', sliderValueAdapter],
@@ -473,6 +475,10 @@ export function getAriaControlTarget(control: HTMLElement): HTMLElement {
 
 	if (control.localName === 'rui-checkbox' || control.localName === 'rui-switch') {
 		return control.querySelector<HTMLElement>('input') ?? control;
+	}
+
+	if (control.localName === 'rui-checkbox-group') {
+		return control.querySelector<HTMLElement>('[data-checkbox-group-root]') ?? control;
 	}
 
 	if (control.localName === 'rui-radio-group') {

--- a/packages/radiant-ui/src/components/ui/form/form.stories.tsx
+++ b/packages/radiant-ui/src/components/ui/form/form.stories.tsx
@@ -9,6 +9,7 @@ import { RuiAlertDescription, RuiAlertTitle } from '../alert';
 import { RuiAlert as RuiAlertElement, type RuiAlertProps } from '../alert/alert.script';
 import { RuiButton } from '../button/button';
 import { RuiCheckbox } from '../checkbox';
+import { RuiCheckboxGroup } from '../checkbox-group';
 import { RuiCombobox } from '../combobox';
 import { RuiDateField } from '../date-field';
 import { RuiDateRangePicker } from '../date-range-picker';
@@ -397,6 +398,44 @@ export const WithRadioGroup: Story = {
 			await waitFor(() => {
 				expect(getFieldErrorMessage(canvasElement, 'plan')).toBeNull();
 			});
+		});
+	},
+};
+
+export const WithCheckboxGroup: Story = {
+	render: () => (
+		<RuiForm defaultValues={{ topics: '' }}>
+			<RuiField name="topics" rules={{ required: 'Select at least one topic' }}>
+				<RuiLabel>Topics</RuiLabel>
+				<RuiCheckboxGroup
+					options={[
+						{ value: 'news', label: 'News' },
+						{ value: 'travel', label: 'Travel' },
+					]}
+				/>
+				<RuiFieldError />
+			</RuiField>
+			<RuiButton type="submit">Continue</RuiButton>
+		</RuiForm>
+	),
+	play: async ({ canvasElement, step }) => {
+		const canvas = within(canvasElement);
+		const checkboxes = Array.from(
+			canvasElement.querySelectorAll('rui-checkbox input[type="checkbox"]'),
+		) as HTMLInputElement[];
+
+		await step('submit without selection shows error', async () => {
+			await userEvent.click(canvas.getByRole('button', { name: 'Continue' }));
+			await expectFieldError(canvasElement, 'topics', 'Select at least one topic');
+		});
+
+		await step('selecting a value clears the error', async () => {
+			await userEvent.click(checkboxes[0]);
+			await userEvent.click(canvas.getByRole('button', { name: 'Continue' }));
+			await waitFor(() => {
+				expect(getFieldErrorMessage(canvasElement, 'topics')).toBeNull();
+			});
+			await expect(canvasElement.querySelector('rui-checkbox-group')).toHaveAttribute('value', 'news');
 		});
 	},
 };

--- a/packages/radiant-ui/src/components/ui/shared/multi-value.ts
+++ b/packages/radiant-ui/src/components/ui/shared/multi-value.ts
@@ -1,5 +1,8 @@
 /** Parses the comma-separated value protocol used by multi-select controls. */
-export function parseMultiValue(value: string): string[] {
+export function parseMultiValue(value: string | null | undefined): string[] {
+	if (!value) {
+		return [];
+	}
 	return value
 		.split(',')
 		.map((item) => item.trim())

--- a/packages/radiant-ui/src/index.ts
+++ b/packages/radiant-ui/src/index.ts
@@ -14,6 +14,7 @@ export * from './components/ui/button-group';
 export * from './components/ui/calendar';
 export * from './components/ui/carousel';
 export * from './components/ui/checkbox';
+export * from './components/ui/checkbox-group';
 export * from './components/ui/chip';
 export * from './components/ui/chip-list';
 export * from './components/ui/combobox';

--- a/packages/radiant-ui/src/jsx-custom-elements.d.ts
+++ b/packages/radiant-ui/src/jsx-custom-elements.d.ts
@@ -3,6 +3,7 @@ import type { RuiAlert, RuiAlertProps } from './components/ui/alert/alert.script
 import type { RuiBreadcrumb, RuiBreadcrumbProps } from './components/ui/breadcrumb/breadcrumb.script';
 import type { RuiCarousel, RuiCarouselProps } from './components/ui/carousel/carousel.script';
 import type { RuiCheckbox, RuiCheckboxProps } from './components/ui/checkbox/checkbox.script';
+import type { RuiCheckboxGroup, RuiCheckboxGroupProps } from './components/ui/checkbox-group/checkbox-group.script';
 import type { RuiCombobox, RuiComboboxProps } from './components/ui/combobox/combobox.script';
 import type { RuiCycleToggle, RuiCycleToggleProps } from './components/ui/cycle-toggle/cycle-toggle.script';
 import type { RuiDialog, RuiDialogProps } from './components/ui/dialog/dialog.script';
@@ -45,6 +46,7 @@ declare module '@ecopages/jsx/jsx-runtime' {
 		'rui-breadcrumb': JsxCustomElementAttributes<RuiBreadcrumb, RuiBreadcrumbProps>;
 		'rui-carousel': JsxCustomElementAttributes<RuiCarousel, RuiCarouselProps>;
 		'rui-checkbox': JsxCustomElementAttributes<RuiCheckbox, RuiCheckboxProps>;
+		'rui-checkbox-group': JsxCustomElementAttributes<RuiCheckboxGroup, RuiCheckboxGroupProps>;
 		'rui-combobox': JsxCustomElementAttributes<RuiCombobox, RuiComboboxProps>;
 		'rui-cycle-toggle': JsxCustomElementAttributes<RuiCycleToggle, RuiCycleToggleProps>;
 		'rui-dialog': JsxCustomElementAttributes<RuiDialog, RuiDialogProps>;

--- a/packages/radiant-ui/src/styles/style-dependencies.json
+++ b/packages/radiant-ui/src/styles/style-dependencies.json
@@ -2,88 +2,58 @@
 	"components": {
 		"alert": {
 			"direct": [],
-			"styles": [
-				"@ecopages/radiant-ui/alert/styles.css"
-			]
+			"styles": ["@ecopages/radiant-ui/alert/styles.css"]
 		},
 		"autocomplete": {
 			"direct": [],
-			"styles": [
-				"@ecopages/radiant-ui/autocomplete/styles.css"
-			]
+			"styles": ["@ecopages/radiant-ui/autocomplete/styles.css"]
 		},
 		"avatar": {
 			"direct": [],
-			"styles": [
-				"@ecopages/radiant-ui/avatar/styles.css"
-			]
+			"styles": ["@ecopages/radiant-ui/avatar/styles.css"]
 		},
 		"badge": {
 			"direct": [],
-			"styles": [
-				"@ecopages/radiant-ui/badge/styles.css"
-			]
+			"styles": ["@ecopages/radiant-ui/badge/styles.css"]
 		},
 		"breadcrumb": {
 			"direct": [],
-			"styles": [
-				"@ecopages/radiant-ui/breadcrumb/styles.css"
-			]
+			"styles": ["@ecopages/radiant-ui/breadcrumb/styles.css"]
 		},
 		"button": {
 			"direct": [],
-			"styles": [
-				"@ecopages/radiant-ui/button/styles.css"
-			]
+			"styles": ["@ecopages/radiant-ui/button/styles.css"]
 		},
 		"button-group": {
-			"direct": [
-				"button"
-			],
-			"styles": [
-				"@ecopages/radiant-ui/button/styles.css",
-				"@ecopages/radiant-ui/button-group/styles.css"
-			]
+			"direct": ["button"],
+			"styles": ["@ecopages/radiant-ui/button/styles.css", "@ecopages/radiant-ui/button-group/styles.css"]
 		},
 		"calendar": {
 			"direct": [],
-			"styles": [
-				"@ecopages/radiant-ui/calendar/styles.css"
-			]
+			"styles": ["@ecopages/radiant-ui/calendar/styles.css"]
 		},
 		"carousel": {
-			"direct": [
-				"button"
-			],
-			"styles": [
-				"@ecopages/radiant-ui/button/styles.css",
-				"@ecopages/radiant-ui/carousel/styles.css"
-			]
+			"direct": ["button"],
+			"styles": ["@ecopages/radiant-ui/button/styles.css", "@ecopages/radiant-ui/carousel/styles.css"]
 		},
 		"checkbox": {
 			"direct": [],
-			"styles": [
-				"@ecopages/radiant-ui/checkbox/styles.css"
-			]
+			"styles": ["@ecopages/radiant-ui/checkbox/styles.css"]
+		},
+		"checkbox-group": {
+			"direct": ["checkbox"],
+			"styles": ["@ecopages/radiant-ui/checkbox/styles.css", "@ecopages/radiant-ui/checkbox-group/styles.css"]
 		},
 		"chip": {
 			"direct": [],
-			"styles": [
-				"@ecopages/radiant-ui/chip/styles.css"
-			]
+			"styles": ["@ecopages/radiant-ui/chip/styles.css"]
 		},
 		"chip-list": {
 			"direct": [],
-			"styles": [
-				"@ecopages/radiant-ui/chip-list/styles.css"
-			]
+			"styles": ["@ecopages/radiant-ui/chip-list/styles.css"]
 		},
 		"combobox": {
-			"direct": [
-				"autocomplete",
-				"listbox",
-				"primitives"
-			],
+			"direct": ["autocomplete", "listbox", "primitives"],
 			"styles": [
 				"@ecopages/radiant-ui/autocomplete/styles.css",
 				"@ecopages/radiant-ui/listbox/styles.css",
@@ -92,19 +62,11 @@
 			]
 		},
 		"cycle-toggle": {
-			"direct": [
-				"button"
-			],
-			"styles": [
-				"@ecopages/radiant-ui/button/styles.css",
-				"@ecopages/radiant-ui/cycle-toggle/styles.css"
-			]
+			"direct": ["button"],
+			"styles": ["@ecopages/radiant-ui/button/styles.css", "@ecopages/radiant-ui/cycle-toggle/styles.css"]
 		},
 		"date-field": {
-			"direct": [
-				"calendar",
-				"primitives"
-			],
+			"direct": ["calendar", "primitives"],
 			"styles": [
 				"@ecopages/radiant-ui/calendar/styles.css",
 				"@ecopages/radiant-ui/primitives.css",
@@ -112,10 +74,7 @@
 			]
 		},
 		"date-range-picker": {
-			"direct": [
-				"calendar",
-				"primitives"
-			],
+			"direct": ["calendar", "primitives"],
 			"styles": [
 				"@ecopages/radiant-ui/calendar/styles.css",
 				"@ecopages/radiant-ui/primitives.css",
@@ -124,100 +83,62 @@
 		},
 		"dialog": {
 			"direct": [],
-			"styles": [
-				"@ecopages/radiant-ui/dialog/styles.css"
-			]
+			"styles": ["@ecopages/radiant-ui/dialog/styles.css"]
 		},
 		"disclosure": {
 			"direct": [],
-			"styles": [
-				"@ecopages/radiant-ui/disclosure/styles.css"
-			]
+			"styles": ["@ecopages/radiant-ui/disclosure/styles.css"]
 		},
 		"feed": {
 			"direct": [],
-			"styles": [
-				"@ecopages/radiant-ui/feed/styles.css"
-			]
+			"styles": ["@ecopages/radiant-ui/feed/styles.css"]
 		},
 		"field": {
 			"direct": [],
-			"styles": [
-				"@ecopages/radiant-ui/field/styles.css"
-			]
+			"styles": ["@ecopages/radiant-ui/field/styles.css"]
 		},
 		"form": {
 			"direct": [],
-			"styles": [
-				"@ecopages/radiant-ui/form/styles.css"
-			]
+			"styles": ["@ecopages/radiant-ui/form/styles.css"]
 		},
 		"grid": {
 			"direct": [],
-			"styles": [
-				"@ecopages/radiant-ui/grid/styles.css"
-			]
+			"styles": ["@ecopages/radiant-ui/grid/styles.css"]
 		},
 		"heading": {
-			"direct": [
-				"headline"
-			],
-			"styles": [
-				"@ecopages/radiant-ui/headline/styles.css",
-				"@ecopages/radiant-ui/heading/styles.css"
-			]
+			"direct": ["headline"],
+			"styles": ["@ecopages/radiant-ui/headline/styles.css", "@ecopages/radiant-ui/heading/styles.css"]
 		},
 		"headline": {
 			"direct": [],
-			"styles": [
-				"@ecopages/radiant-ui/headline/styles.css"
-			]
+			"styles": ["@ecopages/radiant-ui/headline/styles.css"]
 		},
 		"hover-card": {
-			"direct": [
-				"primitives"
-			],
-			"styles": [
-				"@ecopages/radiant-ui/primitives.css",
-				"@ecopages/radiant-ui/hover-card/styles.css"
-			]
+			"direct": ["primitives"],
+			"styles": ["@ecopages/radiant-ui/primitives.css", "@ecopages/radiant-ui/hover-card/styles.css"]
 		},
 		"input": {
 			"direct": [],
-			"styles": [
-				"@ecopages/radiant-ui/input/styles.css"
-			]
+			"styles": ["@ecopages/radiant-ui/input/styles.css"]
 		},
 		"input-group": {
 			"direct": [],
-			"styles": [
-				"@ecopages/radiant-ui/input-group/styles.css"
-			]
+			"styles": ["@ecopages/radiant-ui/input-group/styles.css"]
 		},
 		"knob": {
 			"direct": [],
-			"styles": [
-				"@ecopages/radiant-ui/knob/styles.css"
-			]
+			"styles": ["@ecopages/radiant-ui/knob/styles.css"]
 		},
 		"label": {
 			"direct": [],
-			"styles": [
-				"@ecopages/radiant-ui/label/styles.css"
-			]
+			"styles": ["@ecopages/radiant-ui/label/styles.css"]
 		},
 		"listbox": {
 			"direct": [],
-			"styles": [
-				"@ecopages/radiant-ui/listbox/styles.css"
-			]
+			"styles": ["@ecopages/radiant-ui/listbox/styles.css"]
 		},
 		"menu-button": {
-			"direct": [
-				"button",
-				"primitives",
-				"separator"
-			],
+			"direct": ["button", "primitives", "separator"],
 			"styles": [
 				"@ecopages/radiant-ui/button/styles.css",
 				"@ecopages/radiant-ui/primitives.css",
@@ -226,10 +147,7 @@
 			]
 		},
 		"menubar": {
-			"direct": [
-				"primitives",
-				"separator"
-			],
+			"direct": ["primitives", "separator"],
 			"styles": [
 				"@ecopages/radiant-ui/primitives.css",
 				"@ecopages/radiant-ui/separator/styles.css",
@@ -238,30 +156,18 @@
 		},
 		"meter": {
 			"direct": [],
-			"styles": [
-				"@ecopages/radiant-ui/meter/styles.css"
-			]
+			"styles": ["@ecopages/radiant-ui/meter/styles.css"]
 		},
 		"navigation-menu": {
-			"direct": [
-				"button"
-			],
-			"styles": [
-				"@ecopages/radiant-ui/button/styles.css",
-				"@ecopages/radiant-ui/navigation-menu/styles.css"
-			]
+			"direct": ["button"],
+			"styles": ["@ecopages/radiant-ui/button/styles.css", "@ecopages/radiant-ui/navigation-menu/styles.css"]
 		},
 		"number-field": {
 			"direct": [],
-			"styles": [
-				"@ecopages/radiant-ui/number-field/styles.css"
-			]
+			"styles": ["@ecopages/radiant-ui/number-field/styles.css"]
 		},
 		"pagination": {
-			"direct": [
-				"button",
-				"primitives"
-			],
+			"direct": ["button", "primitives"],
 			"styles": [
 				"@ecopages/radiant-ui/button/styles.css",
 				"@ecopages/radiant-ui/primitives.css",
@@ -269,25 +175,15 @@
 			]
 		},
 		"popover": {
-			"direct": [
-				"primitives"
-			],
-			"styles": [
-				"@ecopages/radiant-ui/primitives.css",
-				"@ecopages/radiant-ui/popover/styles.css"
-			]
+			"direct": ["primitives"],
+			"styles": ["@ecopages/radiant-ui/primitives.css", "@ecopages/radiant-ui/popover/styles.css"]
 		},
 		"radio-group": {
 			"direct": [],
-			"styles": [
-				"@ecopages/radiant-ui/radio-group/styles.css"
-			]
+			"styles": ["@ecopages/radiant-ui/radio-group/styles.css"]
 		},
 		"select": {
-			"direct": [
-				"listbox",
-				"primitives"
-			],
+			"direct": ["listbox", "primitives"],
 			"styles": [
 				"@ecopages/radiant-ui/listbox/styles.css",
 				"@ecopages/radiant-ui/primitives.css",
@@ -296,108 +192,67 @@
 		},
 		"separator": {
 			"direct": [],
-			"styles": [
-				"@ecopages/radiant-ui/separator/styles.css"
-			]
+			"styles": ["@ecopages/radiant-ui/separator/styles.css"]
 		},
 		"sidebar": {
-			"direct": [
-				"button"
-			],
-			"styles": [
-				"@ecopages/radiant-ui/button/styles.css",
-				"@ecopages/radiant-ui/sidebar/styles.css"
-			]
+			"direct": ["button"],
+			"styles": ["@ecopages/radiant-ui/button/styles.css", "@ecopages/radiant-ui/sidebar/styles.css"]
 		},
 		"slider": {
 			"direct": [],
-			"styles": [
-				"@ecopages/radiant-ui/slider/styles.css"
-			]
+			"styles": ["@ecopages/radiant-ui/slider/styles.css"]
 		},
 		"spinner": {
 			"direct": [],
-			"styles": [
-				"@ecopages/radiant-ui/spinner/styles.css"
-			]
+			"styles": ["@ecopages/radiant-ui/spinner/styles.css"]
 		},
 		"switch": {
 			"direct": [],
-			"styles": [
-				"@ecopages/radiant-ui/switch/styles.css"
-			]
+			"styles": ["@ecopages/radiant-ui/switch/styles.css"]
 		},
 		"table": {
-			"direct": [
-				"checkbox"
-			],
-			"styles": [
-				"@ecopages/radiant-ui/checkbox/styles.css",
-				"@ecopages/radiant-ui/table/styles.css"
-			]
+			"direct": ["checkbox"],
+			"styles": ["@ecopages/radiant-ui/checkbox/styles.css", "@ecopages/radiant-ui/table/styles.css"]
 		},
 		"tabs": {
 			"direct": [],
-			"styles": [
-				"@ecopages/radiant-ui/tabs/styles.css"
-			]
+			"styles": ["@ecopages/radiant-ui/tabs/styles.css"]
 		},
 		"tag-group": {
 			"direct": [],
-			"styles": [
-				"@ecopages/radiant-ui/tag-group/styles.css"
-			]
+			"styles": ["@ecopages/radiant-ui/tag-group/styles.css"]
 		},
 		"textarea": {
 			"direct": [],
-			"styles": [
-				"@ecopages/radiant-ui/textarea/styles.css"
-			]
+			"styles": ["@ecopages/radiant-ui/textarea/styles.css"]
 		},
 		"toast": {
 			"direct": [],
-			"styles": [
-				"@ecopages/radiant-ui/toast/styles.css"
-			]
+			"styles": ["@ecopages/radiant-ui/toast/styles.css"]
 		},
 		"toc": {
 			"direct": [],
-			"styles": [
-				"@ecopages/radiant-ui/toc/styles.css"
-			]
+			"styles": ["@ecopages/radiant-ui/toc/styles.css"]
 		},
 		"toolbar": {
 			"direct": [],
-			"styles": [
-				"@ecopages/radiant-ui/toolbar/styles.css"
-			]
+			"styles": ["@ecopages/radiant-ui/toolbar/styles.css"]
 		},
 		"tooltip": {
-			"direct": [
-				"primitives"
-			],
-			"styles": [
-				"@ecopages/radiant-ui/primitives.css",
-				"@ecopages/radiant-ui/tooltip/styles.css"
-			]
+			"direct": ["primitives"],
+			"styles": ["@ecopages/radiant-ui/primitives.css", "@ecopages/radiant-ui/tooltip/styles.css"]
 		},
 		"tree": {
 			"direct": [],
-			"styles": [
-				"@ecopages/radiant-ui/tree/styles.css"
-			]
+			"styles": ["@ecopages/radiant-ui/tree/styles.css"]
 		},
 		"treegrid": {
 			"direct": [],
-			"styles": [
-				"@ecopages/radiant-ui/treegrid/styles.css"
-			]
+			"styles": ["@ecopages/radiant-ui/treegrid/styles.css"]
 		},
 		"window-splitter": {
 			"direct": [],
-			"styles": [
-				"@ecopages/radiant-ui/window-splitter/styles.css"
-			]
+			"styles": ["@ecopages/radiant-ui/window-splitter/styles.css"]
 		}
 	}
 }

--- a/packages/radiant-ui/src/styles/styles.css
+++ b/packages/radiant-ui/src/styles/styles.css
@@ -13,6 +13,7 @@
 @import '../components/ui/calendar/calendar.css';
 @import '../components/ui/carousel/carousel.css';
 @import '../components/ui/checkbox/checkbox.css';
+@import '../components/ui/checkbox-group/checkbox-group.css';
 @import '../components/ui/chip/chip.css';
 @import '../components/ui/chip-list/chip-list.css';
 @import '../components/ui/combobox/combobox.css';


### PR DESCRIPTION
## Summary

- Add `RuiCheckboxGroup` with `RuiCheckboxGroupControl`, comma-separated `value`, and `options` convenience API.
- Stamp `data-disabled` on `RuiCheckbox` so group sync preserves per-option disabled state; drive children via typed `RuiCheckbox` hosts instead of inner inputs.
- Register the group in field control protocol (`RuiField` / `RuiForm`) and add docs, stories, and a changeset.

## Commits

1. `fix(radiant-ui): guard multi-value parse against nullish strings`
2. `fix(radiant-ui): preserve checkbox disabled via data-disabled marker`
3. `feat(radiant-ui): add checkbox-group component and package exports`
4. `feat(radiant-ui): register checkbox-group in field control protocol`
5. `docs(radiant-ui): add checkbox-group docs and cross-links`
6. `chore(changeset): add checkbox-group release note`

## Test plan

- [x] Checkbox-group SSR tests
- [x] Checkbox / checkbox-group / form Storybook interaction tests
- [x] Package typecheck
- [x] Verify checkbox-group docs page in `pnpm dev:ui`
- [x] Confirm `WithCheckboxGroup` form story validates required multi-select