### PR TITLE
Keep internal packages unpublished without blocking pnpm publish

### DIFF
--- a/.agents/skills/changesets/references/project.md
+++ b/.agents/skills/changesets/references/project.md
@@ -11,7 +11,7 @@ Source of truth: `.changeset/config.json`. Prerelease channel: `.changeset/pre.j
 | Platform (`fixed`)         | `@ecopages/jsx`, `@ecopages/signals`, `@ecopages/radiant`           | List only those with a user-visible change. `fixed` bumps all three to the same version regardless.               |
 | Design system              | `@ecopages/radiant-ui`                                              | List when components, tokens, themes, or public exports change. Versions independently — never add it to `fixed`. |
 | Vite integration (`fixed`) | `@ecopages/vite-plugin-radiant`, `@ecopages/storybook-radiant-vite` | List when either public API changes. `fixed` bumps both to the same version. Not in the platform group.           |
-| Private                    | `apps/*`, `playground/*`                                            | Never list, never publish.                                                                                        |
+| Private                    | `apps/*`, `playground/*`, `@ecopages/oxlint-config`                 | Never list, never publish. `"private": true` plus `privatePackages` in `.changeset/config.json`.                  |
 
 Do not invent a `packages/core/` layout to co-version the platform trio — `fixed` already does that.
 

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -9,5 +9,9 @@
 	"linked": [],
 	"access": "public",
 	"baseBranch": "release/v0.3.0",
-	"updateInternalDependencies": "patch"
+	"updateInternalDependencies": "patch",
+	"privatePackages": {
+		"version": false,
+		"tag": false
+	}
 }

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ For more details, [see the docs page](https://radiant.ecopages.app/).
 - [@ecopages/vite-plugin-radiant](./packages/vite-plugin-radiant/README.md)
 - [@ecopages/storybook-radiant-vite](./packages/storybook-radiant-vite/README.md)
 
-Internal tooling: [shared Oxlint rules](./packages/oxlint-config/README.md) and [shared TypeScript compiler options](./configs/README.md).
+Internal tooling (not published): [shared Oxlint rules](./packages/oxlint-config/README.md) and [shared TypeScript compiler options](./configs/README.md).
 
 The JSX package README is the source of truth for entrypoint boundaries. In particular, [packages/jsx/README.md](./packages/jsx/README.md) documents when to use `@ecopages/jsx/server` directly, including the SSR hydration binding scope helpers intended for framework integrations that compose one page from multiple server renders.
 

--- a/package.json
+++ b/package.json
@@ -1,9 +1,7 @@
 {
 	"name": "@ecopages/radiant-monorepo",
+	"private": true,
 	"description": "A minimalist web component library designed for simplicity and flexibility",
-	"publishConfig": {
-		"access": "public"
-	},
 	"packageManager": "pnpm@11.17.0",
 	"scripts": {
 		"clean": "clear && pnpm dlx npkill -D -y && rm -rf node_modules pnpm-lock.yaml && pnpm install",

--- a/packages/oxlint-config/README.md
+++ b/packages/oxlint-config/README.md
@@ -2,4 +2,6 @@
 
 The workspace-wide Oxlint baseline. Import `@ecopages/oxlint-config/base` from an `oxlint.config.ts` file, extend it, and add only package-specific rules or plugins.
 
+This package is **private** and is never published to npm. `"private": true` makes `pnpm publish` refuse it; Changesets is configured with `privatePackages.version` and `privatePackages.tag` set to `false`, so it is not versioned or tagged either. The `0.0.0` version exists only so `pnpm publish` can rewrite `workspace:*` when a public package lists this as a `devDependency`.
+
 The base configuration starts with a cyclomatic-complexity limit of 50 and preserves the repository's existing lint policy. Lower the limit only in a follow-up that refactors every affected workspace. Every rule belongs here only when it is valid across all apps, libraries, and playgrounds.

--- a/packages/oxlint-config/package.json
+++ b/packages/oxlint-config/package.json
@@ -1,5 +1,6 @@
 {
 	"name": "@ecopages/oxlint-config",
+	"version": "0.0.0",
 	"private": true,
 	"type": "module",
 	"exports": {


### PR DESCRIPTION
## Summary
- Give `@ecopages/oxlint-config` a dummy `0.0.0` version so `pnpm publish` can rewrite `workspace:*` when `@ecopages/radiant-ui` lists it as a `devDependency`.
- Mark the monorepo root `private` and set Changesets `privatePackages` so internal tooling is never versioned, tagged, or published.

## Test plan
- [x] `pnpm --filter @ecopages/radiant-ui pack --dry-run` succeeds (no `ERR_PNPM_CANNOT_RESOLVE_WORKSPACE_PROTOCOL`)
- [x] `changeset publish` publishes `@ecopages/radiant-ui` and does not attempt to publish `@ecopages/oxlint-config`
- [x] Confirm `@ecopages/oxlint-config` stays off the npm registry