### PR TITLE
docs(oxlint-config): clarify internal usage and publishing status

### DIFF
--- a/.agents/skills/changesets/references/project.md
+++ b/.agents/skills/changesets/references/project.md
@@ -11,7 +11,7 @@ Source of truth: `.changeset/config.json`. Prerelease channel: `.changeset/pre.j
 | Platform (`fixed`)         | `@ecopages/jsx`, `@ecopages/signals`, `@ecopages/radiant`           | List only those with a user-visible change. `fixed` bumps all three to the same version regardless.               |
 | Design system              | `@ecopages/radiant-ui`                                              | List when components, tokens, themes, or public exports change. Versions independently — never add it to `fixed`. |
 | Vite integration (`fixed`) | `@ecopages/vite-plugin-radiant`, `@ecopages/storybook-radiant-vite` | List when either public API changes. `fixed` bumps both to the same version. Not in the platform group.           |
-| Private                    | `apps/*`, `playground/*`, `@ecopages/oxlint-config`                 | Never list, never publish. `"private": true` plus `privatePackages` in `.changeset/config.json`.                  |
+| Private                    | `apps/*`, `playground/*`, `@ecopages/oxlint-config`                 | Never list in changesets, never publish. Internal packages stay `"private": true` with `0.0.0` so `workspace:*` can resolve. |
 
 Do not invent a `packages/core/` layout to co-version the platform trio — `fixed` already does that.
 

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -9,9 +9,5 @@
 	"linked": [],
 	"access": "public",
 	"baseBranch": "release/v0.3.0",
-	"updateInternalDependencies": "patch",
-	"privatePackages": {
-		"version": false,
-		"tag": false
-	}
+	"updateInternalDependencies": "patch"
 }

--- a/packages/oxlint-config/README.md
+++ b/packages/oxlint-config/README.md
@@ -1,7 +1,9 @@
 # @ecopages/oxlint-config
 
-The workspace-wide Oxlint baseline. Import `@ecopages/oxlint-config/base` from an `oxlint.config.ts` file, extend it, and add only package-specific rules or plugins.
+Internal workspace package for the Oxlint baseline. Other workspaces list it as a `workspace:*` `devDependency` and import `@ecopages/oxlint-config/base`, then extend it with package-specific rules or plugins.
 
-This package is **private** and is never published to npm. `"private": true` makes `pnpm publish` refuse it; Changesets is configured with `privatePackages.version` and `privatePackages.tag` set to `false`, so it is not versioned or tagged either. The `0.0.0` version exists only so `pnpm publish` can rewrite `workspace:*` when a public package lists this as a `devDependency`.
+This is the same shape as Turborepo's `@repo/eslint-config`: a real package in the workspace graph, not a loose file in `configs/`. Keep it that way so dependents declare the relationship, `pnpm` can link it, and a future task runner can invalidate lint when this package changes.
+
+It is **never published**. `"private": true` makes `pnpm publish` skip it and Changesets skips private packages. `"version": "0.0.0"` is the internal-package convention: it is not a release. `pnpm publish` needs a version so it can rewrite `workspace:*` on public packages that depend on this as a `devDependency`.
 
 The base configuration starts with a cyclomatic-complexity limit of 50 and preserves the repository's existing lint policy. Lower the limit only in a follow-up that refactors every affected workspace. Every rule belongs here only when it is valid across all apps, libraries, and playgrounds.


### PR DESCRIPTION
## Summary

- clarify the private Oxlint config package’s workspace role
- remove redundant Changesets private-package configuration
- align release-maintainer guidance

## Validation

- `git diff --check`